### PR TITLE
change the way to get projectId

### DIFF
--- a/plugin/remote/gitlab/gitlab.go
+++ b/plugin/remote/gitlab/gitlab.go
@@ -156,8 +156,15 @@ func (r *Gitlab) GetRepos(user *model.User) ([]*model.Repo, error) {
 // repository and returns in string format.
 func (r *Gitlab) GetScript(user *model.User, repo *model.Repo, hook *model.Hook) ([]byte, error) {
 	var client = NewClient(r.url, user.Access, r.SkipVerify)
-	var path = ns(repo.Owner, repo.Name)
-	return client.RepoRawFile(path, hook.Sha, ".drone.yml")
+
+	projectId, err := client.SearchProjectId(repo.Owner, repo.Name)
+	if err != nil || projectId == 0 {
+		var emptyByte = make([]byte, 0)
+		return emptyByte, err
+	}
+	id := strconv.Itoa(projectId)
+
+	return client.RepoRawFile(id, hook.Sha, ".drone.yml")
 }
 
 // Activate activates a repository by adding a Post-commit hook and


### PR DESCRIPTION
When I use gitlab and drone, sometimes I cannot activate repository through drone.
I found that specification of repository failed in 'Activate' function.

I added new method below and modify this project.
https://github.com/Bugagazavr/go-gitlab-client/blob/master/projects.go


I really want to use GitLab and drone.