### PR TITLE
Make bundled assets overridable

### DIFF
--- a/packaging/root/etc/drone/drone.toml
+++ b/packaging/root/etc/drone/drone.toml
@@ -9,6 +9,12 @@ port=":80"
 # key=""
 # cert=""
 
+#####################################################################
+# Assets configuration
+#
+# [server.assets]
+# folder=""
+
 # [session]
 # secret=""
 # expires=""


### PR DESCRIPTION
This adds a `server-assets-folder` configuration option which allows overriding the assets bundled to the binary.

This makes iterations on the UI easier and files can be updated without rebuilding and restarting droned.