### PR TITLE
Correct VolumesFrom definition

### DIFF
--- a/shared/build/docker/structs.go
+++ b/shared/build/docker/structs.go
@@ -133,7 +133,7 @@ type Config struct {
 	Dns             []string
 	Image           string // Name of the image as it was passed by the operator (eg. could be symbolic)
 	Volumes         map[string]struct{}
-	VolumesFrom     string
+	VolumesFrom     []string
 	WorkingDir      string
 	Entrypoint      []string
 	NetworkDisabled bool


### PR DESCRIPTION
Fixes #1068 .

`VolumesFrom` is `[]string` since v1.0.0.
https://github.com/docker/docker/blob/v1.0.0/runconfig/hostconfig.go#L32