### PR TITLE
Sync logging should use repo.Owner not user.Login

### DIFF
--- a/server/sync/sync.go
+++ b/server/sync/sync.go
@@ -43,7 +43,7 @@ func SyncUser(ctx context.Context, user *model.User, remote remote.Remote) {
 			continue
 		}
 
-		log.Println("Successfully syced repo.", user.Login+"/"+repo.Name)
+		log.Printf("Successfully syced repo. %s/%s\n", repo.Owner, repo.Name)
 	}
 
 	user.Synced = time.Now().UTC().Unix()


### PR DESCRIPTION
Was pretty confused when I ran across this the first time, fixes the logging up for sync'd repos.