### PR TITLE
Wrap commands in sh -c ''

### DIFF
--- a/plugin/deploy/git/git_test.go
+++ b/plugin/deploy/git/git_test.go
@@ -34,7 +34,7 @@ func Test_Git(t *testing.T) {
 
 			d.Write(b)
 			out := b.String()
-			g.Assert(strings.Contains(out, "\ngit remote add deploy git://foo.com/bar/baz.git\n")).Equal(true)
+			g.Assert(strings.Contains(out, "git remote add deploy git://foo.com/bar/baz.git")).Equal(true)
 		})
 
 		g.It("Should push to remote", func() {
@@ -45,7 +45,7 @@ func Test_Git(t *testing.T) {
 
 			d.Write(b)
 			out := b.String()
-			g.Assert(strings.Contains(out, "\ngit push deploy $COMMIT:master\n")).Equal(true)
+			g.Assert(strings.Contains(out, "git push deploy $COMMIT:master")).Equal(true)
 		})
 
 		g.It("Should push to alternate branch", func() {
@@ -57,7 +57,7 @@ func Test_Git(t *testing.T) {
 
 			d.Write(b)
 			out := b.String()
-			g.Assert(strings.Contains(out, "\ngit push deploy $COMMIT:foo\n")).Equal(true)
+			g.Assert(strings.Contains(out, "git push deploy $COMMIT:foo")).Equal(true)
 		})
 
 		g.It("Should force push to remote", func() {
@@ -69,9 +69,9 @@ func Test_Git(t *testing.T) {
 
 			d.Write(b)
 			out := b.String()
-			g.Assert(strings.Contains(out, "\ngit add -A\n")).Equal(true)
-			g.Assert(strings.Contains(out, "\ngit commit -m 'add build artifacts'\n")).Equal(true)
-			g.Assert(strings.Contains(out, "\ngit push deploy HEAD:master --force\n")).Equal(true)
+			g.Assert(strings.Contains(out, "git add -A")).Equal(true)
+			g.Assert(strings.Contains(out, "git commit -m 'add build artifacts'")).Equal(true)
+			g.Assert(strings.Contains(out, "git push deploy HEAD:master --force")).Equal(true)
 		})
 
 	})

--- a/plugin/deploy/heroku/heroku_test.go
+++ b/plugin/deploy/heroku/heroku_test.go
@@ -34,7 +34,7 @@ func Test_Heroku(t *testing.T) {
 
 			h.Write(b)
 			out := b.String()
-			g.Assert(strings.Contains(out, "\ngit remote add heroku git@heroku.com:drone.git\n")).Equal(true)
+			g.Assert(strings.Contains(out, "git remote add heroku git@heroku.com:drone.git")).Equal(true)
 		})
 
 		g.It("Should push to remote", func() {
@@ -45,7 +45,7 @@ func Test_Heroku(t *testing.T) {
 
 			d.Write(b)
 			out := b.String()
-			g.Assert(strings.Contains(out, "\ngit push heroku $COMMIT:master\n")).Equal(true)
+			g.Assert(strings.Contains(out, "git push heroku $COMMIT:master")).Equal(true)
 		})
 
 		g.It("Should force push to remote", func() {
@@ -57,9 +57,9 @@ func Test_Heroku(t *testing.T) {
 
 			h.Write(b)
 			out := b.String()
-			g.Assert(strings.Contains(out, "\ngit add -A\n")).Equal(true)
-			g.Assert(strings.Contains(out, "\ngit commit -m 'adding build artifacts'\n")).Equal(true)
-			g.Assert(strings.Contains(out, "\ngit push heroku HEAD:master --force\n")).Equal(true)
+			g.Assert(strings.Contains(out, "git add -A")).Equal(true)
+			g.Assert(strings.Contains(out, "git commit -m 'adding build artifacts'")).Equal(true)
+			g.Assert(strings.Contains(out, "git push heroku HEAD:master --force")).Equal(true)
 		})
 
 	})

