### PR TITLE
Run drone daemon as unprivileged user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,8 @@ install:
 	cd bin && install -t /usr/local/bin drone
 	cd bin && install -t /usr/local/bin droned
 	mkdir -p /var/lib/drone
+	getent passwd drone >/dev/null || useradd -r -M -d /var/lib/drone -s /bin/false -g docker drone
+	chown drone:docker /var/lib/drone
 
 clean:
 	cd cmd/droned   && rice clean

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ sudo dpkg -i drone.deb
 $ sudo start drone
 ```
 
-Once Drone is running (by default on :80) navigate to **http://localhost:80/install**
+Once Drone is running (by default on :8080) navigate to **http://localhost:8080/install**
 and follow the steps in the setup wizard.
 
 **IMPORTANT** You will also need a GitHub Client ID and Secret:
@@ -31,7 +31,7 @@ and follow the steps in the setup wizard.
 * Register a new application https://github.com/settings/applications
 * Set the homepage URL to http://$YOUR_IP_ADDRESS/
 * Set the callback URL to http://$YOUR_IP_ADDRESS/auth/login/github
-* Copy the Client ID and Secret into the Drone admin console http://localhost:80/account/admin/settings
+* Copy the Client ID and Secret into the Drone admin console http://localhost:8080/account/admin/settings
 
 I'm working on a getting started video. Having issues with volume, but hopefully
 you can still get a feel for the steps:

--- a/deb/drone/DEBIAN/postinst
+++ b/deb/drone/DEBIAN/postinst
@@ -11,6 +11,21 @@ case "$1" in
     ;;
 esac
 
+if ! getent passwd drone >/dev/null; then
+    adduser --quiet --system --group --no-create-home \
+        --home /var/lib/drone drone
+fi
+
+# Add to docker group if available
+if getent group docker >/dev/null; then
+    gpasswd --add drone docker >/dev/null
+fi
+
+if ! dpkg-statoverride --list --quiet "/var/lib/drone" >/dev/null; then
+    dpkg-statoverride --force --quiet --update \
+        --add drone drone 0755 "/var/lib/drone"
+fi
+
 echo "Starting drone ..."
 if [ -f /etc/init/drone.conf ]; then
     if pidof /usr/local/bin/droned >/dev/null; then

--- a/deb/drone/DEBIAN/postrm
+++ b/deb/drone/DEBIAN/postrm
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = "purge" ]; then
+    update-rc.d drone remove defaults >/dev/null
+
+    if dpkg-statoverride --list --quiet "/var/lib/drone" >/dev/null; then
+        dpkg-statoverride --force --quiet --remove "/var/lib/drone"
+    fi
+
+    deluser --quiet --system drone > /dev/null || true
+    deluser --group --quiet --system --only-if-empty drone > dev/null || true
+
+    rm -rf /var/lib/drone > /dev/null 2>&1
+fi

--- a/deb/drone/etc/init/drone.conf
+++ b/deb/drone/etc/init/drone.conf
@@ -2,9 +2,10 @@ start on (filesystem and net-device-up)
 
 chdir /var/lib/drone
 console log
+setuid drone
+setgid drone
 
 script
-    DRONED_OPTS="--port=:80"
     if [ -f /etc/default/$UPSTART_JOB ]; then
         . /etc/default/$UPSTART_JOB
     fi


### PR DESCRIPTION
Hi again :)

Running the drone daemon as root is not such a good idea, especially for a service that exposes a web front-end.
As far as I tested, drone works flawlessly as a normal user if it can access the docker socket (group docker) and has write access to /var/lib/drone.

But update will break setups that use a web front-end port under 1024, since drone cannot acquire such a privileged port. :/ 

I changed the default port to 8080 and adapted the readme, a reverse proxy is needed in front of drone to allow access to privileged ports (and imho heavily recommended for TLS). At very last I added apt-get --purge code for total cleanup.

Also tried to implement a "drop to unprivileged user" feature, but for now Go developer discourage [using it](https://code.google.com/p/go/issues/detail?id=1435#c19)

PS: I'am very sorry if you got some mails from my drone, completely forgot that the default .drone.yml includes your mail address :/ should not happen again.