### PR TITLE
Fixing an issue with branch grouping due to substring matching

### DIFF
--- a/server/app/views/repo.html
+++ b/server/app/views/repo.html
@@ -38,7 +38,7 @@
 		<section ng-repeat="group in commits | filter: { pull_request: '' } | unique: 'branch'">
 			<div class="pure-g cards">
 				<h2 class="pure-u-1" style="font-size:22px;margin-bottom:20px;"><i class="fa fa-code-fork"></i> {{group.branch}}</h2>
-				<a class="pure-u-1 pure-u-md-1-4 pure-u-lg-1-4 pure-u-xl-1-4 card card" ng-href="/{{ repo | fullPath }}/{{ commit.branch }}/{{ commit.sha }}" ng-repeat="commit in commits | filter: { branch: group.branch } | limitTo:4" data-status="{{ commit.status }}">
+				<a class="pure-u-1 pure-u-md-1-4 pure-u-lg-1-4 pure-u-xl-1-4 card card" ng-href="/{{ repo | fullPath }}/{{ commit.branch }}/{{ commit.sha }}" ng-repeat="commit in commits | filter:{ branch:group.branch }:true | limitTo:4" data-status="{{ commit.status }}">
 					<div class="l-box">
 						<h2>{{ commit.message }}</h2>
 						<em ng-if="commit.finished_at != 0">{{ commit.author }}<br/>{{ commit.finished_at | fromNow }}</em>


### PR DESCRIPTION
I noticed that if one branches name exists within another branch, its commits are included in both branches, this is because the AngularJS "filter" filter defaults to a substring match rather than a strict equality comparison. Simply specifying the comparator explicitly resolves the issue. 

https://docs.angularjs.org/api/ng/filter/filter 