### PR TITLE
Add an option to disable recursive clone

### DIFF
--- a/server/worker/docker/docker.go
+++ b/server/worker/docker/docker.go
@@ -111,13 +111,14 @@ func (d *Docker) Do(c context.Context, r *worker.Work) {
 
 	path := r.Repo.Host + "/" + r.Repo.Owner + "/" + r.Repo.Name
 	repo := &repo.Repo{
-		Name:   path,
-		Path:   r.Repo.CloneURL,
-		Branch: r.Commit.Branch,
-		Commit: r.Commit.Sha,
-		PR:     r.Commit.PullRequest,
-		Dir:    filepath.Join("/var/cache/drone/src", git.GitPath(script.Git, path)),
-		Depth:  git.GitDepth(script.Git),
+		Name:      path,
+		Path:      r.Repo.CloneURL,
+		Branch:    r.Commit.Branch,
+		Commit:    r.Commit.Sha,
+		PR:        r.Commit.PullRequest,
+		Dir:       filepath.Join("/var/cache/drone/src", git.GitPath(script.Git, path)),
+		Depth:     git.GitDepth(script.Git),
+		Recursive: git.GitRecursive(script.Git),
 	}
 
 	priorCommit, _ := datastore.GetCommitPrior(c, r.Commit)

--- a/shared/build/build_test.go
+++ b/shared/build/build_test.go
@@ -556,7 +556,7 @@ func TestWriteBuildScript(t *testing.T) {
 	f.WriteEnv("CI_PULL_REQUEST", "123")
 	f.WriteHost("127.0.0.1")
 	f.WriteFile("$HOME/.ssh/id_rsa", []byte("ssh-rsa AAA..."), 600)
-	f.WriteCmd("git clone --depth=0 --recursive git://github.com/drone/drone.git /var/cache/drone/github.com/drone/drone")
+	f.WriteCmd("git clone --depth=0 git://github.com/drone/drone.git /var/cache/drone/github.com/drone/drone")
 	f.WriteCmd("git fetch origin +refs/pull/123/head:refs/remotes/origin/pr/123")
 	f.WriteCmd("git checkout -qf -b pr/123 origin/pr/123")
 

--- a/shared/build/git/git.go
+++ b/shared/build/git/git.go
@@ -1,7 +1,8 @@
 package git
 
 const (
-	DefaultGitDepth = 50
+	DefaultGitDepth     = 50
+	DefaultGitRecursive = true
 )
 
 // Git stores the configuration details for
@@ -12,11 +13,15 @@ type Git struct {
 	// number of revisions.
 	Depth *int `yaml:"depth,omitempty"`
 
+	// Recursive option instructs git to do a recursive
+	// clone of all submodules.
+	Recursive *bool `yaml:"recursive,omitempty"`
+
 	// The name of a directory to clone into.
 	Path *string `yaml:"path,omitempty"`
 }
 
-// GitDepth returns GitDefaultDepth
+// GitDepth returns DefaultGitDepth
 // when Git.Depth is empty.
 // GitDepth returns Git.Depth
 // when it is not empty.
@@ -25,6 +30,17 @@ func GitDepth(g *Git) int {
 		return DefaultGitDepth
 	}
 	return *g.Depth
+}
+
+// GitRecursive returns DefaultGitRecursive
+// when Git.Recursive is empty.
+// GitRecursive returns Git.Recursive
+// when it is not empty.
+func GitRecursive(g *Git) bool {
+	if g == nil || g.Recursive == nil {
+		return DefaultGitRecursive
+	}
+	return *g.Recursive
 }
 
 // GitPath returns the given default path

--- a/shared/build/git/git_test.go
+++ b/shared/build/git/git_test.go
@@ -38,3 +38,38 @@ func TestGitDepth(t *testing.T) {
 		t.Errorf("The result is invalid. [expected: %d][actual: %d]", expected, actual)
 	}
 }
