### PR TITLE
Adding ability to pull from a private registry for the build image

### DIFF
--- a/shared/build/build_test.go
+++ b/shared/build/build_test.go
@@ -80,7 +80,7 @@ func TestSetup(t *testing.T) {
 	b.Repo = &repo.Repo{}
 	b.Repo.Path = "git://github.com/drone/drone.git"
 	b.Build = &script.Build{}
-	b.Build.Image = "go1.2"
+	b.Build.Docker.Image.Name = "go1.2"
 	b.dockerClient = client
 
 	if err := b.setup(); err != nil {
@@ -88,8 +88,8 @@ func TestSetup(t *testing.T) {
 	}
 
 	// verify the Image is being correctly set
-	if b.image == nil {
-		t.Errorf("Expected image not nil")
+	if len(b.Build.Docker.Image.Name) == 0 {
+		t.Errorf("Expected image to be set")
 	}
 
 	expectedID := "7bf9ce0ffb7236ca68da0f9fed0e1682053b393db3c724ff3c5a4e8c0793b34c"
@@ -147,7 +147,7 @@ func TestSetupErrorRunDaemonPorts(t *testing.T) {
 	b.Repo = &repo.Repo{}
 	b.Repo.Path = "git://github.com/drone/drone.git"
 	b.Build = &script.Build{}
-	b.Build.Image = "go1.2"
+	b.Build.Docker.Image.Name = "go1.2"
 	b.Build.Services = append(b.Build.Services, "mysql")
 	b.dockerClient = client
 
@@ -186,7 +186,7 @@ func TestSetupErrorServiceInspect(t *testing.T) {
 	b.Repo = &repo.Repo{}
 	b.Repo.Path = "git://github.com/drone/drone.git"
 	b.Build = &script.Build{}
-	b.Build.Image = "go1.2"
+	b.Build.Docker.Image.Name = "go1.2"
 	b.Build.Services = append(b.Build.Services, "mysql")
 	b.dockerClient = client
 
@@ -214,7 +214,7 @@ func TestSetupErrorImagePull(t *testing.T) {
 	b.Repo = &repo.Repo{}
 	b.Repo.Path = "git://github.com/drone/drone.git"
 	b.Build = &script.Build{}
-	b.Build.Image = "go1.2"
+	b.Build.Docker.Image.Name = "go1.2"
 	b.Build.Services = append(b.Build.Services, "mysql")
 	b.dockerClient = client
 
@@ -244,7 +244,7 @@ func TestSetupErrorBuild(t *testing.T) {
 	b.Repo = &repo.Repo{}
 	b.Repo.Path = "git://github.com/drone/drone.git"
 	b.Build = &script.Build{}
-	b.Build.Image = "go1.2"
+	b.Build.Docker.Image.Name = "go1.2"
 	b.dockerClient = client
 
 	var got, want = b.setup(), docker.ErrBadRequest
@@ -279,7 +279,7 @@ func TestSetupErrorBuildInspect(t *testing.T) {
 	b.Repo = &repo.Repo{}
 	b.Repo.Path = "git://github.com/drone/drone.git"
 	b.Build = &script.Build{}
-	b.Build.Image = "go1.2"
+	b.Build.Docker.Image.Name = "go1.2"
 	b.dockerClient = client
 
 	var got, want = b.setup(), docker.ErrBadRequest

--- a/shared/build/docker/container.go
+++ b/shared/build/docker/container.go
@@ -24,7 +24,7 @@ func (c *ContainerService) ListAll() ([]*Containers, error) {
 }
 
 // Create a Container
-func (c *ContainerService) Create(conf *Config) (*Run, error) {
+func (c *ContainerService) Create(conf *Config, auth AuthConfiguration) (*Run, error) {
 	run, err := c.create(conf)
 	switch {
 	// if no error, exit immediately
@@ -39,7 +39,7 @@ func (c *ContainerService) Create(conf *Config) (*Run, error) {
 	}
 
 	// attempt to pull the image
-	if err := c.Images.Pull(conf.Image); err != nil {
+	if err := c.Images.Pull(conf.Image, auth); err != nil {
 		return nil, err
 	}
 
@@ -89,9 +89,9 @@ func (c *ContainerService) Inspect(id string) (*Container, error) {
 }
 
 // Run the container
-func (c *ContainerService) Run(conf *Config, host *HostConfig, out io.Writer) (*Wait, error) {
+func (c *ContainerService) Run(conf *Config, host *HostConfig, out io.Writer, auth AuthConfiguration) (*Wait, error) {
 	// create the container from the image
-	run, err := c.Create(conf)
+	run, err := c.Create(conf, auth)
 	if err != nil {
 		return nil, err
 	}
@@ -116,8 +116,8 @@ func (c *ContainerService) Run(conf *Config, host *HostConfig, out io.Writer) (*
 }
 
 // Run the container as a Daemon
-func (c *ContainerService) RunDaemon(conf *Config, host *HostConfig) (*Run, error) {
-	run, err := c.Create(conf)
+func (c *ContainerService) RunDaemon(conf *Config, host *HostConfig, auth AuthConfiguration) (*Run, error) {
+	run, err := c.Create(conf, auth)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func (c *ContainerService) RunDaemon(conf *Config, host *HostConfig) (*Run, erro
 	return run, err
 }
 
-func (c *ContainerService) RunDaemonPorts(image string, ports map[Port]struct{}) (*Run, error) {
+func (c *ContainerService) RunDaemonPorts(image string, ports map[Port]struct{}, auth AuthConfiguration) (*Run, error) {
 	// setup configuration
 	config := Config{Image: image}
 	config.ExposedPorts = ports
@@ -142,5 +142,5 @@ func (c *ContainerService) RunDaemonPorts(image string, ports map[Port]struct{})
 	}
 	//127.0.0.1::%s
 	//map[3306/tcp:{}] map[3306/tcp:[{127.0.0.1 }]]
-	return c.RunDaemon(&config, &host)
+	return c.RunDaemon(&config, &host, auth)
 }

--- a/shared/build/script/docker.go
+++ b/shared/build/script/docker.go
@@ -1,24 +1,40 @@
 package script
 
+import "github.com/drone/drone/shared/build/docker"
+
 const (
-    DefaultDockerNetworkMode = "bridge"
+	DefaultDockerNetworkMode = "bridge"
 )
+
+type Image struct {
+	Name     string
+	Username string
+	Password string
+	Email    string
+}
 
 // Docker stores the configuration details for
 // configuring docker container.
 type Docker struct {
-    // NetworkMode (also known as `--net` option)
-    // Could be set only if Docker is running in privileged mode
-    NetworkMode *string `yaml:"net,omitempty"`
+	// Net (also known as `--net` option)
+	// Could be set only if Docker is running in privileged mode
+	Net *string `yaml:"net,omitempty"`
+
+	// Advanced image options
+	Image Image
 }
 
-// DockerNetworkMode returns DefaultNetworkMode
+// Returns DefaultNetworkMode
 // when Docker.NetworkMode is empty.
-// DockerNetworkMode returns Docker.NetworkMode
+// Returns Docker.NetworkMode
 // when it is not empty.
-func DockerNetworkMode(d *Docker) string {
-    if d == nil || d.NetworkMode == nil {
-        return DefaultDockerNetworkMode
-    }
-    return *d.NetworkMode
+func (d *Docker) NetworkMode() string {
+	if d.Net == nil {
+		return DefaultDockerNetworkMode
+	}
+	return *d.Net
+}
+
+func (d *Docker) AuthConfig() docker.AuthConfiguration {
+	return docker.AuthConfiguration{Username: d.Image.Username, Password: d.Image.Password, Email: d.Image.Email}
 }

--- a/shared/build/script/docker_test.go
+++ b/shared/build/script/docker_test.go
@@ -1,40 +1,36 @@
 package script
 
 import (
-    "testing"
+	"testing"
 )
 
 func TestDockerNetworkMode(t *testing.T) {
-    var d *Docker
-    var expected string
+	var d *Docker
+	var expected string
 
-    expected = DefaultDockerNetworkMode
-    d = nil
-    if actual := DockerNetworkMode(d); actual != expected {
-        t.Errorf("The result is invalid. [expected: %s][actual: %s]", expected, actual)
-    }
+	expected = DefaultDockerNetworkMode
 
-    expected = DefaultDockerNetworkMode
-    d = &Docker{}
-    if actual := DockerNetworkMode(d); actual != expected {
-        t.Errorf("The result is invalid. [expected: %s][actual: %s]", expected, actual)
-    }
+	expected = DefaultDockerNetworkMode
+	d = &Docker{}
+	if actual := d.NetworkMode(); actual != expected {
+		t.Errorf("The result is invalid. [expected: %s][actual: %s]", expected, actual)
+	}
 
-    expected = DefaultDockerNetworkMode
-    d = &Docker{NetworkMode: nil}
-    if actual := DockerNetworkMode(d); actual != expected {
-        t.Errorf("The result is invalid. [expected: %s][actual: %s]", expected, actual)
-    }
+	expected = DefaultDockerNetworkMode
+	d = &Docker{Net: nil}
+	if actual := d.NetworkMode(); actual != expected {
+		t.Errorf("The result is invalid. [expected: %s][actual: %s]", expected, actual)
+	}
 
-    expected = "bridge"
-    d = &Docker{NetworkMode: &expected}
-    if actual := DockerNetworkMode(d); actual != expected {
-        t.Errorf("The result is invalid. [expected: %s][actual: %s]", expected, actual)
-    }
+	expected = "bridge"
+	d = &Docker{Net: &expected}
+	if actual := d.NetworkMode(); actual != expected {
+		t.Errorf("The result is invalid. [expected: %s][actual: %s]", expected, actual)
+	}
 
-    expected = "host"
-    d = &Docker{NetworkMode: &expected}
-    if actual := DockerNetworkMode(d); actual != expected {
-        t.Errorf("The result is invalid. [expected: %s][actual: %s]", expected, actual)
-    }
+	expected = "host"
+	d = &Docker{Net: &expected}
+	if actual := d.NetworkMode(); actual != expected {
+		t.Errorf("The result is invalid. [expected: %s][actual: %s]", expected, actual)
+	}
 }

--- a/shared/build/script/script.go
+++ b/shared/build/script/script.go
@@ -19,6 +19,12 @@ func ParseBuild(data string) (*Build, error) {
 
 	// parse the build configuration file
 	err := yaml.Unmarshal([]byte(data), &build)
+
+	// alias simple image tag to the docker struct
+	if len(build.Docker.Image.Name) == 0 {
+		build.Docker.Image.Name = build.Image
+	}
+
 	return &build, err
 }
 
@@ -74,7 +80,7 @@ type Build struct {
 
 	// Docker container parameters, such as
 	// NetworkMode and UserName
-	Docker *Docker `yaml:"docker,omitempty"`
+	Docker Docker
 }
 
 // Write adds all the steps to the build script, including


### PR DESCRIPTION
Added an extra section to the drone yml file to define auth credentials for the docker repo, the credentials are passed via http header if set.  This allows drone to pull a docker image from a registry that requires authentication. 

I am still a bit unsure on the exact setup, thoughts?

This also fixes #245 

```
image: quay.io/epipho/test-pvt:latest

auth:
  email: $$email
  username: $$user
  password: $$pass

script:
  - env

```
