### PR TITLE
Enable to use slash and hash in brach name

### DIFF
--- a/server/app/scripts/app.js
+++ b/server/app/scripts/app.js
@@ -248,6 +248,9 @@ app.controller("CommitController", function($scope, $http, $route, $routeParams,
 			}
 		});
 	}
+	var encode = function(str) {
+		return encodeURIComponent(str.replace(/\//g, "%2F"));
+	}
 
 	feed.subscribe(function(item) {
 		if (item.commit.sha    == commit &&
@@ -275,12 +278,12 @@ app.controller("CommitController", function($scope, $http, $route, $routeParams,
 		});
 
 	// load the repo commit data
-	$http({method: 'GET', url: '/api/repos/'+remote+'/'+owner+"/"+name+"/branches/"+branch+"/commits/"+commit}).
+	$http({method: 'GET', url: '/api/repos/'+remote+'/'+owner+"/"+name+"/branches/"+encode(branch)+"/commits/"+encode(commit)}).
 		success(function(data, status, headers, config) {
 			$scope.commit = data;
 
 			if (data.status!='Started' && data.status!='Pending') {
-				$http({method: 'GET', url: '/api/repos/'+remote+'/'+owner+"/"+name+"/branches/"+branch+"/commits/"+commit+"/console"}).
+				$http({method: 'GET', url: '/api/repos/'+remote+'/'+owner+"/"+name+"/branches/"+encode(branch)+"/commits/"+encode(commit)+"/console"}).
 					success(function(data, status, headers, config) {
 						var lineFormatter = new Drone.LineFormatter();
 						var el = document.querySelector('#output');
@@ -309,7 +312,7 @@ app.controller("CommitController", function($scope, $http, $route, $routeParams,
 	}
 
 	$scope.rebuildCommit = function() {
-        $http({method: 'POST', url: '/api/repos/'+remote+'/'+owner+'/'+name+'/'+'branches/'+branch+'/'+'commits/'+commit+'?action=rebuild' });
+        $http({method: 'POST', url: '/api/repos/'+remote+'/'+owner+'/'+name+'/'+'branches/'+encode(branch)+'/'+'commits/'+encode(commit)+'?action=rebuild' });
 	}
 
 

--- a/server/app/scripts/filters/filters.js
+++ b/server/app/scripts/filters/filters.js
@@ -1,7 +1,17 @@
 'use strict';
 
 (function () {
-
+  /**
+   * encode is a helper function that return an encoded string 
+   * replaced slash with "%2F" and encodeURIComponent in order to
+   * process branch and commit containing control chars like slash
+   * hash (#), and so on.
+   */ 
+  function encode() {
+    return function(data) {
+      return encodeURIComponent(data.replace(/\//g, "%2F");
+    }
+  }
   /**
    * fromNow is a helper function that returns a human readable
    * string for the elapsed time between the given unix date and the
@@ -190,6 +200,7 @@
     .module('app')
     .filter('badgeMarkdown', badgeMarkdown)
     .filter('badgeMarkup', badgeMarkup)
+    .filter('encode', encode)
     .filter('fromNow', fromNow)
     .filter('fullName', fullName)
     .filter('fullPath', fullPath)

--- a/server/app/views/repo.html
+++ b/server/app/views/repo.html
@@ -1,6 +1,6 @@
 <div class="toast" ng-if="msg != undefined">
 	<span>commit </span>
-	<a ng-href="/{{ msg.repo | fullPath }}/{{ msg.commit.branch }}/{{ msg.commit.sha }}">{{ msg.commit.sha | shortHash }}</a>
+	<a ng-href="/{{ msg.repo | fullPath }}/{{ msg.commit.branch | encode }}/{{ msg.commit.sha }}">{{ msg.commit.sha | shortHash }}</a>
 	<span ng-if="msg.commit.status == 'Started'">is running</span>
 	<span ng-if="msg.commit.status == 'Success'">finished successfully</span>
 	<span ng-if="msg.commit.status == 'Failure'">finished with errors</span>
@@ -38,7 +38,7 @@
 		<section ng-repeat="group in commits | filter: { pull_request: '' } | unique: 'branch'">
 			<div class="pure-g cards">
 				<h2 class="pure-u-1" style="font-size:22px;margin-bottom:20px;"><i class="fa fa-code-fork"></i> {{group.branch}}</h2>
-				<a class="pure-u-1 pure-u-md-1-4 pure-u-lg-1-4 pure-u-xl-1-4 card card" ng-href="/{{ repo | fullPath }}/{{ commit.branch }}/{{ commit.sha }}" ng-repeat="commit in commits | filter: { branch: group.branch } | limitTo:4" data-status="{{ commit.status }}">
+				<a class="pure-u-1 pure-u-md-1-4 pure-u-lg-1-4 pure-u-xl-1-4 card card" ng-href="/{{ repo | fullPath }}/{{ commit.branch | encode }}/{{ commit.sha }}" ng-repeat="commit in commits | filter: { branch: group.branch } | limitTo:4" data-status="{{ commit.status }}">
 					<div class="l-box">
 						<h2>{{ commit.message }}</h2>
 						<em ng-if="commit.finished_at != 0">{{ commit.author }}<br/>{{ commit.finished_at | fromNow }}</em>
@@ -53,7 +53,7 @@
 		<section ng-if="(commits | pullRequests).length!=0">
 			<div class="pure-g cards">
 				<h2 class="pure-u-1" style="font-size:22px;margin-bottom:20px;"><i class="fa fa-code-fork"></i> Pull Requests</h2>
-				<a class="pure-u-1 pure-u-md-1-4 pure-u-lg-1-4 pure-u-xl-1-4 card card" ng-href="/{{ repo | fullPath }}/{{ commit.branch }}/{{ commit.sha }}" ng-repeat="commit in commits | pullRequests | limitTo:4" data-status="{{ commit.status }}">
+				<a class="pure-u-1 pure-u-md-1-4 pure-u-lg-1-4 pure-u-xl-1-4 card card" ng-href="/{{ repo | fullPath }}/{{ commit.branch | encode }}/{{ commit.sha }}" ng-repeat="commit in commits | pullRequests | limitTo:4" data-status="{{ commit.status }}">
 					<div class="l-box">
 						<h2>{{ commit.message }}</h2>
 						<em ng-if="commit.finished_at != 0">{{ commit.author }}<br/>{{ commit.finished_at | fromNow }}</em>

--- a/server/handler/commit.go
+++ b/server/handler/commit.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
 
 	"github.com/drone/drone/server/datastore"
 	"github.com/drone/drone/server/worker"
@@ -43,8 +44,9 @@ func GetCommit(c web.C, w http.ResponseWriter, r *http.Request) {
 		hash   = c.URLParams["commit"]
 		repo   = ToRepo(c)
 	)
+	_branch, _ := url.QueryUnescape(branch)
 
-	commit, err := datastore.GetCommitSha(ctx, repo, branch, hash)
+	commit, err := datastore.GetCommitSha(ctx, repo, _branch, hash)
 	if err != nil {
 		w.WriteHeader(http.StatusNotFound)
 		return
@@ -67,8 +69,9 @@ func PostCommit(c web.C, w http.ResponseWriter, r *http.Request) {
 		hash   = c.URLParams["commit"]
 		repo   = ToRepo(c)
 	)
+	_branch, _ := url.QueryUnescape(branch)
 
-	commit, err := datastore.GetCommitSha(ctx, repo, branch, hash)
+	commit, err := datastore.GetCommitSha(ctx, repo, _branch, hash)
 	if err != nil {
 		w.WriteHeader(http.StatusNotFound)
 		return

--- a/server/handler/output.go
+++ b/server/handler/output.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"io"
 	"net/http"
+	"net/url"
 	"path/filepath"
 
 	"github.com/drone/drone/server/blobstore"
@@ -23,8 +24,8 @@ func GetOutput(c web.C, w http.ResponseWriter, r *http.Request) {
 		branch = c.URLParams["branch"]
 		hash   = c.URLParams["commit"]
 	)
-
-	path := filepath.Join(host, owner, name, branch, hash)
+	_branch, _ := url.QueryUnescape(branch)
+	path := filepath.Join(host, owner, name, _branch, hash)
 	rc, err := blobstore.GetReader(ctx, path)
 	if err != nil {
 		w.WriteHeader(http.StatusNotFound)


### PR DESCRIPTION
Purpose
------
This PR enables to use slash and hash in brach name.

Currently drone (0.3) cannot use branch name containing control chars such as slash, hash.
But we use "feature/somethingnew_#333" as branch name. 

