### PR TITLE
Supports "to default" ANSII styles

### DIFF
--- a/server/app/scripts/line_formatter.js
+++ b/server/app/scripts/line_formatter.js
@@ -29,6 +29,8 @@ if(typeof(Drone) === 'undefined') { Drone = {}; }
 				switch (code) {
 					case 'm':
 					case '0m':
+					case '39m':
+					case '49m':
 						var len = this.styles.length;
 						for (var i=0; i < len; i++) {
 							this.styles.pop();


### PR DESCRIPTION
This PR supports to two `39m` and `49m` [1] ANSII codes that reset the foreground and background colors.

It simply reset the current styles; this can be improved in the future by managing explicitly foreground and background colors.

[1] http://pueblo.sourceforge.net/doc/manual/ansi_color_codes.html