### PR TITLE
remove `url_.Path` for relative_path gitlab

### DIFF
--- a/pkg/remote/builtin/gitlab/gitlab.go
+++ b/pkg/remote/builtin/gitlab/gitlab.go
@@ -44,7 +44,6 @@ func NewDriver(config string) (remote.Remote, error) {
 		return nil, err
 	}
 	params := url_.Query()
-	url_.Path = ""
 	url_.RawQuery = ""
 
 	gitlab := Gitlab{}


### PR DESCRIPTION
there is a necessary to remove url._Path for gitlab using relative_path.