### PR TITLE
modified get project id

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -91,6 +91,7 @@ type Config struct {
 		SkipVerify bool     `envconfig:"optional"`
 		Open       bool     `envconfig:"optional"`
 		Orgs       []string `envconfig:"optional"`
+		Search     bool     `envconfig:"optional"`
 	}
 }
 

--- a/pkg/remote/builtin/gitlab/helper.go
+++ b/pkg/remote/builtin/gitlab/helper.go
@@ -3,6 +3,7 @@ package gitlab
 import (
 	"fmt"
 	"net/url"
+	"strconv"
 
 	"github.com/drone/drone/Godeps/_workspace/src/github.com/Bugagazavr/go-gitlab-client"
 )
@@ -81,4 +82,18 @@ func ns(owner, name string) string {
 
 func GetUserEmail(client *gogitlab.Gitlab, defaultURL string) (*gogitlab.Gitlab, error) {
 	return client, nil
+}
+
+func GetProjectId(r *Gitlab, client *gogitlab.Gitlab, owner, name string) (projectId string, err error) {
+	if r.Search {
+		_projectId, err := client.SearchProjectId(owner, name)
+		if err != nil || _projectId == 0 {
+			return "", err
+		}
+		projectId := strconv.Itoa(_projectId)
+		return projectId, nil
+	} else {
+		projectId := ns(owner, name)
+		return projectId, nil
+	}
 }


### PR DESCRIPTION
@Bugagazavr 

I use GitLab (v7.13.0) and drone 0.4-database branch on 28.07.2015.
(drone's https://github.com/drone/drone/commit/4ab17dd9d9ee0ffd13284ae3e09c44b3573e1b02)

I cannot get repository info below

```Go
id := ns(owner, name)

repo_, err := client.Project(path)
```

I modified using below.

https://github.com/Bugagazavr/go-gitlab-client/pull/9

please let me know your thought.