+
+func TestGitRecursive(t *testing.T) {
+	var g *Git
+	var expected bool
+
+	expected = DefaultGitRecursive
+	g = nil
+	if actual := GitRecursive(g); actual != expected {
+		t.Errorf("The result is invalid. [expected: %v][actual: %v]", expected, actual)
+	}
+
+	expected = DefaultGitRecursive
+	g = &Git{}
+	if actual := GitRecursive(g); actual != expected {
+		t.Errorf("The result is invalid. [expected: %v][actual: %v]", expected, actual)
+	}
+
+	expected = DefaultGitRecursive
+	g = &Git{Recursive: nil}
+	if actual := GitRecursive(g); actual != expected {
+		t.Errorf("The result is invalid. [expected: %v][actual: %v]", expected, actual)
+	}
+
+	expected = false
+	g = &Git{Recursive: &expected}
+	if actual := GitRecursive(g); actual != expected {
+		t.Errorf("The result is invalid. [expected: %v][actual: %v]", expected, actual)
+	}
+
+	expected = true
+	g = &Git{Recursive: &expected}
+	if actual := GitRecursive(g); actual != expected {
+		t.Errorf("The result is invalid. [expected: %v][actual: %v]", expected, actual)
+	}
+}

--- a/shared/build/repo/repo.go
+++ b/shared/build/repo/repo.go
@@ -40,6 +40,9 @@ type Repo struct {
 
 	// (optional) The depth of the `git clone` command.
 	Depth int
+
+	// (optional) Specify if the clone should be recursive.
+	Recursive bool
 }
 
 // IsRemote returns true if the Repository is located
@@ -96,6 +99,16 @@ func (r *Repo) IsGit() bool {
 	return false
 }
 
+// recursiveFlag returns the string " --recursive" if the
+// git.recursive option was set to true in .drone.yml,
+// otherwise it returns and empty string.
+func (r *Repo) recursiveFlag() string {
+	if r.Recursive {
+		return " --recursive"
+	}
+	return ""
+}
+
 // returns commands that can be used in a Dockerfile
 // to clone the repository.
 //
@@ -111,12 +124,12 @@ func (r *Repo) Commands() []string {
 	cmds := []string{}
 	if len(r.PR) > 0 {
 		// If a specific PR is provided then we need to clone it.
-		cmds = append(cmds, fmt.Sprintf("git clone --depth=%d --recursive %s %s", r.Depth, r.Path, r.Dir))
+		cmds = append(cmds, fmt.Sprintf("git clone --depth=%d%s %s %s", r.Depth, r.recursiveFlag(), r.Path, r.Dir))
 		cmds = append(cmds, fmt.Sprintf("git fetch origin +refs/pull/%s/head:refs/remotes/origin/pr/%s", r.PR, r.PR))
 		cmds = append(cmds, fmt.Sprintf("git checkout -qf -b pr/%s origin/pr/%s", r.PR, r.PR))
 	} else {
 		// Otherwise just clone the branch.
-		cmds = append(cmds, fmt.Sprintf("git clone --depth=%d --recursive --branch=%s %s %s", r.Depth, branch, r.Path, r.Dir))
+		cmds = append(cmds, fmt.Sprintf("git clone --depth=%d%s --branch=%s %s %s", r.Depth, r.recursiveFlag(), branch, r.Path, r.Dir))
 		// If a specific commit is provided then we'll need to check it out.
 		if len(r.Commit) > 0 {
 			cmds = append(cmds, fmt.Sprintf("git checkout -qf %s", r.Commit))


### PR DESCRIPTION
This change adds the following configuration item to .drone.yml:

    git:
      recursive: false

If the item is left out then the default is `true`, i.e. perform a recursive clone.

I couldn't find where to add the documentation for the new configuration (granted I didn't do an exhaustive search). If you point it out I can update that.

I'm not even sure if you'll be interested in this change, however it was quite useful for me today!