### PR TITLE
add --ssh-config option to drone cli

### DIFF
--- a/shared/build/build_test.go
+++ b/shared/build/build_test.go
@@ -509,7 +509,7 @@ func TestWriteSSHConfigFile(t *testing.T) {
 	// persist a dummy id_rsa keyfile to disk
 	sshconfig, err := ioutil.ReadFile(filepath.Join(dir, "config"))
 	if err != nil {
-		t.Errorf("Expected id_rsa file saved to disk")
+		t.Errorf("Expected config file saved to disk")
 	}
 
 	if string(sshconfig) != string(b.SSHConfig) {

--- a/shared/build/build_test.go
+++ b/shared/build/build_test.go
@@ -497,6 +497,27 @@ func TestWriteIdentifyFile(t *testing.T) {
 	}
 }
 
+func TestWriteSSHConfigFile(t *testing.T) {
+	// temporary directory to store file
+	dir, _ := ioutil.TempDir("", "drone-test-")
+	defer os.RemoveAll(dir)
+
+	b := Builder{}
+	b.SSHConfig = []byte("Host gitlab.myorg.com: ...")
+	b.writeSSHConfigFile(dir)
+
+	// persist a dummy id_rsa keyfile to disk
+	sshconfig, err := ioutil.ReadFile(filepath.Join(dir, "config"))
+	if err != nil {
+		t.Errorf("Expected id_rsa file saved to disk")
+	}
+
+	if string(sshconfig) != string(b.SSHConfig) {
+		t.Errorf("Expected config value saved as %s, got %s", b.SSHConfig, sshconfig)
+	}
+}
+
+
 func TestWriteProxyScript(t *testing.T) {
 	// temporary directory to store file
 	dir, _ := ioutil.TempDir("", "drone-test-")


### PR DESCRIPTION
Allows you to inject a .ssh/config file similarly to how -i allows you to insert id_rsa key. 

In our use case we need to inject .ssh/config to force `go get` to use correct ssh user when fetching/cloning dependencies.
