### PR TITLE
Exclude Pull Requests from the branches.

### DIFF
--- a/server/app/views/repo.html
+++ b/server/app/views/repo.html
@@ -34,8 +34,7 @@
 			<p>Add a .drone.yml file and make a commit to trigger a build</p>
 			<div><i class="fa fa-file-code-o"></i></div>
 		</section>
-
-		<section ng-repeat="group in commits | filter: { pull_request: '' } | unique: 'branch'">
+		<section ng-repeat="group in commits | filter:{ pull_request: '' }:true | unique: 'branch'">
 			<div class="pure-g cards">
 				<h2 class="pure-u-1" style="font-size:22px;margin-bottom:20px;"><i class="fa fa-code-fork"></i> {{group.branch}}</h2>
 				<a class="pure-u-1 pure-u-md-1-4 pure-u-lg-1-4 pure-u-xl-1-4 card card" ng-href="/{{ repo | fullPath }}/{{ commit.branch }}/{{ commit.sha }}" ng-repeat="commit in commits | filter:{ branch:group.branch }:true | limitTo:4" data-status="{{ commit.status }}">


### PR DESCRIPTION
Currently they are included because the AngularJS "filter" filter defaults to a substring match rather than a strict equality comparison, so filtering by '' includes everything.
https://docs.angularjs.org/api/ng/filter/filter

This issue was also discussed in #819.