### PR TITLE
Support org whitelists for GitHub+GHE remotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,14 @@ open=true
 [github]
 client=""
 secret=""
+orgs=[]
 
 [github_enterprise]
 client=""
 secret=""
 api=""
 url=""
+orgs=[]
 private_mode=false
 
 [bitbucket]

--- a/packaging/root/etc/drone/drone.toml
+++ b/packaging/root/etc/drone/drone.toml
@@ -37,12 +37,14 @@ datasource="/var/lib/drone/drone.sqlite"
 # [github]
 # client=""
 # secret=""
+# orgs=[]
 
 # [github_enterprise]
 # client=""
 # secret=""
 # api=""
 # url=""
+# orgs=[]
 # private_mode=false
 
 # [bitbucket]

--- a/plugin/remote/github/github_test.go
+++ b/plugin/remote/github/github_test.go
@@ -94,7 +94,11 @@ func Test_Github(t *testing.T) {
 
 		g.It("Should parse a pull request hook")
 
-		g.It("Should authorize a valid user", func() {
+		g.Describe("Authorize", func() {
+			g.AfterEach(func() {
+				github.Orgs = []string{}
+			})
+
 			var resp = httptest.NewRecorder()
 			var state = "validstate"
 			var req, _ = http.NewRequest(
@@ -104,9 +108,25 @@ func Test_Github(t *testing.T) {
 			)
 			req.AddCookie(&http.Cookie{Name: "github_state", Value: state})
 
-			var login, err = github.Authorize(resp, req)
-			g.Assert(err == nil).IsTrue()
-			g.Assert(login == nil).IsFalse()
+			g.It("Should authorize a valid user with no org restrictions", func() {
+				var login, err = github.Authorize(resp, req)
+				g.Assert(err == nil).IsTrue()
+				g.Assert(login == nil).IsFalse()
+			})
+
+			g.It("Should authorize a valid user in the correct org", func() {
+				github.Orgs = []string{"octocats-inc"}
+				var login, err = github.Authorize(resp, req)
+				g.Assert(err == nil).IsTrue()
+				g.Assert(login == nil).IsFalse()
+			})
+
+			g.It("Should not authorize a valid user in the wrong org", func() {
+				github.Orgs = []string{"acme"}
+				var login, err = github.Authorize(resp, req)
+				g.Assert(err != nil).IsTrue()
+				g.Assert(login == nil).IsTrue()
+			})
 		})
 	})
 }

--- a/plugin/remote/github/github_test.go
+++ b/plugin/remote/github/github_test.go
@@ -1,6 +1,9 @@
 package github
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/drone/drone/plugin/remote/github/testdata"
@@ -90,5 +93,20 @@ func Test_Github(t *testing.T) {
 		g.It("Should parse a commit hook")
 
 		g.It("Should parse a pull request hook")
+
+		g.It("Should authorize a valid user", func() {
+			var resp = httptest.NewRecorder()
+			var state = "validstate"
+			var req, _ = http.NewRequest(
+				"GET",
+				fmt.Sprintf("%s/?code=sekret&state=%s", server.URL, state),
+				nil,
+			)
+			req.AddCookie(&http.Cookie{Name: "github_state", Value: state})
+
+			var login, err = github.Authorize(resp, req)
+			g.Assert(err == nil).IsTrue()
+			g.Assert(login == nil).IsFalse()
+		})
 	})
 }

--- a/plugin/remote/github/helper.go
+++ b/plugin/remote/github/helper.go
@@ -270,3 +270,25 @@ func GetPayload(req *http.Request) []byte {
 	}
 	return []byte(payload)
 }
