### PR TITLE
Tag push event support

### DIFF
--- a/plugin/remote/gitlab/gitlab.go
+++ b/plugin/remote/gitlab/gitlab.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"code.google.com/p/goauth2/oauth"
-	"github.com/Bugagazavr/go-gitlab-client"
+	"github.com/depay/go-gitlab-client"
 	"github.com/drone/drone/shared/httputil"
 	"github.com/drone/drone/shared/model"
 )
@@ -184,7 +184,7 @@ func (r *Gitlab) Activate(user *model.User, repo *model.Repo, link string) error
 	link += "?owner=" + repo.Owner + "&name=" + repo.Name
 
 	// add the hook
-	return client.AddProjectHook(path, link, true, false, true)
+	return client.AddProjectHook(path, link, true, false, true, true)
 }
 
 // Deactivate removes a repository by removing all the post-commit hooks
@@ -233,39 +233,41 @@ func (r *Gitlab) ParseHook(req *http.Request) (*model.Hook, error) {
 		return nil, err
 	}
 
-	if len(parsed.After) == 0 || parsed.TotalCommitsCount == 0 {
-		return nil, nil
-	}
-
 	if parsed.ObjectKind == "merge_request" {
 		// TODO (bradrydzewski) figure out how to handle merge requests
 		return nil, nil
 	}
 
