### PR TITLE
be capable to use `docker-machine` with `drone build`

### DIFF
--- a/cli/build.go
+++ b/cli/build.go
@@ -42,19 +42,28 @@ func NewBuildCommand() cli.Command {
 				Usage: "runs drone build with publishing enabled",
 			},
 			cli.StringFlag{
-				Name:  "docker-host",
+				Name:  "docker-host, H",
 				Value: getHost(),
 				Usage: "docker daemon address",
 			},
 			cli.StringFlag{
-				Name:  "docker-cert",
+				Name:  "docker-cert, tlscert",
 				Value: getCert(),
 				Usage: "docker daemon tls certificate",
 			},
 			cli.StringFlag{
-				Name:  "docker-key",
+				Name:  "docker-key, tlskey",
 				Value: getKey(),
 				Usage: "docker daemon tls key",
+			},
+			cli.BoolFlag{
+				Name:  "tls",
+				Usage: "runs drone build with docker arguments using tls",
+			},
+			cli.StringFlag{
+				Name:  "tlscacert",
+				Value: "",
+				Usage: "trusted docker daemon that signed by CA given here",
 			},
 		},
 		Action: func(c *cli.Context) {


### PR DESCRIPTION
## Scenario

Specify docker daemon arguments for command `drone build` with [docker machine](https://github.com/docker/machine) command `docker-machine config`. so that it keeps arguments of `drone build` consistent with those in docker.

## Today

```shell
$ docker-machine env
export DOCKER_TLS_VERIFY=yes
export DOCKER_CERT_PATH=/Users/shawnzhu/.docker/machines/.client
export DOCKER_HOST=tcp://192.168.99.100:2376
```
Then:
```shell
$ drone build --docker-host --docker-cert --docker-key
```

## Expect

    $ drone build $(docker-machine config)

## Impact

it will hide the docker details when using drone build with boot2docker via docker machine, especially on OSX. the workflow would be as simple as:

```shell
$ brew install docker
$ docker-machine create -d virtualbox boot2docker-vm
$ drone build $(docker-machine config)  # assume you've got drone compiled and installed on OSX
```

it works for me very well on OSX since boot2docker VM will take care of shared directory.