### PR TITLE
shared/build/images.go: add go1.4 tag

### DIFF
--- a/shared/build/images.go
+++ b/shared/build/images.go
@@ -198,6 +198,7 @@ var builders = map[string]*image{
 	"go1.1": {Tag: "bradrydzewski/go:1.1"},
 	"go1.2": {Tag: "bradrydzewski/go:1.2"},
 	"go1.3": {Tag: "bradrydzewski/go:1.3"},
+	"go1.4": {Tag: "bradrydzewski/go:1.4"},
 
 	// Haskell build images
 	"haskell":    {Tag: "bradrydzewski/haskell:7.4"},


### PR DESCRIPTION
Noticed there is a Go 1.4 image available on [Docker hub](https://registry.hub.docker.com/u/bradrydzewski/go/tags/manage/) but that image is not listed yet in `images.go`.