### PR TITLE
0.4.0 fix config panic

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ datasource="/var/lib/drone/drone.sqlite"
 cert = ""
 key = ""
 addr = "unix:///var/run/docker.sock"
-swarm = ""
+swarm = false
 
 [remote]
 kind = "github"

--- a/dist/drone/etc/drone/drone.toml
+++ b/dist/drone/etc/drone/drone.toml
@@ -15,7 +15,7 @@ datasource="/var/lib/drone/drone.sqlite"
 cert = ""
 key = ""
 addr = "unix:///var/run/docker.sock"
-swarm = ""
+# swarm = false
 
 # [remote]
 # kind = "github"


### PR DESCRIPTION
I got the following error when starting drone:
```shell
$ sudo drone --config="/etc/drone/drone.toml"
panic: toml: unmarshal: line 18: struct { Cert string "envconfig:\"optional\""; Key string "envconfig:\"optional\""; Addr string "envconfig:\"optional\""; Swarm bool "envconfig:\"optional\"" }.Swarm: `string' type is not assignable to `bool' type
```

Then I found the default configuration `swarm` under section `docker` is empty string instead of `true`.