### PR TITLE
Fix services behaviour when docker net is host

### DIFF
--- a/shared/build/build.go
+++ b/shared/build/build.go
@@ -198,7 +198,15 @@ func (b *Builder) setup() error {
 		log.Infof("starting service container %s", cname)
 
 		// Run the contianer
-		run, err := b.dockerClient.Containers.RunDaemonPorts(cname, img.Config.ExposedPorts)
+		var run *docker.Run
+		networkMode := script.DockerNetworkMode(b.Build.Docker)
+		privileged := b.Privileged && len(b.Repo.PR) == 0
+		if privileged && networkMode == "host" {
+			run, err = b.dockerClient.Containers.RunDaemonHost(cname)
+
+		} else {
+			run, err = b.dockerClient.Containers.RunDaemonPorts(cname, img.Config.ExposedPorts)
+		}
 		if err != nil {
 			return err
 		}
@@ -337,13 +345,15 @@ func (b *Builder) run() error {
 	log.Noticef("starting build %s", b.Build.Name)
 
 	// link service containers
-	for i, service := range b.services {
-		// convert name of the image to a slug
-		_, name, _ := parseImageName(b.Build.Services[i])
+	if host.NetworkMode != "host" {
+		for i, service := range b.services {
+			// convert name of the image to a slug
+			_, name, _ := parseImageName(b.Build.Services[i])
 
-		// link the service container to our
-		// build container.
-		host.Links = append(host.Links, service.Name[1:]+":"+name)
+			// link the service container to our
+			// build container.
+			host.Links = append(host.Links, service.Name[1:]+":"+name)
+		}
 	}
 
 	// where are temp files going to go?

--- a/shared/build/docker/container.go
+++ b/shared/build/docker/container.go
@@ -144,3 +144,11 @@ func (c *ContainerService) RunDaemonPorts(image string, ports map[Port]struct{})
 	//map[3306/tcp:{}] map[3306/tcp:[{127.0.0.1 }]]
 	return c.RunDaemon(&config, &host)
 }
+
+func (c *ContainerService) RunDaemonHost(image string) (*Run, error) {
+	// setup configuration
+	config := Config{Image: image}
+	host := HostConfig{}
+	host.NetworkMode = "host"
+	return c.RunDaemon(&config, &host)
+}


### PR DESCRIPTION
When the image runs with `--net host`, docker links will not work.
This commit checks to see if `--net host` has been set, and if so
creates the services in `--net host` also.

Fixes #839

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>