### PR TITLE
Add Gogs to the config file and Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ secret=""
 url=""
 skip_verify=false
 
+[gogs]
+url=""
+secret=""
+
 [smtp]
 host=""
 port=""

--- a/packaging/root/etc/drone/drone.toml
+++ b/packaging/root/etc/drone/drone.toml
@@ -53,6 +53,9 @@ datasource="/var/lib/drone/drone.sqlite"
 # url=""
 # skip_verify=false
 
+# [gogs]
+# url=""
+# secret=""
 
 #####################################################################
 # SMTP configuration for Drone. This is required if you plan


### PR DESCRIPTION
While updating an Ansible module I noticed that while Gogs is supported,
it doesn't appear, commented out, in the TOML file or in the Readme.
This commit adds it

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>