### PR TITLE
Add sequencing logic into the InsertBuild and test

### DIFF
--- a/datastore/bolt/build_test.go
+++ b/datastore/bolt/build_test.go
@@ -1,1 +1,46 @@
 package bolt
+
+import (
+	"os"
+	"testing"
+
+	"github.com/drone/drone/common"
+	. "github.com/franela/goblin"
+)
+
+func TestBuild(t *testing.T) {
+	g := Goblin(t)
+	g.Describe("Build", func() {
+		var db *DB // temporary database
+		repo := string("github.com/octopod/hq")
+
+		// create a new database before each unit
+		// test and destroy afterwards.
+		g.BeforeEach(func() {
+			db = Must("/tmp/drone.test.db")
+		})
+		g.AfterEach(func() {
+			os.Remove(db.Path())
+		})
+
+		g.It("Should sequence builds", func() {
+			err := db.InsertBuild(repo, &common.Build{State: "pending"})
+			g.Assert(err).Equal(nil)
+
+			// the first build should always be numero 1
+			build, err := db.GetBuild(repo, 1)
+			g.Assert(err).Equal(nil)
+			g.Assert(build.State).Equal("pending")
+
+			// add another build, just for fun
+			err = db.InsertBuild(repo, &common.Build{State: "success"})
+			g.Assert(err).Equal(nil)
+
+			// get the next build
+			build, err = db.GetBuild(repo, 2)
+			g.Assert(err).Equal(nil)
+			g.Assert(build.State).Equal("success")
+		})
+
+	})
+}


### PR DESCRIPTION
Appreciate review and comments on this effort.

I think it is worth considering a slight refactor of the [utility functions](https://github.com/drone/drone/blob/bolt/datastore/bolt/util.go) to take a `*bolt.Tx` -- a `nil` would indicate that they should create the `bolt.Tx`.

Either this, or BoltDB supporting nested transactions (AFAICT it does not) would simplify these changes, and allow them leverage the `insert` function. I think this signature would work: 

```go
func insert(db *DB, t *bolt.Tx, bucket, key []byte, v interface{}) error {
}
```

As an aside, is there a reason the `get`, `raw`, `update`, `insert`, and `delete` functions should not be defined as methods on the DB type? I suppose this is a style question, but given they all operate on a `*DB`, it seems a natural fit.

Thanks!