### PR TITLE
Remove explicit `go get` for rice and goblin pkgs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ all: build
 deps:
 	# which npm && npm -g install uglify-js less autoprefixer
 	go get github.com/GeertJohan/go.rice/rice
-	go get github.com/franela/goblin
 	go get -t -v ./...
 
 test:


### PR DESCRIPTION
Both of these packages will be pulled in by the `go get` invocation on the following line as they are references by imports, so there's no need to list them separately.