### PR TITLE
Vagrant kick over to Dockerfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,5 @@
+Vagrant.configure("2") do |config|
+  config.vm.provider "docker" do |d|
+    d.build_dir = "."
+  end
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,3 +1,6 @@
+# boilerplate config from:
+# http://docs.vagrantup.com/v2/docker/basics.html
+
 Vagrant.configure("2") do |config|
   config.vm.provider "docker" do |d|
     d.build_dir = "."


### PR DESCRIPTION
Hey Guys,

I saw the discussion around issue 915 and although removing
Vagrant makes sense if no-one is looking after it I thought
I would suggest an alternative.

The associated change will allow vagrant based toolsets to 
continue to run drone, only with some extra dependencies:
* Docker
* vagrant docker provider (std since v1.6 - Apr 2014)

The change itself is boiler plate. grabbed directly from the 
Vagrant docker provider documentation:
http://docs.vagrantup.com/v2/docker/basics.html

Obviously it's up to you, but this change will potentially
break less ppl