-	if len(parsed.After) == 0 {
+	if parsed.ObjectKind == "tag_push" {
+		// TODO (Wei.ZHAO) figure out how to handle tag push evnets
 		return nil, nil
 	}
 
-	var hook = new(model.Hook)
-	hook.Owner = req.FormValue("owner")
-	hook.Repo = req.FormValue("name")
-	hook.Sha = parsed.After
-	hook.Branch = parsed.Branch()
+	if parsed.ObjectKind == "push" {
+		if len(parsed.After) == 0 || parsed.TotalCommitsCount == 0 {
+			return nil, nil
+		}
+		var hook = new(model.Hook)
+		hook.Owner = req.FormValue("owner")
+		hook.Repo = req.FormValue("name")
+		hook.Sha = parsed.After
+		hook.Branch = parsed.Branch()
 
-	var head = parsed.Head()
-	hook.Message = head.Message
-	hook.Timestamp = head.Timestamp
+		var head = parsed.Head()
+		hook.Message = head.Message
+		hook.Timestamp = head.Timestamp
 
-	// extracts the commit author (ideally email)
-	// from the post-commit hook
-	switch {
-	case head.Author != nil:
-		hook.Author = head.Author.Email
-	case head.Author == nil:
-		hook.Author = parsed.UserName
+		// extracts the commit author (ideally email)
+		// from the post-commit hook
+		switch {
+		case head.Author != nil:
+			hook.Author = head.Author.Email
+		case head.Author == nil:
+			hook.Author = parsed.UserName
+		}
+		return hook, nil
 	}
-
-	return hook, nil
+	return nil, nil
 }
 
 func (r *Gitlab) OpenRegistration() bool {

--- a/plugin/remote/gitlab/gitlab.go
+++ b/plugin/remote/gitlab/gitlab.go
@@ -240,7 +240,19 @@ func (r *Gitlab) ParseHook(req *http.Request) (*model.Hook, error) {
 
 	if parsed.ObjectKind == "tag_push" {
 		// TODO (Wei.ZHAO) figure out how to handle tag push evnets
-		return nil, nil
+		// SHA="0000..0" means removing a tag
+		// using both '0' & ' ' to avoid probable existence of space
+		if strings.Trim(parsed.After, "0 ") == "" {
+			return nil, nil
+		}
+		var hook = new(model.Hook)
+		hook.Tag = parsed.Tag()
+		hook.Owner = req.FormValue("owner")
+		hook.Repo = req.FormValue("name")
+		hook.Sha = parsed.After
+		hook.Branch = "tags"
+		hook.Author = parsed.UserName
+		return hook, nil
 	}
 
 	if parsed.ObjectKind == "push" {

--- a/plugin/remote/gitlab/helper.go
+++ b/plugin/remote/gitlab/helper.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 
 	"code.google.com/p/goauth2/oauth"
-	"github.com/Bugagazavr/go-gitlab-client"
+	"github.com/depay/go-gitlab-client"
 	"github.com/gorilla/securecookie"
 )
 

--- a/server/app/views/repo_edit.html
+++ b/server/app/views/repo_edit.html
@@ -29,6 +29,12 @@
 						<span>Enable Pull Request Hooks</span>
 					</div>
 
+					<div class="toggle">
+						<input type="checkbox" ng-model="repo.tag_push" id="tag_push" />
+						<label for="tag_push"></label>
+						<span>Enable Tag Push Hooks</span>
+					</div>
+
 					<div class="toggle" ng-if="user.admin == true">
 						<input type="checkbox" ng-model="repo.privileged" id="privileged" />
 						<label for="privileged"></label>

--- a/server/datastore/migrate/migrate.go
+++ b/server/datastore/migrate/migrate.go
@@ -106,6 +106,7 @@ CREATE TABLE IF NOT EXISTS repos (
 	,repo_privileged   BOOLEAN
 	,repo_post_commit  BOOLEAN
 	,repo_pull_request BOOLEAN
+	,repo_tag          BOOLEAN
 	,repo_public_key   BLOB
 	,repo_private_key  BLOB
 	,repo_params       BLOB
@@ -135,6 +136,7 @@ CREATE TABLE IF NOT EXISTS commits (
 	,commit_sha        VARCHAR(255)
 	,commit_branch     VARCHAR(255)
 	,commit_pr         VARCHAR(255)
+	,commit_tag        VARCHAR(255)
 	,commit_author     VARCHAR(255)
 	,commit_gravatar   VARCHAR(255)
 	,commit_timestamp  VARCHAR(255)

--- a/server/handler/hook.go
+++ b/server/handler/hook.go
@@ -64,8 +64,9 @@ func PostHook(c web.C, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if repo.Active == false ||
-		(repo.PostCommit == false && len(hook.PullRequest) == 0) ||
-		(repo.PullRequest == false && len(hook.PullRequest) != 0) {
+		(len(hook.PullRequest) != 0 && repo.PullRequest == false) ||
+		(len(hook.Tag) != 0 && repo.Tag == false) ||
+		repo.PostCommit == false {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
@@ -102,7 +103,7 @@ func PostHook(c web.C, w http.ResponseWriter, r *http.Request) {
 	// branches (unless it is a pull request). Note that we don't really
 	// care if parsing the yaml fails here.
 	s, _ := script.ParseBuild(string(yml))
-	if len(hook.PullRequest) == 0 && !s.MatchBranch(hook.Branch) {
+	if len(hook.Tag) == 0 && !s.MatchBranch(hook.Branch) {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
@@ -113,6 +114,7 @@ func PostHook(c web.C, w http.ResponseWriter, r *http.Request) {
 		Sha:         hook.Sha,
 		Branch:      hook.Branch,
 		PullRequest: hook.PullRequest,
+		Tag:         hook.Tag,
 		Timestamp:   hook.Timestamp,
 		Message:     hook.Message,
 		Config:      string(yml),

--- a/server/handler/repo.go
+++ b/server/handler/repo.go
@@ -126,6 +126,7 @@ func PostRepo(c web.C, w http.ResponseWriter, r *http.Request) {
 	repo.Active = true
 	repo.PullRequest = true
 	repo.PostCommit = true
+	repo.Tag = true
 	repo.UserID = user.ID
 	repo.Timeout = 3600 // default to 1 hour
 

--- a/server/handler/repo.go
+++ b/server/handler/repo.go
@@ -103,6 +103,7 @@ func DeactivateRepo(c web.C, w http.ResponseWriter, r *http.Request) {
 	repo.Active = false
 	repo.PullRequest = false
 	repo.PostCommit = false
+	repo.Tag = false
 	repo.UserID = 0
 
 	if err := datastore.PutRepo(ctx, repo); err != nil {
@@ -196,6 +197,7 @@ func PutRepo(c web.C, w http.ResponseWriter, r *http.Request) {
 	in := struct {
 		PostCommit  *bool   `json:"post_commits"`
 		PullRequest *bool   `json:"pull_requests"`
+		Tag_push    *bool   `json:"tag_push"`
 		Privileged  *bool   `json:"privileged"`
 		Params      *string `json:"params"`
 		Timeout     *int64  `json:"timeout"`
@@ -219,6 +221,9 @@ func PutRepo(c web.C, w http.ResponseWriter, r *http.Request) {
 	}
 	if in.PullRequest != nil {
 		repo.PullRequest = *in.PullRequest
+	}
+	if in.Tag_push != nil {
+		repo.Tag = *in.Tag_push
 	}
 	if in.Privileged != nil && user.Admin {
 		repo.Privileged = *in.Privileged

--- a/server/worker/docker/docker.go
+++ b/server/worker/docker/docker.go
@@ -117,6 +117,7 @@ func (d *Docker) Do(c context.Context, r *worker.Work) {
 		Branch:  r.Commit.Branch,
 		Commit:  r.Commit.Sha,
 		PR:      r.Commit.PullRequest,
+		Tag:     r.Commit.Tag,
 		Private: r.Repo.Private,
 		Dir:     filepath.ToSlash(filepath.Join("/var/cache/drone/src", git.GitPath(script.Git, path))),
 		Depth:   git.GitDepth(script.Git),

--- a/shared/build/repo/repo.go
+++ b/shared/build/repo/repo.go
@@ -123,7 +123,7 @@ func (r *Repo) Commands() []string {
 		cmds = append(cmds, fmt.Sprintf("git checkout -qf -b pr/%s origin/pr/%s", r.PR, r.PR))
 	} else {
 		if len(r.Tag) > 0 {
-			cmds = append(cmds, fmt.Sprintf("git clone --depth=%d --recursive %s %s", r.Depth, r.Path, r.Dir))
+			cmds = append(cmds, fmt.Sprintf("git clone --recursive %s %s", r.Path, r.Dir))
 			cmds = append(cmds, fmt.Sprintf("git checkout -qf -b tags/%s %s", r.Tag, r.Tag))
 		} else {
 			// Otherwise just clone the branch.

--- a/shared/build/repo/repo.go
+++ b/shared/build/repo/repo.go
@@ -33,6 +33,10 @@ type Repo struct {
 	// checkout when the Repository is cloned.
 	PR string
 
+	// (optional) Tag that we should checkout when the
+	// Repository is cloned.
+	Tag string
+
 	// Private specifies if a git repo is private or not
 	Private bool
 
@@ -118,11 +122,16 @@ func (r *Repo) Commands() []string {
 		cmds = append(cmds, fmt.Sprintf("git fetch origin +refs/pull/%s/head:refs/remotes/origin/pr/%s", r.PR, r.PR))
 		cmds = append(cmds, fmt.Sprintf("git checkout -qf -b pr/%s origin/pr/%s", r.PR, r.PR))
 	} else {
-		// Otherwise just clone the branch.
-		cmds = append(cmds, fmt.Sprintf("git clone --depth=%d --recursive --branch=%s %s %s", r.Depth, branch, r.Path, r.Dir))
-		// If a specific commit is provided then we'll need to check it out.
-		if len(r.Commit) > 0 {
-			cmds = append(cmds, fmt.Sprintf("git checkout -qf %s", r.Commit))
+		if len(r.Tag) > 0 {
+			cmds = append(cmds, fmt.Sprintf("git clone --depth=%d --recursive %s %s", r.Depth, r.Path, r.Dir))
+			cmds = append(cmds, fmt.Sprintf("git checkout -qf -b tags/%s %s", r.Tag, r.Tag))
+		} else {
+			// Otherwise just clone the branch.
+			cmds = append(cmds, fmt.Sprintf("git clone --depth=%d --recursive --branch=%s %s %s", r.Depth, branch, r.Path, r.Dir))
+			// If a specific commit is provided then we'll need to check it out.
+			if len(r.Commit) > 0 {
+				cmds = append(cmds, fmt.Sprintf("git checkout -qf %s", r.Commit))
+			}
 		}
 	}
 

--- a/shared/model/commit.go
+++ b/shared/model/commit.go
@@ -14,6 +14,7 @@ type Commit struct {
 	Sha         string `meddler:"commit_sha"       json:"sha"`
 	Branch      string `meddler:"commit_branch"    json:"branch"`
 	PullRequest string `meddler:"commit_pr"        json:"pull_request"`
+	Tag         string `meddler:"commit_tag"       json:"tag"`
 	Author      string `meddler:"commit_author"    json:"author"`
 	Gravatar    string `meddler:"commit_gravatar"  json:"gravatar"`
 	Timestamp   string `meddler:"commit_timestamp" json:"timestamp"`

--- a/shared/model/hook.go
+++ b/shared/model/hook.go
@@ -7,6 +7,7 @@ type Hook struct {
 	Repo        string
 	Sha         string
 	Branch      string
+	Tag         string
 	PullRequest string
 	Author      string
 	Gravatar    string

--- a/shared/model/repo.go
+++ b/shared/model/repo.go
@@ -34,6 +34,7 @@ type Repo struct {
 	Privileged  bool   `meddler:"repo_privileged"   json:"privileged"`
 	PostCommit  bool   `meddler:"repo_post_commit"  json:"post_commits"`
 	PullRequest bool   `meddler:"repo_pull_request" json:"pull_requests"`
+	Tag         bool   `meddler:"repo_tag"          json:"tags"`
 	PublicKey   string `meddler:"repo_public_key"   json:"-"`
 	PrivateKey  string `meddler:"repo_private_key"  json:"-"`
 	Params      string `meddler:"repo_params"       json:"-"`
@@ -55,6 +56,7 @@ func NewRepo(remote, owner, name string) (*Repo, error) {
 	repo.Active = false
 	repo.PostCommit = true
 	repo.PullRequest = true
+	repo.Tag = true
 	repo.Timeout = DefaultTimeout
 	return &repo, nil
 }

--- a/shared/model/repo.go
+++ b/shared/model/repo.go
@@ -34,7 +34,7 @@ type Repo struct {
 	Privileged  bool   `meddler:"repo_privileged"   json:"privileged"`
 	PostCommit  bool   `meddler:"repo_post_commit"  json:"post_commits"`
 	PullRequest bool   `meddler:"repo_pull_request" json:"pull_requests"`
-	Tag         bool   `meddler:"repo_tag"          json:"tags"`
+	Tag         bool   `meddler:"repo_tag"          json:"tag_push"`
 	PublicKey   string `meddler:"repo_public_key"   json:"-"`
 	PrivateKey  string `meddler:"repo_private_key"  json:"-"`
 	Params      string `meddler:"repo_params"       json:"-"`


### PR DESCRIPTION
User may wanna do some specific operations on tag_push event, e.g. build new released images. Drone should accept tag_push event hook. This PR support tag_push event, currently just for gitlab.

Changing the go-gitlab-client to my fork branch to support that hook type, util upstream merges that PR for go-gitlab-client.

User can easily enable/disable that hook on web UI.