### PR TITLE
Fix token problems at first login

### DIFF
--- a/plugin/remote/gitlab/gitlab.go
+++ b/plugin/remote/gitlab/gitlab.go
@@ -268,7 +268,8 @@ func (r *Gitlab) OpenRegistration() bool {
 
 func (r *Gitlab) GetToken(user *model.User) (*model.Token, error) {
 	expiry := time.Unix(user.TokenExpiry, 0)
-	if user.TokenExpiry == 0 || expiry.Sub(time.Now()) > (60*time.Second) {
+	if user.TokenExpiry == 0 && len(user.Access) != 0 ||
+		expiry.Sub(time.Now()) > (60*time.Second) {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Ignore Refresh token only if Expiry eq 0, and Access token exists