### PR TITLE
Change repo to be private when GHE is private mode.

### DIFF
--- a/plugin/remote/github/github.go
+++ b/plugin/remote/github/github.go
@@ -169,6 +169,7 @@ func (r *GitHub) GetRepos(user *model.User) ([]*model.Repo, error) {
 
 		if r.Private || repo.Private {
 			repo.CloneURL = *item.SSHURL
+			repo.Private = true
 		}
 
 		// if no permissions we should skip the repository


### PR DESCRIPTION
When the case of sending pull-request to repository on private-mode Github:enterprise,
build of `origin` fails because it can't checkount repository.  
(build of `forked` repository will success)

It is because of [builder writes private-key when repository is private](https://github.com/drone/drone/blob/master/server/worker/docker/docker.go#L155),
however, private-mode ghe's repository is not flagged as private,
so builder doesn't write private-key.