### PR TITLE
Probe for push tag events

### DIFF
--- a/plugin/remote/gitlab/gitlab.go
+++ b/plugin/remote/gitlab/gitlab.go
@@ -184,7 +184,7 @@ func (r *Gitlab) Activate(user *model.User, repo *model.Repo, link string) error
 	link += "?owner=" + repo.Owner + "&name=" + repo.Name
 
 	// add the hook
-	return client.AddProjectHook(path, link, true, false, true)
+	return client.AddProjectHook(path, link, true, false, true, false)
 }
 
 // Deactivate removes a repository by removing all the post-commit hooks


### PR DESCRIPTION
In `0.4` we implement this, keep `0.3` working with new client changes