--- a/plugin/deploy/modulus/modulus_test.go
+++ b/plugin/deploy/modulus/modulus_test.go
@@ -41,12 +41,12 @@ func Test_Modulus(t *testing.T) {
 
 			m.Write(b)
 			g.Assert(b.String()).Equal(`export MODULUS_TOKEN="bar"
-[ -f /usr/bin/npm ] || echo ERROR: npm is required for modulus.io deployments
-[ -f /usr/bin/npm ] || exit 1
-[ -f /usr/bin/sudo ] || npm install -g modulus
-[ -f /usr/bin/sudo ] && sudo npm install -g modulus
+sh -c "[ -f /usr/bin/npm ] || echo ERROR: npm is required for modulus.io deployments"
+sh -c "[ -f /usr/bin/npm ] || exit 1"
+sh -c "[ -f /usr/bin/sudo ] || npm install -g modulus"
+sh -c "[ -f /usr/bin/sudo ] && sudo npm install -g modulus"
 echo '#DRONE:6d6f64756c7573206465706c6f79202d702022666f6f22'
-modulus deploy -p "foo"
+sh -c "modulus deploy -p \"foo\""
 `)
 		})
 	})

--- a/plugin/deploy/nodejitsu/nodejitsu_test.go
+++ b/plugin/deploy/nodejitsu/nodejitsu_test.go
@@ -42,10 +42,10 @@ func Test_Modulus(t *testing.T) {
 			n.Write(b)
 			g.Assert(b.String()).Equal(`export username="foo"
 export apiToken="bar"
-[ -f /usr/bin/sudo ] || npm install -g jitsu
-[ -f /usr/bin/sudo ] && sudo npm install -g jitsu
+sh -c "[ -f /usr/bin/sudo ] || npm install -g jitsu"
+sh -c "[ -f /usr/bin/sudo ] && sudo npm install -g jitsu"
 echo '#DRONE:6a69747375206465706c6f79'
-jitsu deploy
+sh -c "jitsu deploy"
 `)
 		})
 	})

--- a/plugin/deploy/ssh_test.go
+++ b/plugin/deploy/ssh_test.go
@@ -70,7 +70,7 @@ func TestSSHNoArtifact(t *testing.T) {
 		t.Error("Expect script not to contains scp command")
 	}
 
-	if !strings.Contains(bscr, "ssh -o StrictHostKeyChecking=no -p 22 user@test.example.com \"/opt/bin/redeploy.sh\"") {
+	if !strings.Contains(bscr, "sh -c \"ssh -o StrictHostKeyChecking=no -p 22 user@test.example.com \\\"/opt/bin/redeploy.sh\\\"\"") {
 		t.Error("Expect script to contains ssh command")
 	}
 }

--- a/plugin/deploy/tsuru/tsuru_test.go
+++ b/plugin/deploy/tsuru/tsuru_test.go
@@ -34,7 +34,7 @@ func Test_Tsuru(t *testing.T) {
 
 			d.Write(b)
 			out := b.String()
-			g.Assert(strings.Contains(out, "\ngit remote add tsuru git://foo.com/bar/baz.git\n")).Equal(true)
+			g.Assert(strings.Contains(out, "git remote add tsuru git://foo.com/bar/baz.git")).Equal(true)
 		})
 
 		g.It("Should push to remote", func() {
@@ -45,7 +45,7 @@ func Test_Tsuru(t *testing.T) {
 
 			d.Write(b)
 			out := b.String()
-			g.Assert(strings.Contains(out, "\ngit push tsuru $COMMIT:master\n")).Equal(true)
+			g.Assert(strings.Contains(out, "git push tsuru $COMMIT:master")).Equal(true)
 		})
 
 		g.It("Should force push to remote", func() {
@@ -57,9 +57,9 @@ func Test_Tsuru(t *testing.T) {
 
 			d.Write(b)
 			out := b.String()
-			g.Assert(strings.Contains(out, "\ngit add -A\n")).Equal(true)
-			g.Assert(strings.Contains(out, "\ngit commit -m 'adding build artifacts'\n")).Equal(true)
-			g.Assert(strings.Contains(out, "\ngit push tsuru HEAD:master --force\n")).Equal(true)
+			g.Assert(strings.Contains(out, "git add -A")).Equal(true)
+			g.Assert(strings.Contains(out, "git commit -m 'adding build artifacts'")).Equal(true)
+			g.Assert(strings.Contains(out, "git push tsuru HEAD:master --force")).Equal(true)
 		})
 
 	})

