### PR TITLE
Enforce word breaks in terminal output

### DIFF
--- a/server/app/styles/drone.less
+++ b/server/app/styles/drone.less
@@ -1338,6 +1338,7 @@ nav {
 			font-family:@mono;
 			font-size:13px;
 			white-space: pre-wrap;
+			word-break: break-all;
 			overflow: hidden;
 			line-height:18px;
 		}


### PR DESCRIPTION
Fixes terminal output weirdness in `Firefox` with long lines in terminal output (`rspec` dot progress formatter for example).