### PR TITLE
Use 'which' (if present) to check socat anywhere in path #869.

### DIFF
--- a/shared/build/proxy/proxy.go
+++ b/shared/build/proxy/proxy.go
@@ -17,7 +17,7 @@ set +e
 // this command string will check if the socat utility
 // exists, and if it does, will proxy connections to
 // the external IP address.
-const command = "[ -x /usr/bin/socat ] && socat TCP-LISTEN:%s,fork TCP:%s:%s &\n"
+const command = "[ -x /usr/bin/which ] && which socat >/dev/null && socat TCP-LISTEN:%s,fork TCP:%s:%s &\n"
 
 // alternative command that acts as a "polyfill" for socat
 // in the event that it isn't installed on the server

--- a/shared/build/proxy/proxy.go
+++ b/shared/build/proxy/proxy.go
@@ -17,7 +17,7 @@ set +e
 // this command string will check if the socat utility
 // exists, and if it does, will proxy connections to
 // the external IP address.
-const command = "[ -x /usr/bin/which ] && which socat >/dev/null && socat TCP-LISTEN:%s,fork TCP:%s:%s &\n"
+const command = "command -v socat >/dev/null && socat TCP-LISTEN:%s,fork TCP:%s:%s &\n"
 
 // alternative command that acts as a "polyfill" for socat
 // in the event that it isn't installed on the server

--- a/shared/build/proxy/proxy_test.go
+++ b/shared/build/proxy/proxy_test.go
@@ -12,7 +12,7 @@ func TestProxy(t *testing.T) {
 	p.Set("8080", "172.1.4.5")
 	b := p.Bytes()
 
-	expected := header + "[ -x /usr/bin/socat ] && socat TCP-LISTEN:8080,fork TCP:172.1.4.5:8080 &\n"
+	expected := header + "[ -x /usr/bin/which ] && which socat >/dev/null && socat TCP-LISTEN:8080,fork TCP:172.1.4.5:8080 &\n"
 	if string(b) != expected {
 		t.Errorf("Invalid proxy got:\n%s\nwant:\n%s", string(b), expected)
 	}

--- a/shared/build/proxy/proxy_test.go
+++ b/shared/build/proxy/proxy_test.go
@@ -12,7 +12,7 @@ func TestProxy(t *testing.T) {
 	p.Set("8080", "172.1.4.5")
 	b := p.Bytes()
 
-	expected := header + "[ -x /usr/bin/which ] && which socat >/dev/null && socat TCP-LISTEN:8080,fork TCP:172.1.4.5:8080 &\n"
+	expected := header + "command -v socat >/dev/null && socat TCP-LISTEN:8080,fork TCP:172.1.4.5:8080 &\n"
 	if string(b) != expected {
 		t.Errorf("Invalid proxy got:\n%s\nwant:\n%s", string(b), expected)
 	}


### PR DESCRIPTION
When using a base image that is not the provided ones (some custom container), the socat utility
could have been installed on a diferent place than /usr/bin. For instance, yum on CentOS installs
socat on /usr/local/bin.

This commit just rely ou 'which' (when present) to check if socat exists anywhere on the path.
Also, if socat is installed anywhere by /usr/bin before this, the access to services failed
silently.