+
+// UserBelongsToOrg returns true if the currently authenticated user is a
+// member of any of the organizations provided.
+func UserBelongsToOrg(client *github.Client, permittedOrgs []string) (bool, error) {
+	userOrgs, err := GetOrgs(client)
+	if err != nil {
+		return false, err
+	}
+
+	userOrgSet := make(map[string]struct{}, len(userOrgs))
+	for _, org := range userOrgs {
+		userOrgSet[*org.Login] = struct{}{}
+	}
+
+	for _, org := range permittedOrgs {
+		if _, ok := userOrgSet[org]; ok {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/plugin/remote/github/helper.go
+++ b/plugin/remote/github/helper.go
@@ -138,7 +138,7 @@ func GetOrgRepos(client *github.Client, org string) ([]github.Repository, error)
 }
 
 // GetOrgs is a helper function that returns a list of
-// all org repositories.
+// all orgs that a user belongs to.
 func GetOrgs(client *github.Client) ([]github.Organization, error) {
 	orgs, _, err := client.Organizations.List("", nil)
 	return orgs, err

--- a/plugin/remote/github/helper_test.go
+++ b/plugin/remote/github/helper_test.go
@@ -12,13 +12,22 @@ func Test_Helper(t *testing.T) {
 	var server = testdata.NewServer()
 	defer server.Close()
 
+	var client = NewClient(server.URL, "sekret", false)
+
 	g := goblin.Goblin(t)
 	g.Describe("GitHub Helper Functions", func() {
 
 		g.It("Should Get a User")
 		g.It("Should Get a User Primary Email")
 		g.It("Should Get a User + Primary Email")
-		g.It("Should Get a list of Orgs")
+
+		g.It("Should Get a list of Orgs", func() {
+			var orgs, err = GetOrgs(client)
+			g.Assert(err == nil).IsTrue()
+			g.Assert(len(orgs)).Equal(1)
+			g.Assert(*orgs[0].Login).Equal("octocats-inc")
+		})
+
 		g.It("Should Get a list of User Repos")
 		g.It("Should Get a list of Org Repos")
 		g.It("Should Get a list of All Repos")

--- a/plugin/remote/github/helper_test.go
+++ b/plugin/remote/github/helper_test.go
@@ -39,5 +39,20 @@ func Test_Helper(t *testing.T) {
 		g.It("Should Create or Update a Repo Hook")
 		g.It("Should Get a Repo File")
 
+		g.Describe("UserBelongsToOrg", func() {
+			g.It("Should confirm user does belong to 'octocats-inc' org", func() {
+				var requiredOrgs = []string{"one", "octocats-inc", "two"}
+				var member, err = UserBelongsToOrg(client, requiredOrgs)
+				g.Assert(err == nil).IsTrue()
+				g.Assert(member).IsTrue()
+			})
+
+			g.It("Should confirm user not does belong to 'octocats-inc' org", func() {
+				var requiredOrgs = []string{"one", "two"}
+				var member, err = UserBelongsToOrg(client, requiredOrgs)
+				g.Assert(err == nil).IsTrue()
+				g.Assert(member).IsFalse()
+			})
+		})
 	})
 }

--- a/plugin/remote/github/register.go
+++ b/plugin/remote/github/register.go
@@ -9,6 +9,7 @@ var (
 	// GitHub cloud configuration details
 	githubClient = config.String("github-client", "")
 	githubSecret = config.String("github-secret", "")
+	githubOrgs   = config.Strings("github-orgs")
 
 	// GitHub Enterprise configuration details
 	githubEnterpriseURL        = config.String("github-enterprise-url", "")
@@ -17,6 +18,7 @@ var (
 	githubEnterpriseSecret     = config.String("github-enterprise-secret", "")
 	githubEnterprisePrivate    = config.Bool("github-enterprise-private-mode", true)
 	githubEnterpriseSkipVerify = config.Bool("github-enterprise-skip-verify", false)
+	githubEnterpriseOrgs       = config.Strings("github-enterprise-orgs")
 )
 
 // Registers the GitHub plugins using the default
@@ -33,7 +35,7 @@ func registerGitHub() {
 		return
 	}
 	remote.Register(
-		NewDefault(*githubClient, *githubSecret),
+		NewDefault(*githubClient, *githubSecret, *githubOrgs),
 	)
 }
 
@@ -53,6 +55,7 @@ func registerGitHubEnterprise() {
 			*githubEnterpriseSecret,
 			*githubEnterprisePrivate,
 			*githubEnterpriseSkipVerify,
+			*githubEnterpriseOrgs,
 		),
 	)
 }

--- a/plugin/remote/github/testdata/testdata.go
+++ b/plugin/remote/github/testdata/testdata.go
@@ -21,7 +21,7 @@ func NewServer() *httptest.Server {
 		case "/user/orgs":
 			w.Write(userOrgsPayload)
 			return
-		case "/orgs/github/repos":
+		case "/orgs/octocats-inc/repos":
 			w.Write(userReposPayload)
 			return
 		case "/repos/octocat/Hello-World/contents/.drone.yml":
@@ -108,7 +108,7 @@ var emptyObjPayload = []byte(`{}`)
 // sample org list response
 var userOrgsPayload = []byte(`
 [
-	{ "login": "github", "id": 1 }
+	{ "login": "octocats-inc", "id": 1 }
 ]
 `)
 

--- a/plugin/remote/github/testdata/testdata.go
+++ b/plugin/remote/github/testdata/testdata.go
@@ -15,6 +15,15 @@ func NewServer() *httptest.Server {
 
 		// evaluate the path to serve a dummy data file
 		switch r.URL.Path {
+		case "/login/oauth/access_token":
+			w.Write(accessTokenPayload)
+			return
+		case "/user":
+			w.Write(userPayload)
+			return
+		case "/user/emails":
+			w.Write(userEmailsPayload)
+			return
 		case "/user/repos":
 			w.Write(userReposPayload)
 			return
@@ -55,6 +64,64 @@ func NewServer() *httptest.Server {
 	// will need to know the base URL path
 	return server
 }
+
+var accessTokenPayload = []byte(`access_token=sekret&scope=repo%2Cuser%3Aemail&token_type=bearer`)
+
+var userPayload = []byte(`
+{
+  "login": "octocat",
+  "id": 1,
+  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+  "gravatar_id": "",
+  "url": "https://api.github.com/users/octocat",
+  "html_url": "https://github.com/octocat",
+  "followers_url": "https://api.github.com/users/octocat/followers",
+  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+  "organizations_url": "https://api.github.com/users/octocat/orgs",
+  "repos_url": "https://api.github.com/users/octocat/repos",
+  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+  "received_events_url": "https://api.github.com/users/octocat/received_events",
+  "type": "User",
+  "site_admin": false,
+  "name": "monalisa octocat",
+  "company": "GitHub",
+  "blog": "https://github.com/blog",
+  "location": "San Francisco",
+  "email": "octocat@github.com",
+  "hireable": false,
+  "bio": "There once was...",
+  "public_repos": 2,
+  "public_gists": 1,
+  "followers": 20,
+  "following": 0,
+  "created_at": "2008-01-14T04:33:35Z",
+  "updated_at": "2008-01-14T04:33:35Z",
+  "total_private_repos": 100,
+  "owned_private_repos": 100,
+  "private_gists": 81,
+  "disk_usage": 10000,
+  "collaborators": 8,
+  "plan": {
+    "name": "Medium",
+    "space": 400,
+    "private_repos": 20,
+    "collaborators": 0
+  }
+}
+`)
+
+var userEmailsPayload = []byte(`
+[
+  {
+    "email": "octocat@github.com",
+    "verified": true,
+    "primary": true
+  }
+]
+`)
 
 // sample repository list
 var userReposPayload = []byte(`


### PR DESCRIPTION
Allow the GitHub and GitHub Enterprise remotes to restrict who can login
based on a user's organisation membership. This can be used as a safe
addition to open registration and also ensures that access is revoked when a
user is subsequently removed from the org. The default is not to restrict at
all.

---

Plus some supporting tests..