### PR TITLE
Clarify 'sync running' message

### DIFF
--- a/server/app/views/home.html
+++ b/server/app/views/home.html
@@ -1,5 +1,5 @@
 <div class="toast" ng-if="msg != undefined">
-	<span ng-if="msg == 'already'">sync already runned</span>
+	<span ng-if="msg == 'already'">sync already in progress</span>
 	<span ng-if="msg == 'bad'">bad response</span>
 </div>
 

--- a/server/app/views/repo_list.html
+++ b/server/app/views/repo_list.html
@@ -1,5 +1,5 @@
 <div class="toast" ng-if="msg != undefined">
-	<span ng-if="msg == 'already'">sync already runned</span>
+	<span ng-if="msg == 'already'">sync already in progress</span>
 	<span ng-if="msg == 'bad'">bad response</span>
 </div>
 


### PR DESCRIPTION
Improve the grammar of the 'sync already runned' message to 'sync
already in progress', which should clarify what is happening when this
message is displayed.