### PR TITLE
SCM plugins

### DIFF
--- a/cli/build.go
+++ b/cli/build.go
@@ -13,6 +13,8 @@ import (
 	"github.com/drone/drone/shared/build/repo"
 	"github.com/drone/drone/shared/build/script"
 
+	"github.com/drone/drone/plugin/scm/local"
+
 	"github.com/codegangsta/cli"
 )
 
@@ -105,6 +107,8 @@ func buildCommandFunc(c *cli.Context) {
 
 // TODO this has gotten a bit out of hand. refactor input params
 func run(path, identity, dockerhost, dockercert, dockerkey string, publish, deploy, privileged bool) (int, error) {
+	local.Register()
+
 	dockerClient, err := docker.NewHostCertFile(dockerhost, dockercert, dockerkey)
 	if err != nil {
 		log.Err(err.Error())
@@ -162,6 +166,7 @@ func run(path, identity, dockerhost, dockercert, dockerkey string, publish, depl
 	// this is where the code gets uploaded to the container
 	// TODO move this code to the build package
 	code.Dir = filepath.Join("/var/cache/drone/src", filepath.Clean(code.Dir))
+	code.Scm = "local"
 
 	// ssh key to import into container
 	var key []byte

--- a/plugin/remote/bitbucket/bitbucket.go
+++ b/plugin/remote/bitbucket/bitbucket.go
@@ -158,8 +158,20 @@ func (r *Bitbucket) GetRepos(user *model.User) ([]*model.Repo, error) {
 		// TODO use the bitbucketurl.Host and bitbucketurl.Scheme instead of hardcoding
 		//      so that we can support Stash.
 		var html = fmt.Sprintf("https://bitbucket.org/%s/%s", item.Owner, item.Slug)
-		var clone = fmt.Sprintf("https://bitbucket.org/%s/%s.git", item.Owner, item.Slug)
-		var ssh = fmt.Sprintf("git@bitbucket.org:%s/%s.git", item.Owner, item.Slug)
+		var clone = ""
+		var ssh = ""
+		var scm = ""
+		switch {
+		case item.Scm == "hg":
+			scm = model.Mercurial
+			clone = fmt.Sprintf("https://bitbucket.org/%s/%s", item.Owner, item.Name)
+			ssh = fmt.Sprintf("ssh://hg@bitbucket.org:%s/%s", item.Owner, item.Name)
+		case item.Scm == "git":
+		default:
+			scm = model.Git
+			clone = fmt.Sprintf("https://bitbucket.org/%s/%s.git", item.Owner, item.Name)
+			ssh = fmt.Sprintf("git@bitbucket.org:%s/%s.git", item.Owner, item.Name)
+		}
 
 		var repo = model.Repo{
 			UserID:   user.ID,
@@ -167,6 +179,7 @@ func (r *Bitbucket) GetRepos(user *model.User) ([]*model.Repo, error) {
 			Host:     hostname,
 			Owner:    item.Owner,
 			Name:     item.Slug,
+			Scm:      scm,
 			Private:  item.Private,
 			URL:      html,
 			CloneURL: clone,

--- a/plugin/remote/github/github.go
+++ b/plugin/remote/github/github.go
@@ -159,6 +159,7 @@ func (r *GitHub) GetRepos(user *model.User) ([]*model.Repo, error) {
 			Host:     hostname,
 			Owner:    *item.Owner.Login,
 			Name:     *item.Name,
+			Scm:      model.Git,
 			Private:  *item.Private,
 			URL:      *item.HTMLURL,
 			CloneURL: *item.GitURL,

--- a/plugin/remote/gitlab/gitlab.go
+++ b/plugin/remote/gitlab/gitlab.go
@@ -77,6 +77,7 @@ func (r *Gitlab) GetRepos(user *model.User) ([]*model.Repo, error) {
 			Host:     hostname,
 			Owner:    item.Namespace.Path,
 			Name:     item.Path,
+			Scm:      model.Git,
 			Private:  !item.Public,
 			CloneURL: item.HttpRepoUrl,
 			GitURL:   item.HttpRepoUrl,

--- a/plugin/remote/gogs/gogs.go
+++ b/plugin/remote/gogs/gogs.go
@@ -109,6 +109,7 @@ func (r *Gogs) GetRepos(user *model.User) ([]*model.Repo, error) {
 			Host:     hostname,
 			Owner:    owner,
 			Name:     name,
+			Scm:      model.Git,
 			Private:  repo.Private,
 			CloneURL: repo.CloneUrl,
 			GitURL:   repo.CloneUrl,

--- a/plugin/scm/git/git.go
+++ b/plugin/scm/git/git.go
@@ -1,0 +1,41 @@
+package git
+
+import (
+	"fmt"
+
+	"github.com/drone/drone/shared/build/buildfile"
+	"github.com/drone/drone/shared/build/repo"
+)
+
+type Git struct{}
+
+func New() *Git {
+	return &Git{}
+}
+
+func (g *Git) Commit(f *buildfile.Buildfile, r *repo.Repo) {
+	f.WriteCmd(fmt.Sprintf("git clone --depth=%d --recursive %s %s", r.Depth, r.Path, r.Dir))
+	f.WriteCmd(fmt.Sprintf("git checkout -qf %s", r.Commit))
+}
+
+func (g *Git) PullRequest(f *buildfile.Buildfile, r *repo.Repo) {
+	f.WriteCmd(fmt.Sprintf("git clone --depth=%d --recursive %s %s", r.Depth, r.Path, r.Dir))
+	f.WriteCmd(fmt.Sprintf("git fetch origin +refs/pull/%s/head:refs/remotes/origin/pr/%s", r.PR, r.PR))
+	f.WriteCmd(fmt.Sprintf("git checkout -qf -b pr/%s origin/pr/%s", r.PR, r.PR))
+}
+
+func (g *Git) DefaultBranch() string {
+	return "master"
+}
+
+func (g *Git) GetBranch(r *repo.Repo) string {
+	if r.Branch == "" {
+		return g.DefaultBranch()
+	} else {
+		return r.Branch
+	}
+}
+
+func (g *Git) GetKind() string {
+	return "git"
+}

--- a/plugin/scm/git/register.go
+++ b/plugin/scm/git/register.go
@@ -1,0 +1,11 @@
+package git
+
+import (
+	"github.com/drone/drone/plugin/scm"
+)
+
+func Register() {
+	scm.Register(
+		New(),
+	)
+}

--- a/plugin/scm/local/local.go
+++ b/plugin/scm/local/local.go
@@ -1,0 +1,35 @@
+// Abstract package over rsync, for local drone cli
+package local
+
+import (
+	"fmt"
+
+	"github.com/drone/drone/shared/build/buildfile"
+	"github.com/drone/drone/shared/build/repo"
+)
+
+type Local struct{}
+
+func New() *Local {
+	return &Local{}
+}
+
+func (l *Local) Commit(f *buildfile.Buildfile, r *repo.Repo) {
+	f.WriteCmd(fmt.Sprintf("rsync -rt %s %s", r.Path, r.Dir))
+}
+
+func (l *Local) PullRequest(f *buildfile.Buildfile, r *repo.Repo) {
+	return
+}
+
+func (l *Local) DefaultBranch() string {
+	return ""
+}
+
+func (l *Local) GetBranch(r *repo.Repo) string {
+	return l.DefaultBranch()
+}
+
+func (l *Local) GetKind() string {
+	return "local"
+}

--- a/plugin/scm/local/register.go
+++ b/plugin/scm/local/register.go
@@ -1,0 +1,11 @@
+package local
+
+import (
+	"github.com/drone/drone/plugin/scm"
+)
+
+func Register() {
+	scm.Register(
+		New(),
+	)
+}

--- a/plugin/scm/mercurial/mercurial.go
+++ b/plugin/scm/mercurial/mercurial.go
@@ -1,0 +1,39 @@
+package mercurial
+
+import (
+	"fmt"
+
+	"github.com/drone/drone/shared/build/buildfile"
+	"github.com/drone/drone/shared/build/repo"
+)
+
+type Mercurial struct{}
+
+func New() *Mercurial {
+	return &Mercurial{}
+}
+
+func (m *Mercurial) Commit(f *buildfile.Buildfile, r *repo.Repo) {
+	f.WriteCmd(fmt.Sprintf("hg clone --branch %s %s %s", m.GetBranch(r), r.Path, r.Dir))
+	f.WriteCmd(fmt.Sprintf("hg update %s", r.Commit))
+}
+
+func (m *Mercurial) PullRequest(f *buildfile.Buildfile, r *repo.Repo) {
+	return
+}
+
+func (m *Mercurial) DefaultBranch() string {
+	return "default"
+}
+
+func (m *Mercurial) GetBranch(r *repo.Repo) string {
+	if r.Branch == "" {
+		return m.DefaultBranch()
+	} else {
+		return r.Branch
+	}
+}
+
+func (m *Mercurial) GetKind() string {
+	return "mercurial"
+}

--- a/plugin/scm/mercurial/register.go
+++ b/plugin/scm/mercurial/register.go
@@ -1,0 +1,11 @@
+package mercurial
+
+import (
+	"github.com/drone/drone/plugin/scm"
+)
+
+func Register() {
+	scm.Register(
+		New(),
+	)
+}

--- a/plugin/scm/scm.go
+++ b/plugin/scm/scm.go
@@ -1,0 +1,29 @@
+package scm
+
+import (
+	"github.com/drone/drone/shared/build/buildfile"
+	"github.com/drone/drone/shared/build/repo"
+)
+
+type Scm interface {
+	Commit(f *buildfile.Buildfile, r *repo.Repo)
+	PullRequest(f *buildfile.Buildfile, r *repo.Repo)
+	DefaultBranch() string
+	GetBranch(r *repo.Repo) string
+	GetKind() string
+}
+
+var scms []Scm
+
+func Register(scm Scm) {
+	scms = append(scms, scm)
+}
+
+func Lookup(name string) Scm {
+	for _, scm := range scms {
+		if scm.GetKind() == name {
+			return scm
+		}
+	}
+	return nil
+}

--- a/server/app/scripts/filters/filters.js
+++ b/server/app/scripts/filters/filters.js
@@ -98,7 +98,8 @@
       var scheme = window.location.protocol;
       var host = window.location.host;
       var path = repo.host+'/'+repo.owner+'/'+repo.name;
-      return '[![Build Status]('+scheme+'//'+host+'/api/badge/'+path+'/status.svg?branch=master)]('+scheme+'//'+host+'/'+path+')'
+      var branch = repo.default_branch;
+      return '[![Build Status]('+scheme+'//'+host+'/api/badge/'+path+'/status.svg?branch='+branch+')]('+scheme+'//'+host+'/'+path+')'
     }
   }
 
@@ -112,7 +113,8 @@
       var scheme = window.location.protocol;
       var host = window.location.host;
       var path = repo.host+'/'+repo.owner+'/'+repo.name;
-      return '[![Build Status]('+scheme+'//'+host+'/api/badge/'+path+'/status.svg?branch=master)]('+scheme+'//'+host+'/'+path+')'
+      var branch = repo.default_branch;
+      return '[![Build Status]('+scheme+'//'+host+'/api/badge/'+path+'/status.svg?branch='+branch+')]('+scheme+'//'+host+'/'+path+')'
     }
   }
 

--- a/server/datastore/database/database.go
+++ b/server/datastore/database/database.go
@@ -38,6 +38,7 @@ func Connect(driver, datasource string) (*sql.DB, error) {
 	var migrations = []migration.Migrator{
 		migrate.Setup,
 		migrate.Migrate_20142110,
+		migrate.Migrate_20151801,
 	}
 	return migration.Open(driver, datasource, migrations)
 }

--- a/server/datastore/migrate/migrate.go
+++ b/server/datastore/migrate/migrate.go
@@ -39,6 +39,21 @@ func Migrate_20142110(tx migration.LimitedTx) error {
 	return nil
 }
 
+// Add scm to repos.
+func Migrate_20151801(tx migration.LimitedTx) error {
+	var stmts = []string{
+		repoScmColumn, // add the repo scm column
+		repoScmUpdate, // update the repo scm column to 'git'
+	}
+	for _, stmt := range stmts {
+		_, err := tx.Exec(transform(stmt))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 var userTable = `
 CREATE TABLE IF NOT EXISTS users (
 	 user_id           INTEGER PRIMARY KEY AUTOINCREMENT
@@ -143,4 +158,12 @@ CREATE TABLE IF NOT EXISTS blobs (
 	,blob_data    BLOB
 	,UNIQUE(blob_path)
 );
+`
+
+var repoScmColumn = `
+ALTER TABLE repos ADD COLUMN repo_scm VARCHAR(255);
+`
+
+var repoScmUpdate = `
+UPDATE repos SET repo_scm = 'git';
 `

--- a/server/handler/badge.go
+++ b/server/handler/badge.go
@@ -73,7 +73,7 @@ func GetBadge(c web.C, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if len(branch) == 0 {
-		branch = model.DefaultBranch
+		branch = repo.DefaultBranch()
 	}
 	commit, _ := datastore.GetCommitLast(ctx, repo, branch)
 

--- a/server/handler/repo.go
+++ b/server/handler/repo.go
@@ -36,10 +36,11 @@ func GetRepo(c web.C, w http.ResponseWriter, r *http.Request) {
 	// else we should return restricted fields
 	json.NewEncoder(w).Encode(struct {
 		*model.Repo
-		PublicKey string      `json:"public_key"`
-		Params    string      `json:"params"`
-		Perm      *model.Perm `json:"role"`
-	}{repo, repo.PublicKey, repo.Params, role})
+		DefaultBranch string      `json:"default_branch"`
+		PublicKey     string      `json:"public_key"`
+		Params        string      `json:"params"`
+		Perm          *model.Perm `json:"role"`
+	}{repo, repo.DefaultBranch(), repo.PublicKey, repo.Params, role})
 }
 
 // DelRepo accepts a request to inactivate the named

--- a/server/main.go
+++ b/server/main.go
@@ -25,6 +25,8 @@ import (
 	"github.com/drone/drone/plugin/remote/github"
 	"github.com/drone/drone/plugin/remote/gitlab"
 	"github.com/drone/drone/plugin/remote/gogs"
+	"github.com/drone/drone/plugin/scm/git"
+	"github.com/drone/drone/plugin/scm/mercurial"
 	"github.com/drone/drone/server/blobstore"
 	"github.com/drone/drone/server/datastore"
 	"github.com/drone/drone/server/datastore/database"
@@ -96,6 +98,9 @@ func main() {
 	github.Register()
 	gitlab.Register()
 	gogs.Register()
+
+	git.Register()
+	mercurial.Register()
 
 	// setup the database and cancel all pending
 	// commits in the system.

--- a/server/worker/docker/docker.go
+++ b/server/worker/docker/docker.go
@@ -114,6 +114,7 @@ func (d *Docker) Do(c context.Context, r *worker.Work) {
 		Name:   path,
 		Path:   r.Repo.CloneURL,
 		Branch: r.Commit.Branch,
+		Scm:    r.Repo.Scm,
 		Commit: r.Commit.Sha,
 		PR:     r.Commit.PullRequest,
 		Dir:    filepath.Join("/var/cache/drone/src", git.GitPath(script.Git, path)),

--- a/shared/build/build_test.go
+++ b/shared/build/build_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/drone/drone/plugin/scm/git"
 	"github.com/drone/drone/shared/build/buildfile"
 	"github.com/drone/drone/shared/build/docker"
 	"github.com/drone/drone/shared/build/proxy"
@@ -33,6 +34,7 @@ var (
 // setup a mock docker client for testing purposes. This will use
 // a test http server that can return mock responses to the docker client.
 func setup() {
+	git.Register()
 	mux = http.NewServeMux()
 	server = httptest.NewServer(mux)
 
@@ -79,6 +81,7 @@ func TestSetup(t *testing.T) {
 	b := Builder{}
 	b.Repo = &repo.Repo{}
 	b.Repo.Path = "git://github.com/drone/drone.git"
+	b.Repo.Scm = "git"
 	b.Build = &script.Build{}
 	b.Build.Image = "go1.2"
 	b.dockerClient = client
@@ -146,6 +149,7 @@ func TestSetupErrorRunDaemonPorts(t *testing.T) {
 	b := Builder{}
 	b.Repo = &repo.Repo{}
 	b.Repo.Path = "git://github.com/drone/drone.git"
+	b.Repo.Scm = "git"
 	b.Build = &script.Build{}
 	b.Build.Image = "go1.2"
 	b.Build.Services = append(b.Build.Services, "mysql")
@@ -243,6 +247,7 @@ func TestSetupErrorBuild(t *testing.T) {
 	b := Builder{}
 	b.Repo = &repo.Repo{}
 	b.Repo.Path = "git://github.com/drone/drone.git"
+	b.Repo.Scm = "git"
 	b.Build = &script.Build{}
 	b.Build.Image = "go1.2"
 	b.dockerClient = client
@@ -278,6 +283,7 @@ func TestSetupErrorBuildInspect(t *testing.T) {
 	b := Builder{}
 	b.Repo = &repo.Repo{}
 	b.Repo.Path = "git://github.com/drone/drone.git"
+	b.Repo.Scm = "git"
 	b.Build = &script.Build{}
 	b.Build.Image = "go1.2"
 	b.dockerClient = client
@@ -526,6 +532,7 @@ func TestWriteBuildScript(t *testing.T) {
 		Branch: "master",
 		Commit: "e7e046b35",
 		PR:     "123",
+		Scm:    "git",
 		Dir:    "/var/cache/drone/github.com/drone/drone"}
 	b.writeBuildScript(dir)
 

--- a/shared/build/repo/repo.go
+++ b/shared/build/repo/repo.go
@@ -1,14 +1,12 @@
 package repo
 
-import (
-	"fmt"
-	"strings"
-)
-
 type Repo struct {
 	// The name of the Repository. This should be the
 	// canonical name, for example, github.com/drone/drone.
 	Name string
+
+	// The type of source control management.
+	Scm string
 
 	// The path of the Repoisotry. This could be
 	// the remote path of a Git repository or the path of
@@ -42,86 +40,18 @@ type Repo struct {
 	Depth int
 }
 
-// IsRemote returns true if the Repository is located
-// on a remote server (ie Github, Bitbucket)
 func (r *Repo) IsRemote() bool {
-	switch {
-	case strings.HasPrefix(r.Path, "git://"):
-		return true
-	case strings.HasPrefix(r.Path, "git@"):
-		return true
-	case strings.HasPrefix(r.Path, "gitlab@"):
-		return true
-	case strings.HasPrefix(r.Path, "http://"):
-		return true
-	case strings.HasPrefix(r.Path, "https://"):
-		return true
-	case strings.HasPrefix(r.Path, "ssh://"):
-		return true
-	}
-
-	return false
-}
-
-// IsLocal returns true if the Repository is located
-// on the local filesystem.
-func (r *Repo) IsLocal() bool {
-	return !r.IsRemote()
-}
-
-// IsGit returns true if the Repository is
-// a Git repoisitory.
-func (r *Repo) IsGit() bool {
-	switch {
-	case strings.HasPrefix(r.Path, "git://"):
-		return true
-	case strings.HasPrefix(r.Path, "git@"):
-		return true
-	case strings.HasPrefix(r.Path, "ssh://git@"):
-		return true
-	case strings.HasPrefix(r.Path, "gitlab@"):
-		return true
-	case strings.HasPrefix(r.Path, "ssh://gitlab@"):
-		return true
-	case strings.HasPrefix(r.Path, "https://github"):
-		return true
-	case strings.HasPrefix(r.Path, "http://github"):
-		return true
-	case strings.HasSuffix(r.Path, ".git"):
-		return true
-	}
-
-	// we could also ping the repository to check
-
-	return false
-}
-
-// returns commands that can be used in a Dockerfile
-// to clone the repository.
-//
-// TODO we should also enable Mercurial projects and SVN projects
-func (r *Repo) Commands() []string {
-	// get the branch. default to master
-	// if no branch exists.
-	branch := r.Branch
-	if len(branch) == 0 {
-		branch = "master"
-	}
-
-	cmds := []string{}
-	if len(r.PR) > 0 {
-		// If a specific PR is provided then we need to clone it.
-		cmds = append(cmds, fmt.Sprintf("git clone --depth=%d --recursive %s %s", r.Depth, r.Path, r.Dir))
-		cmds = append(cmds, fmt.Sprintf("git fetch origin +refs/pull/%s/head:refs/remotes/origin/pr/%s", r.PR, r.PR))
-		cmds = append(cmds, fmt.Sprintf("git checkout -qf -b pr/%s origin/pr/%s", r.PR, r.PR))
+	if r.Scm == "local" {
+		return false
 	} else {
-		// Otherwise just clone the branch.
-		cmds = append(cmds, fmt.Sprintf("git clone --depth=%d --recursive --branch=%s %s %s", r.Depth, branch, r.Path, r.Dir))
-		// If a specific commit is provided then we'll need to check it out.
-		if len(r.Commit) > 0 {
-			cmds = append(cmds, fmt.Sprintf("git checkout -qf %s", r.Commit))
-		}
+		return true
 	}
+}
 
-	return cmds
+func (r *Repo) IsLocal() bool {
+	if r.Scm == "local" {
+		return true
+	} else {
+		return false
+	}
 }

--- a/shared/build/repo/repo_test.go
+++ b/shared/build/repo/repo_test.go
@@ -6,49 +6,50 @@ import (
 
 func TestIsRemote(t *testing.T) {
 	repos := []struct {
-		path   string
+		scm    string
 		remote bool
 	}{
-		{"git://github.com/foo/far", true},
-		{"git://github.com/foo/far.git", true},
-		{"git@github.com:foo/far", true},
-		{"git@github.com:foo/far.git", true},
-		{"http://github.com/foo/far.git", true},
-		{"https://github.com/foo/far.git", true},
-		{"ssh://baz.com/foo/far.git", true},
-		{"/var/lib/src", false},
-		{"/home/ubuntu/src", false},
-		{"src", false},
+		{"git", true},
+		{"mercurial", true},
+		{"mercurial", true},
+		{"mercurial", true},
+		{"git", true},
+		{"git", true},
+		{"mercurial", true},
+		{"local", false},
+		{"local", false},
+		{"local", false},
 	}
 
 	for _, r := range repos {
-		repo := Repo{Path: r.path}
+		repo := Repo{Scm: r.scm}
 		if remote := repo.IsRemote(); remote != r.remote {
-			t.Errorf("IsRemote %s was %v, expected %v", r.path, remote, r.remote)
+			t.Errorf("IsRemote %s was %v, expected %v", r.scm, remote, r.remote)
 		}
 	}
 }
 
-func TestIsGit(t *testing.T) {
+func TestIsLocal(t *testing.T) {
 	repos := []struct {
-		path   string
-		remote bool
+		scm   string
+		local bool
 	}{
-		{"git://github.com/foo/far", true},
-		{"git://github.com/foo/far.git", true},
-		{"git@github.com:foo/far", true},
-		{"git@github.com:foo/far.git", true},
-		{"http://github.com/foo/far.git", true},
-		{"https://github.com/foo/far.git", true},
-		{"ssh://baz.com/foo/far.git", true},
-		{"svn://gcc.gnu.org/svn/gcc/branches/gccgo", false},
-		{"https://code.google.com/p/go", false},
+		{"git", false},
+		{"mercurial", false},
+		{"mercurial", false},
+		{"mercurial", false},
+		{"git", false},
+		{"git", false},
+		{"mercurial", false},
+		{"local", true},
+		{"local", true},
+		{"local", true},
 	}
 
 	for _, r := range repos {
-		repo := Repo{Path: r.path}
-		if remote := repo.IsGit(); remote != r.remote {
-			t.Errorf("IsGit %s was %v, expected %v", r.path, remote, r.remote)
+		repo := Repo{Scm: r.scm}
+		if local := repo.IsLocal(); local != r.local {
+			t.Errorf("IsRemote %s was %v, expected %v", r.scm, local, r.local)
 		}
 	}
 }

--- a/shared/model/repo.go
+++ b/shared/model/repo.go
@@ -2,6 +2,14 @@ package model
 
 import (
 	"gopkg.in/yaml.v1"
+
+	"github.com/drone/drone/plugin/scm"
+)
+
+const (
+	Git       = "git"
+	Mercurial = "mercurial"
+	Local     = "local"
 )
 
 var (
@@ -23,6 +31,7 @@ type Repo struct {
 	Host   string `meddler:"repo_host"         json:"host"`
 	Owner  string `meddler:"repo_owner"        json:"owner"`
 	Name   string `meddler:"repo_name"         json:"name"`
+	Scm    string `meddler:"repo_scm"          json:"scm"`
 
 	URL      string `meddler:"repo_url"       json:"url"`
 	CloneURL string `meddler:"repo_clone_url" json:"clone_url"`
@@ -63,4 +72,14 @@ func (r *Repo) ParamMap() (map[string]string, error) {
 	out := map[string]string{}
 	err := yaml.Unmarshal([]byte(r.Params), out)
 	return out, err
+}
+
+func (r *Repo) DefaultBranch() string {
+	source := scm.Lookup(r.Scm)
+
+	if source != nil {
+		return source.DefaultBranch()
+	} else {
+		return "master"
+	}
 }


### PR DESCRIPTION
This is rework pull requests https://github.com/drone/drone/pull/793 and https://github.com/drone/drone/pull/785

This PR allow move scm logic outside build package, to create a simple scm implementations inside drone.

Also has been added scm "local", because when docker add files from root user, non-root users doesn't have write access to this files. For now, files with source adds to `/tmp/drone_cache` and then we use rsync to copy files inside build directory `rsync -rt /tmp/drone_cache/ /var/cache/drone/src/github.com/drone/drone`. Local scm needed for https://github.com/drone/drone/issues/749#issuecomment-67302820 if we want to set `$DRONEPATH` when we use drone cli