### PR TITLE
S3 plugin: check dependencies (and improve output)

### DIFF
--- a/plugin/publish/s3.go
+++ b/plugin/publish/s3.go
@@ -65,12 +65,12 @@ func (s *S3) Write(f *buildfile.Buildfile) {
 
 	// check dependencies
 	f.WriteCmdSilent("echo '+ checking dependencies (the build will die if something critical is missing)'")
-	f.WriteCmdSilent("export AWSCLI_SIGNATURE=$(echo $(awscli -V 2> /dev/null))")
+	f.WriteCmdSilent("export AWSCLI_SIGNATURE=$(echo $(awscli --version 2> /dev/null))")
 	f.WriteCmdSilent("export PIP_SIGNATURE=$(echo $(pip -V 2> /dev/null))")
 	f.WriteCmdSilent(`if [ "$AWSCLI_SIGNATURE" == "" ]; then echo "++ awscli: not present"; else echo "++ awscli: present"; fi`)
 
 	f.WriteCmdSilent(`if [ "$AWSCLI_SIGNATURE" == "" -a "$PIP_SIGNATURE" != "" ]; then echo "++ pip: present. $PIP_SIGNATURE"; fi`)
-	f.WriteCmdSilent(`if [ "$AWSCLI_SIGNATURE" == "" -a "$PIP_SIGNATURE" == "" ]; then echo "++ pip: not present. Failing"; exit 1; fi`)
+	f.WriteCmdSilent(`if [ "$AWSCLI_SIGNATURE" == "" -a "$PIP_SIGNATURE" == "" ]; then echo "++ pip: not present. Pip must be available in the container. Failing"; exit 1; fi`)
 
 	// install the AWS cli using PIP
 	f.WriteCmdSilent(`if [ "$AWSCLI_SIGNATURE" == "" ]; then [ -f /usr/bin/sudo ] || pip install awscli 1> /dev/null 2> /dev/null; fi`)


### PR DESCRIPTION
as @tj pointed out in #412, the lack of logs drives to some annoying build errors. So this PR tries to improve the output of the plugin by checking if `pip` is present.

Also, it checks if the `awscli` package is already available in the container in order to avoid the installation step and use a docker image as small as possible.

Notice that it doesn't use `which`, therefore it doesn't add more dependencies to the container.