### PR TITLE
add proxy info to http.Transport

### DIFF
--- a/pkg/remote/builtin/github/helper.go
+++ b/pkg/remote/builtin/github/helper.go
@@ -25,6 +25,7 @@ func NewClient(uri, token string, skipVerify bool) *github.Client {
 	// self-signed certificates.
 	if skipVerify {
 		t.Transport = &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}
 	}


### PR DESCRIPTION
We want to use 0.4-database behind proxy, and skipVerify mode.

I added Proxy info to `&http.Transport`.