### PR TITLE
Change SSH Key Pair (issue #61)

### DIFF
--- a/cli/keys.go
+++ b/cli/keys.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/codegangsta/cli"
+	"github.com/drone/drone/client"
+)
+
+// NewSetKeyCommand returns the CLI command for "set-key".
+func NewSetKeyCommand() cli.Command {
+	return cli.Command{
+		Name:  "set-key",
+		Usage: "sets the SSH private key used to clone",
+		Flags: []cli.Flag{},
+		Action: func(c *cli.Context) {
+			handle(c, setKeyCommandFunc)
+		},
+	}
+}
+
+// setKeyCommandFunc executes the "set-key" command.
+func setKeyCommandFunc(c *cli.Context, client *client.Client) error {
+	var host, owner, name, path string
+	var args = c.Args()
+
+	if len(args) != 0 {
+		host, owner, name = parseRepo(args[0])
+	}
+
+	if len(args) == 2 {
+		path = args[1]
+	}
+
+	pub, err := ioutil.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("Could not find private RSA key %s. %s", path, err)
+	}
+
+	path_pub := path + ".pub"
+	priv, err := ioutil.ReadFile(path_pub)
+	if err != nil {
+		return fmt.Errorf("Could not find public RSA key %s. %s", path_pub, err)
+	}
+
+	return client.Repos.SetKey(host, owner, name, string(pub), string(priv))
+}

--- a/cli/main.go
+++ b/cli/main.go
@@ -39,6 +39,7 @@ func main() {
 		NewDisableCommand(),
 		NewRestartCommand(),
 		NewWhoamiCommand(),
+		NewSetKeyCommand(),
 	}
 
 	app.Run(os.Args)

--- a/client/repos.go
+++ b/client/repos.go
@@ -38,6 +38,16 @@ func (s *RepoService) Disable(host, owner, name string) error {
 	return s.run("DELETE", path, nil, nil)
 }
 
+// PUT /api/repos/{host}/{owner}/{name}
+func (s *RepoService) SetKey(host, owner, name, pub, priv string) error {
+	var path = fmt.Sprintf("/api/repos/%s/%s/%s", host, owner, name)
+	var in = struct {
+		PublicKey  string `json:"public_key"`
+		PrivateKey string `json:"private_key"`
+	}{pub, priv}
+	return s.run("PUT", path, &in, nil)
+}
+
 // GET /api/user/repos
 func (s *RepoService) List() ([]*model.Repo, error) {
 	var repos []*model.Repo


### PR DESCRIPTION
This is a work-in-progress. The functionality is there but it is not adequately tested (the code compiles, that is as far as I've gotten). It is the last piece of functionality required in order to close out #61

This allows you to change the SSH key used to clone a private repository via the command line utility. The specific command looks like this: `drone set-key github.com/foo/bar ~/.ssh/id_rsa`

There are two arguments that should be provided. First, you provide the full canonical name of the repository. Second, you provide the path to the private key. This assumes that a public key exists at the same path with `.pub` extension. Both will be uploaded to Drone and replace the existing key pair. Note that the keypair will not be updated in GitHub, GitLab, etc.