### PR TITLE
If email is unspecified, pass in -e ' ' to avoid having registry URL interpreted as email, which will fail cryptically.

### DIFF
--- a/plugin/publish/docker.go
+++ b/plugin/publish/docker.go
@@ -94,8 +94,14 @@ func (d *Docker) Write(f *buildfile.Buildfile) {
 
 	// Login?
 	if d.RegistryLogin == true {
+		// If email is unspecified, pass in -e ' ' to avoid having
+		// registry URL interpreted as email, which will fail cryptically.
+		emailOpt := "' '"
+		if d.Email != "" {
+			emailOpt = d.Email
+		}
 		f.WriteCmdSilent(fmt.Sprintf("docker login -u %s -p %s -e %s %s",
-			d.Username, d.Password, d.Email, d.RegistryLoginUrl))
+			d.Username, d.Password, emailOpt, d.RegistryLoginUrl))
 	}
 
 	// Tag and push all tags


### PR DESCRIPTION
If publish.docker.email is unspecified, special-case this to pass in -e ' '.

This avoids having the line end up as 'docker login -u foo -p bar -e someregistry', which is interpreted as 'log in user foo with pass bar and email someregistry to https://index.docker.io/v1/' (c.f. 'docker help login').