### PR TITLE
Possibility to retag docker images

### DIFF
--- a/plugin/publish/docker.go
+++ b/plugin/publish/docker.go
@@ -33,6 +33,7 @@ type Docker struct {
 	KeepBuild bool     `yaml:"keep_build"`
 	Tag       string   `yaml:"tag"`
 	Tags      []string `yaml:"tags"`
+	ForceTags bool     `yaml:"force_tags"`
 
 	Condition *condition.Condition `yaml:"when,omitempty"`
 }
@@ -100,7 +101,11 @@ func (d *Docker) Write(f *buildfile.Buildfile) {
 	// Tag and push all tags
 	for _, tag := range d.Tags {
 		if tag != buildImageTag {
-			f.WriteCmd(fmt.Sprintf("docker tag %s:%s %s:%s", d.ImageName, buildImageTag, d.ImageName, tag))
+			var options string
+			if d.ForceTags {
+				options = "-f"
+			}
+			f.WriteCmd(fmt.Sprintf("docker tag %s %s:%s %s:%s", options, d.ImageName, buildImageTag, d.ImageName, tag))
 		}
 
 		f.WriteCmd(fmt.Sprintf("docker push %s:%s", d.ImageName, tag))

--- a/plugin/publish/docker_test.go
+++ b/plugin/publish/docker_test.go
@@ -214,7 +214,7 @@ func TestTagsNoSingle(t *testing.T) {
 	if !strings.Contains(response, "docker build --pull -t username/image:release-0.2") {
 		t.Fatalf("Response: " + response + " isn't tagging images using our first custom tag\n\n")
 	}
-	if !strings.Contains(response, "docker tag username/image:release-0.2 username/image:release-latest") {
+	if !strings.Contains(response, "docker tag  username/image:release-0.2 username/image:release-latest") {
 		t.Fatalf("Response: " + response + " isn't tagging images using our second custom tag\n\n")
 	}
 	if !strings.Contains(response, "docker push username/image:release-0.2") {
@@ -256,10 +256,10 @@ func TestTagsWithSingle(t *testing.T) {
 	if !strings.Contains(response, "docker build --pull -t username/image:release-0.3") {
 		t.Fatalf("Response: " + response + " isn't tagging images using our first custom tag\n\n")
 	}
-	if !strings.Contains(response, "docker tag username/image:release-0.3 username/image:release-0.2") {
+	if !strings.Contains(response, "docker tag  username/image:release-0.3 username/image:release-0.2") {
 		t.Fatalf("Response: " + response + " isn't tagging images using our second custom tag\n\n")
 	}
-	if !strings.Contains(response, "docker tag username/image:release-0.3 username/image:release-latest") {
+	if !strings.Contains(response, "docker tag  username/image:release-0.3 username/image:release-latest") {
 		t.Fatalf("Response: " + response + " isn't tagging images using our third custom tag\n\n")
 	}
 	if !strings.Contains(response, "docker push username/image:release-0.2") {


### PR DESCRIPTION
From docker 1.4 requires to pass a param to be able to retag images. This https://github.com/drone/drone/pull/782 doesn't really solve fully the problem.

We always push to the docker hub the latest image with the branch tag, so we can always pull the latest successful image of a given branch from the repo easily, `docker pull repo/image:master` instead of using the git hash

We have something like this in the `.drone.yml`

```
publish:
    docker:
  ...
        tags: [$(echo $DRONE_BRANCH), $(git rev-parse --short HEAD)]
        force_tags: true
```