--- a/plugin/publish/github_test.go
+++ b/plugin/publish/github_test.go
@@ -66,7 +66,7 @@ func TestDefaultBehavior(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defaultname := fmt.Sprintf(`-n "%s"`, validcfg["tag"].(string))
+	defaultname := fmt.Sprintf(`-n \"%s\"`, validcfg["tag"].(string))
 	if !strings.Contains(buildfilestr, defaultname) {
 		t.Fatalf("Expected buildfile to contain name default to tag '%s': %s", defaultname, buildfilestr)
 	}

--- a/plugin/publish/npm/npm.go
+++ b/plugin/publish/npm/npm.go
@@ -11,12 +11,10 @@ import (
 // command to create the .npmrc file that stores
 // the login credentials, as opposed to npm login
 // which requires stdin.
-const CmdLogin = `
-cat <<EOF > ~/.npmrc
+const CmdLogin = `cat <<EOF > ~/.npmrc
 _auth = $(echo "%s:%s" | tr -d "\r\n" | base64)
 email = %s
-EOF
-`
+EOF`
 
 const (
 	CmdPublish     = "npm publish %s"

--- a/plugin/publish/npm/npm_test.go
+++ b/plugin/publish/npm/npm_test.go
@@ -31,9 +31,9 @@ func Test_NPM(t *testing.T) {
 
 			n.Write(b)
 			out := b.String()
-			g.Assert(strings.Contains(out, "\nnpm publish /path/to/repo\n")).Equal(true)
-			g.Assert(strings.Contains(out, "\nnpm set")).Equal(false)
-			g.Assert(strings.Contains(out, "\nnpm config set")).Equal(false)
+			g.Assert(strings.Contains(out, "npm publish /path/to/repo")).Equal(true)
+			g.Assert(strings.Contains(out, "npm set")).Equal(false)
+			g.Assert(strings.Contains(out, "npm config set")).Equal(false)
 		})
 
 		g.It("Should set force", func() {
@@ -47,7 +47,7 @@ func Test_NPM(t *testing.T) {
 			}
 
 			n.Write(b)
-			g.Assert(strings.Contains(b.String(), "\nnpm publish /path/to/repo --force\n")).Equal(true)
+			g.Assert(strings.Contains(b.String(), "npm publish /path/to/repo --force")).Equal(true)
 		})
 
 		g.It("Should set tag", func() {
@@ -61,7 +61,7 @@ func Test_NPM(t *testing.T) {
 			}
 
 			n.Write(b)
-			g.Assert(strings.Contains(b.String(), "\nnpm publish /path/to/repo --tag 1.0.0\n")).Equal(true)
+			g.Assert(strings.Contains(b.String(), "npm publish /path/to/repo --tag 1.0.0")).Equal(true)
 		})
 
 		g.It("Should set registry", func() {
@@ -75,7 +75,7 @@ func Test_NPM(t *testing.T) {
 			}
 
 			n.Write(b)
-			g.Assert(strings.Contains(b.String(), "\nnpm config set registry https://npmjs.com\n")).Equal(true)
+			g.Assert(strings.Contains(b.String(), "npm config set registry https://npmjs.com")).Equal(true)
 		})
 
 		g.It("Should set always-auth", func() {
@@ -104,10 +104,7 @@ func Test_NPM(t *testing.T) {
 			b := new(buildfile.Buildfile)
 			n := new(NPM)
 
-			expected := `cat <<EOF > ~/.npmrc
-_auth = $(echo "foo:bar" | tr -d "\r\n" | base64)
-email = foo@bar.com
-EOF`
+			expected := `sh -c "cat <<EOF > ~/.npmrc\n_auth = $(echo \"foo:bar\" | tr -d \"\\r\\n\" | base64)\nemail = foo@bar.com\nEOF"`
 
 			var user, pass, email string = "foo", "bar", "foo@bar.com"
 			DefaultUser = &user
@@ -128,10 +125,7 @@ EOF`
 				AlwaysAuth: true,
 			}
 
-			expected := `cat <<EOF > ~/.npmrc
-_auth = $(echo "foo:bar" | tr -d "\r\n" | base64)
-email = foo@bar.com
-EOF`
+			expected := `sh -c "cat <<EOF > ~/.npmrc\n_auth = $(echo \"foo:bar\" | tr -d \"\\r\\n\" | base64)\nemail = foo@bar.com\nEOF"`
 
 			n.Write(b)
 			g.Assert(strings.Contains(b.String(), expected)).Equal(true)

--- a/shared/build/buildfile/buildfile.go
+++ b/shared/build/buildfile/buildfile.go
@@ -23,13 +23,13 @@ func (b *Buildfile) WriteCmd(command string) {
 	// echo the command as an encoded value
 	b.WriteString(fmt.Sprintf("echo '#DRONE:%x'\n", command))
 	// and then run the command
-	b.WriteString(fmt.Sprintf("%s\n", command))
+	b.WriteString(fmt.Sprintf("sh -c %q\n", command))
 }
 
 // WriteCmdSilent writes a command to the build file
 // but does not echo the command.
 func (b *Buildfile) WriteCmdSilent(command string) {
-	b.WriteString(fmt.Sprintf("%s\n", command))
+	b.WriteString(fmt.Sprintf("sh -c %q\n", command))
 }
 
 // WriteComment adds a comment to the build file. This

--- a/shared/build/buildfile/buildfile_test.go
+++ b/shared/build/buildfile/buildfile_test.go
@@ -14,14 +14,14 @@ func TestWrite(t *testing.T) {
 
 	f = &Buildfile{}
 	f.WriteCmd("echo hi")
-	got, want = f.String(), "echo '#DRONE:6563686f206869'\necho hi\n"
+	got, want = f.String(), "echo '#DRONE:6563686f206869'\nsh -c \"echo hi\"\n"
 	if got != want {
 		t.Errorf("Exepected WriteCmd returned %s, got %s", want, got)
 	}
 
 	f = &Buildfile{}
 	f.WriteCmdSilent("echo hi")
-	got, want = f.String(), "echo hi\n"
+	got, want = f.String(), "sh -c \"echo hi\"\n"
 	if got != want {
 		t.Errorf("Exepected WriteCmdSilent returned %s, got %s", want, got)
 	}
@@ -42,7 +42,7 @@ func TestWrite(t *testing.T) {
 
 	f = &Buildfile{}
 	f.WriteHost("127.0.0.1")
-	got, want = f.String(), "[ -f /usr/bin/sudo ] || echo \"127.0.0.1\" | tee -a /etc/hosts\n[ -f /usr/bin/sudo ] && echo \"127.0.0.1\" | sudo tee -a /etc/hosts\n"
+	got, want = f.String(), "sh -c \"[ -f /usr/bin/sudo ] || echo \\\"127.0.0.1\\\" | tee -a /etc/hosts\"\nsh -c \"[ -f /usr/bin/sudo ] && echo \\\"127.0.0.1\\\" | sudo tee -a /etc/hosts\"\n"
 	if got != want {
 		t.Errorf("Exepected WriteHost returned %s, got %s", want, got)
 	}


### PR DESCRIPTION
This pull request wraps commands in sh -c '' so each of them runs in its own context.

It implements what [I have been proposing](https://github.com/drone/drone/issues/562#issuecomment-62550047) in issue #562.

This is mainly for discussion purposes. I have simply implemented the change and fixed all tests to pass. I have no idea if it will actually work of how big the concequences will be... :-)