### PR TITLE
Try to extract static files to workdir on start from rice box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ cli/cli
 client/client
 server/server
 packaging/root/usr/local
+assets


### PR DESCRIPTION
Extract static files from rice box, to `$(pwd)/assets` on drone start. To provide send static files from nginx