### PR TITLE
[WIP] Hipchat message templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,13 @@ notify:
     on_started: true
     on_success: true
     on_failure: true
+    started_message: Building {{.CommitAuthor}}/{{.RepoName}}/{{.CommitHash}}.
+    success_message: <b>Success:</b> {{.CommitHash}}!
+    failure_message: <b>Failed</b> {{.RepoName}}, commit {{.CommitHash}}, author {{.CommitAuthor}}
 ```
+
+Hipchat messages are customizable using Go templates, available variables:
+`CommitAuthor`, `RepoName`, `CommitHash`, `Host`.
 
 ### Databases
 

--- a/pkg/plugin/notify/hipchat.go
+++ b/pkg/plugin/notify/hipchat.go
@@ -34,7 +34,7 @@ type HipchatContext struct {
 func (h *Hipchat) Send(context *Context) error {
 	hipchatContext := &HipchatContext{
 		CommitHash:   context.Commit.HashShort(),
-		CommitAuthor: context.CommitAuthor,
+		CommitAuthor: context.Commit.Author,
 		RepoName:     context.Repo.Name,
 	}
 	switch {
@@ -51,21 +51,21 @@ func (h *Hipchat) Send(context *Context) error {
 
 func (h *Hipchat) sendStarted(context *HipchatContext) error {
 	var msg bytes.Buffer
-	tmpl = parseTemplate("started", h.StartedMessage, startedMessage)
+	tmpl := parseTemplate("started", h.StartedMessage, startedMessage)
 	tmpl.Execute(&msg, context)
 	return h.send(hipchat.ColorYellow, hipchat.FormatHTML, msg.String())
 }
 
 func (h *Hipchat) sendFailure(context *HipchatContext) error {
 	var msg bytes.Buffer
-	tmpl = parseTemplate("failure", h.FailureMessage, failureMessage)
+	tmpl := parseTemplate("failure", h.FailureMessage, failureMessage)
 	tmpl.Execute(&msg, context)
 	return h.send(hipchat.ColorRed, hipchat.FormatHTML, msg.String())
 }
 
 func (h *Hipchat) sendSuccess(context *HipchatContext) error {
 	var msg bytes.Buffer
-	tmpl = parseTemplate("success", h.SuccessMessage, successMessage)
+	tmpl := parseTemplate("success", h.SuccessMessage, successMessage)
 	tmpl.Execute(&msg, context)
 	return h.send(hipchat.ColorGreen, hipchat.FormatHTML, msg.String())
 }
@@ -85,8 +85,8 @@ func (h *Hipchat) send(color, format, message string) error {
 	return c.PostMessage(req)
 }
 
-func parseTemplate(name, templ, def string) *Template {
-	if templ != nil {
+func parseTemplate(name, templ, def string) *template.Template {
+	if templ != "" {
 		tmpl, err := template.New("failure").Parse(templ)
 		if err != nil {
 			return parseTemplate(name, "Error:"+err.Error(), "")

--- a/pkg/plugin/notify/hipchat_test.go
+++ b/pkg/plugin/notify/hipchat_test.go
@@ -1,0 +1,18 @@
+package notify
+
+import (
+	"bytes"
+	"testing"
+)
+
+func Test_parseTemplate(t *testing.T) {
+	tmpl := parseTemplate("test", "ok", "")
+	var msg bytes.Buffer
+	tmpl.Execute(&msg, interface{})
+	expected = "ok"
+	output := msg.String()
+
+	if output != expected {
+		t.Errorf("Failed to build url. Expected: %s, got %s", expected, output)
+	}
+}

--- a/pkg/plugin/notify/hipchat_test.go
+++ b/pkg/plugin/notify/hipchat_test.go
@@ -5,6 +5,23 @@ import (
 	"testing"
 )
 
+func Test_renderMessage(t *testing.T) {
+	context := &HipchatContext{
+		CommitHash:   "HASH",
+		CommitAuthor: "drone",
+		RepoName:     "drone",
+		Host:         "host",
+	}
+
+	expected = "HASH drone/drone host"
+	template = "{{.CommitHash}} {{.CommitAuthor}}/{{.RepoName}} {{.Host}}"
+	output := renderMessage(context, template, "")
+
+	if output != expected {
+		t.Errorf("Failed to render message. Expected: %s, got %s", expected, output)
+	}
+}
+
 func Test_parseTemplate(t *testing.T) {
 	tmpl := parseTemplate("test", "ok", "")
 	var msg bytes.Buffer
@@ -13,6 +30,6 @@ func Test_parseTemplate(t *testing.T) {
 	output := msg.String()
 
 	if output != expected {
-		t.Errorf("Failed to build url. Expected: %s, got %s", expected, output)
+		t.Errorf("Failed to parse template. Expected: %s, got %s", expected, output)
 	}
 }


### PR DESCRIPTION
The feature will allow setting message templates from the .drone.yml Hipchat block. Implementing #272.

- [x] Use hipchat message templates (started, success, failure) from .drone.yml
- [x] Parse input strings safely with fallback to default templates
- [x] Use go templates http://golang.org/pkg/text/template/
- [x] Add hipchat tests
- [ ] Add all available values to HipchatContext