### PR TITLE
Force worker directory to use slash. Needed to use Drone on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ cli/cli
 client/client
 server/server
 packaging/root/usr/local
+.idea/
+*.iml

--- a/server/worker/docker/docker.go
+++ b/server/worker/docker/docker.go
@@ -118,7 +118,7 @@ func (d *Docker) Do(c context.Context, r *worker.Work) {
 		Commit:  r.Commit.Sha,
 		PR:      r.Commit.PullRequest,
 		Private: r.Repo.Private,
-		Dir:     filepath.Join("/var/cache/drone/src", git.GitPath(script.Git, path)),
+		Dir:     filepath.ToSlash(filepath.Join("/var/cache/drone/src", git.GitPath(script.Git, path))),
 		Depth:   git.GitDepth(script.Git),
 	}
 


### PR DESCRIPTION
I'm completely new to Go but really interested to contribute to the Drone project. I have a devenv on Windows and this modification permits to correctly setup the git clone remote path and have a fully working solution with boot2docker.