### PR TITLE
Refactor ssh deployment to use rsync

### DIFF
--- a/plugin/deploy/ssh.go
+++ b/plugin/deploy/ssh.go
@@ -10,7 +10,7 @@ import (
 )
 
 // SSH struct holds configuration data for deployment
-// via ssh, deployment done by scp-ing file(s) listed
+// via ssh, deployment done by doing rsync on the file(s) listed
 // in artifacts to the target host, and then run cmd
 // remotely.
 // It is assumed that the target host already
@@ -26,21 +26,32 @@ type SSH struct {
 	Target string `yaml:"target,omitempty"`
 
 	// Artifacts is a list of files/dirs to be deployed
-	// to the target host. If artifacts list more than one file
-	// it will be compressed into a single tar.gz file.
-	// if artifacts contain:
-	//   - GITARCHIVE
+	// to the target host and always relative to the project's root directory,
+	// like so:
+	//   artifacts: ./
+	// or
+	//   artifacts: build/
 	//
-	// other file listed in artifacts will be ignored, instead, we will
-	// create git archive from the current revision and deploy that file
-	// alone.
-	// If you need to deploy the git archive along with some other files,
-	// please use build script to create the git archive, and then list
-	// the archive name here with the other files.
-	Artifacts []string `yaml:"artifacts,omitempty"`
+	// To list multiple artifacts, please use multiple-line string
+	// directive instead
+	// eg.
+	//    artifacts: |
+	//      bin/
+	//      include/
+	//      lib/
+	Artifacts string `yaml:"artifacts,omitempty"`
 
-	// Cmd is a single command executed at target host after the artifacts
+	// Cmd is the command executed at target host after the artifacts
 	// is deployed.
+	// To use multiple commands you can write it naturally with
+	// multiple-line string directive
+	// eg.
+	//    cmd: |
+	//      git clone github.com/myproject/myrepo
+	//      cd myrepo
+	//      bundle install --deployment
+	//      bundle exec rake assets:precompile
+	//      touch tmp/restart.txt
 	Cmd string `yaml:"cmd,omitempty"`
 
 	Condition *condition.Condition `yaml:"when,omitempty"`
@@ -48,6 +59,9 @@ type SSH struct {
 
 // Write down the buildfile
 func (s *SSH) Write(f *buildfile.Buildfile) {
+	rsyncTemplate := "rsync -avze 'ssh -p %s' --files-from ${ARTIFACTS} ./ %s"
+	cmdTemplate := "printf %q > /tmp/drone_deploy; sh /tmp/drone_deploy; rm -f /tmp/drone_deploy"
+
 	host := strings.SplitN(s.Target, " ", 2)
 	if len(host) == 1 {
 		host = append(host, "22")
@@ -56,48 +70,26 @@ func (s *SSH) Write(f *buildfile.Buildfile) {
 		host[1] = "22"
 	}
 
-	// Is artifact created?
-	artifact := false
+	// Back to the project's top directory, just in case
+	f.WriteCmdSilent("cd ${DRONE_BUILD_DIR}")
 
-	for _, a := range s.Artifacts {
-		if a == "GITARCHIVE" {
-			artifact = createGitArchive(f)
-			break
-		}
-	}
-
-	if !artifact {
-		if len(s.Artifacts) > 1 {
-			artifact = compress(f, s.Artifacts)
-		} else if len(s.Artifacts) == 1 {
-			f.WriteEnv("ARTIFACT", s.Artifacts[0])
-			artifact = true
-		}
-	}
-
-	if artifact {
-		scpCmd := "scp -o StrictHostKeyChecking=no -P %s -r ${ARTIFACT} %s"
-		f.WriteCmd(fmt.Sprintf(scpCmd, host[1], host[0]))
+	if len(s.Artifacts) > 0 {
+		f.WriteEnv("ARTIFACTS", "$(mktemp)")
+		f.WriteCmdSilent(fmt.Sprintf("printf %q > ${ARTIFACTS}", s.Artifacts))
+		f.WriteCmd(fmt.Sprintf(rsyncTemplate, host[1], host[0]))
+		f.WriteCmdSilent("rm -f ${ARTIFACTS}")
 	}
 
 	if len(s.Cmd) > 0 {
 		sshCmd := "ssh -o StrictHostKeyChecking=no -p %s %s %q"
-		f.WriteCmd(fmt.Sprintf(sshCmd, host[1], strings.SplitN(host[0], ":", 2)[0], s.Cmd))
+		hostnpath := strings.SplitN(host[0], ":", 2)
+		if len(hostnpath) == 2 {
+			// ensure script to run under target directory
+			s.Cmd = fmt.Sprintf("cd %s\n%s", hostnpath[1], s.Cmd)
+		}
+		cmd := fmt.Sprintf(cmdTemplate, s.Cmd)
+		f.WriteCmdSilent(fmt.Sprintf(sshCmd, host[1], hostnpath[0], cmd))
 	}
-}
-
-func createGitArchive(f *buildfile.Buildfile) bool {
-	f.WriteEnv("COMMIT", "$(git rev-parse HEAD)")
-	f.WriteEnv("ARTIFACT", "${PWD##*/}-${COMMIT}.tar.gz")
-	f.WriteCmdSilent("git archive --format=tar.gz --prefix=${PWD##*/}/ ${COMMIT} > ${ARTIFACT}")
-	return true
-}
-
-func compress(f *buildfile.Buildfile, files []string) bool {
-	cmd := "tar -cf ${ARTIFACT} %s"
-	f.WriteEnv("ARTIFACT", "${PWD##*/}.tar.gz")
-	f.WriteCmdSilent(fmt.Sprintf(cmd, strings.Join(files, " ")))
-	return true
 }
 
 func (s *SSH) GetCondition() *condition.Condition {

--- a/plugin/deploy/ssh_test.go
+++ b/plugin/deploy/ssh_test.go
@@ -18,38 +18,43 @@ var sampleYml = `
 deploy:
   ssh:
     target: user@test.example.com
-    cmd: /opt/bin/redeploy.sh
+    cmd:
+     - /opt/bin/redeploy.sh
 `
 
 var sampleYml1 = `
 deploy:
   ssh:
     target: user@test.example.com:/srv/app/location 2212
-    artifacts: ./
-    cmd: /opt/bin/redeploy.sh
+    artifacts:
+      - ./
+    cmd:
+      - /opt/bin/redeploy.sh
 `
 
 var sampleYml2 = `
 deploy:
   ssh:
     target: user@test.example.com:/srv/app/location 2212
-    artifacts: |
-      build.result
-      config/file
-    cmd: /opt/bin/redeploy.sh
+    artifacts:
+      - build.result
+      - config/file
+    cmd:
+      - /opt/bin/redeploy.sh
 `
 
 var sampleYml3 = `
 deploy:
   ssh:
     target: user@test.example.com:/srv/app/location 2212
-    artifacts: ./
-    cmd: |
-      cd /srv/app/location
-      bundle install --deployment
-      bundle exec rake assets:clobber
-      RAILS_ENV=production bundle exec rake assets:precompile
-      sudo sv restart puma
+    artifacts:
+      - ./
+    cmd:
+      - cd /srv/app/location
+      - bundle install --deployment
+      - bundle exec rake assets:clobber
+      - RAILS_ENV=production bundle exec rake assets:precompile
+      - sudo sv restart puma
 `
 
 func setUp(input string) (string, error) {
@@ -99,7 +104,7 @@ func TestSSHMultiArtifact(t *testing.T) {
 		t.Fatalf("Can't unmarshal deploy script: %s", err)
 	}
 
-	if !strings.Contains(bscr, `printf "build.result\nconfig/file\n" > ${ARTIFACTS}`) {
+	if !strings.Contains(bscr, `printf "build.result\nconfig/file" > ${ARTIFACTS}`) {
 		t.Errorf("Expect script to contains artifact")
 	}
 }

--- a/plugin/deploy/ssh_test.go
+++ b/plugin/deploy/ssh_test.go
@@ -25,8 +25,7 @@ var sampleYml1 = `
 deploy:
   ssh:
     target: user@test.example.com:/srv/app/location 2212
-    artifacts:
-      - build.result
+    artifacts: ./
     cmd: /opt/bin/redeploy.sh
 `
 
@@ -34,9 +33,9 @@ var sampleYml2 = `
 deploy:
   ssh:
     target: user@test.example.com:/srv/app/location 2212
-    artifacts:
-      - build.result
-      - config/file
+    artifacts: |
+      build.result
+      config/file
     cmd: /opt/bin/redeploy.sh
 `
 
@@ -44,9 +43,13 @@ var sampleYml3 = `
 deploy:
   ssh:
     target: user@test.example.com:/srv/app/location 2212
-    artifacts:
-      - GITARCHIVE
-    cmd: /opt/bin/redeploy.sh
+    artifacts: ./
+    cmd: |
+      cd /srv/app/location
+      bundle install --deployment
+      bundle exec rake assets:clobber
+      RAILS_ENV=production bundle exec rake assets:precompile
+      sudo sv restart puma
 `
 
 func setUp(input string) (string, error) {
@@ -66,11 +69,11 @@ func TestSSHNoArtifact(t *testing.T) {
 		t.Fatalf("Can't unmarshal deploy script: %s", err)
 	}
 
-	if strings.Contains(bscr, `scp`) {
-		t.Error("Expect script not to contains scp command")
+	if strings.Contains(bscr, "rsync") {
+		t.Error("Expect script not to contains rsync command")
 	}
 
-	if !strings.Contains(bscr, "ssh -o StrictHostKeyChecking=no -p 22 user@test.example.com \"/opt/bin/redeploy.sh\"") {
+	if !strings.Contains(bscr, "ssh -o StrictHostKeyChecking=no -p 22 user@test.example.com") {
 		t.Error("Expect script to contains ssh command")
 	}
 }
@@ -81,12 +84,12 @@ func TestSSHOneArtifact(t *testing.T) {
 		t.Fatalf("Can't unmarshal deploy script: %s", err)
 	}
 
-	if !strings.Contains(bscr, `ARTIFACT="build.result"`) {
-		t.Error("Expect script to contains artifact")
+	if !strings.Contains(bscr, `printf "./" > ${ARTIFACTS}`) {
+		t.Errorf("Expect script to contains artifacts file listing")
 	}
 
-	if !strings.Contains(bscr, "scp -o StrictHostKeyChecking=no -P 2212 -r ${ARTIFACT} user@test.example.com:/srv/app/location") {
-		t.Errorf("Expect script to contains scp command, got:\n%s", bscr)
+	if !strings.Contains(bscr, `rsync -avze 'ssh -p 2212' --files-from ${ARTIFACTS} ./ user@test.example.com:/srv/app/location`) {
+		t.Errorf("Expect script to contains rsync command, got:\n%s", bscr)
 	}
 }
 
@@ -96,34 +99,8 @@ func TestSSHMultiArtifact(t *testing.T) {
 		t.Fatalf("Can't unmarshal deploy script: %s", err)
 	}
 
-	if !strings.Contains(bscr, `ARTIFACT="${PWD##*/}.tar.gz"`) {
+	if !strings.Contains(bscr, `printf "build.result\nconfig/file\n" > ${ARTIFACTS}`) {
 		t.Errorf("Expect script to contains artifact")
-	}
-
-	if !strings.Contains(bscr, "tar -cf ${ARTIFACT} build.result config/file") {
-		t.Errorf("Expect script to contains tar command. got: %s\n", bscr)
 	}
 }
 
-func TestSSHGitArchive(t *testing.T) {
-	bscr, err := setUp(sampleYml3)
-	if err != nil {
-		t.Fatalf("Can't unmarshal deploy script: %s", err)
-	}
-
-	if !strings.Contains(bscr, `COMMIT="$(git rev-parse HEAD)"`) {
-		t.Errorf("Expect script to contains commit ref")
-	}
-
-	if !strings.Contains(bscr, `ARTIFACT="${PWD##*/}-${COMMIT}.tar.gz"`) {
-		t.Errorf("Expect script to contains artifact")
-	}
-
-	if strings.Contains(bscr, "=GITARCHIVE") {
-		t.Errorf("Doesn't expect script to contains GITARCHIVE literals")
-	}
-
-	if !strings.Contains(bscr, "git archive --format=tar.gz --prefix=${PWD##*/}/ ${COMMIT} > ${ARTIFACT}") {
-		t.Errorf("Expect script to run git archive")
-	}
-}


### PR DESCRIPTION
And support multiple commands to run on the target server.

Fixes #689 and #690 

As discussed at #689, use rsync instead of scp for deploying artifacts.
Drone will first create a temp file for listing the artifacts and then use rsync's `--files-from` option for the transfer, to enable deploying multiple artifacts (possibly under different directories) at once.

To support running multiple command on the target host, drone first create a script file on the target host (named `/tmp/drone_deploy`), and running it as `sh` script.

~~To specify multiple artifacts and/or multiple commands, write them as multi-line string literals (not as list) indicated by pipe character("|"):~~
``` yml
ssh:
  target: app@example.com:/srv/.app/myapp 2222
  artifacts:
    - ./
  cmd:
    - bundle intall --deployment
    - bundle exec rake assets:clobber
    - RAKE_ENV=production bundle exec rake assets:precompile
    - sv -w 240 restart puma
```

~~yml ref: http://yaml.org/spec/1.2/spec.html#id2760844~~