### PR TITLE
Adding support for setting the workspace directly in the config

### DIFF
--- a/cmd/drone-build/main.go
+++ b/cmd/drone-build/main.go
@@ -37,7 +37,6 @@ func main() {
 		os.Exit(1)
 		return
 	}
-	createClone(ctx)
 
 	// creates the Docker client, connecting to the
 	// linked Docker daemon
@@ -68,7 +67,8 @@ func main() {
 		os.Exit(1)
 		return
 	}
-
+	createClone(ctx)
+	
 	var execs []execFunc
 	if *clone {
 		execs = append(execs, execClone)
@@ -135,7 +135,7 @@ func createClone(c *Context) error {
 	if err != nil {
 		return err
 	}
-	c.Clone.Dir = filepath.Join("/drone/src", url_.Host, c.Repo.FullName)
+	c.Clone.Dir, _ = c.Conf.Clone.Config["path"]
 	return nil
 }
 

--- a/cmd/drone-build/main.go
+++ b/cmd/drone-build/main.go
@@ -5,9 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"net/url"
 	"os"
-	"path/filepath"
 	"strings"
 
 	log "github.com/drone/drone/Godeps/_workspace/src/github.com/Sirupsen/logrus"
@@ -68,7 +66,7 @@ func main() {
 		return
 	}
 	createClone(ctx)
-	
+
 	var execs []execFunc
 	if *clone {
 		execs = append(execs, execClone)
@@ -130,13 +128,15 @@ func createClone(c *Context) error {
 	// to the clone object for merge requests from bitbucket, gitlab, et al
 	// if len(c.Commit.PullRequest) != 0 {
 	// }
-
-	url_, err := url.Parse(c.Repo.Link)
-	if err != nil {
-		return err
+	pathv, ok := c.Conf.Clone.Config["path"]
+	if ok {
+		path, ok := pathv.(string)
+		if ok {
+			c.Clone.Dir = path
+			return nil
+		}
 	}
-	c.Clone.Dir, _ = c.Conf.Clone.Config["path"]
-	return nil
+	return fmt.Errorf("Workspace path not found")
 }
 
 func parseContext() (*Context, error) {

--- a/cmd/drone-build/run.go
+++ b/cmd/drone-build/run.go
@@ -64,17 +64,6 @@ func setup(c *Context) error {
 		c.Conf.Build.Environment = append(c.Conf.Build.Environment, env)
 	}
 
-	// attempt to extract the clone path. i'm not a huge fan of
-	// this, by the way, but for now we'll keep it.
-	// TODO consider moving this to a transform?
-	pathv, ok := c.Conf.Clone.Config["path"]
-	if ok {
-		path, ok := pathv.(string)
-		if ok {
-			c.Clone.Dir = filepath.Join("/drone/src", path)
-		}
-	}
-
 	return nil
 }
 

--- a/cmd/drone-build/run.go
+++ b/cmd/drone-build/run.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"path/filepath"
-
 	"github.com/drone/drone/Godeps/_workspace/src/github.com/samalba/dockerclient"
 	common "github.com/drone/drone/pkg/types"
 	"github.com/drone/drone/pkg/yaml"

--- a/pkg/runner/builtin/runner.go
+++ b/pkg/runner/builtin/runner.go
@@ -2,14 +2,14 @@ package builtin
 
 import (
 	"bytes"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"time"
-	"crypto/tls"
-	"crypto/x509"
 
 	"github.com/drone/drone/Godeps/_workspace/src/github.com/samalba/dockerclient"
 	"github.com/drone/drone/pkg/docker"

--- a/pkg/yaml/lint_test.go
+++ b/pkg/yaml/lint_test.go
@@ -116,7 +116,7 @@ func Test_Linter(t *testing.T) {
 		g.It("Should pass with cache path inside workspace", func() {
 			c := &common.Config{
 				Build: &common.Step{
-					Cache: []string{".git","/.git","/.git/../.git/../.git"},
+					Cache: []string{".git", "/.git", "/.git/../.git/../.git"},
 				},
 			}
 			g.Assert(expectCacheInWorkspace(c) == nil).IsTrue()
@@ -125,7 +125,7 @@ func Test_Linter(t *testing.T) {
 		g.It("Should fail with cache path outside workspace", func() {
 			c := &common.Config{
 				Build: &common.Step{
-					Cache: []string{".git","/.git","../../.git"},
+					Cache: []string{".git", "/.git", "../../.git"},
 				},
 			}
 			g.Assert(expectCacheInWorkspace(c) != nil).IsTrue()
@@ -134,7 +134,7 @@ func Test_Linter(t *testing.T) {
 		g.It("Should fail when caching workspace directory", func() {
 			c := &common.Config{
 				Build: &common.Step{
-					Cache: []string{".git",".git/../"},
+					Cache: []string{".git", ".git/../"},
 				},
 			}
 			g.Assert(expectCacheInWorkspace(c) != nil).IsTrue()
@@ -143,7 +143,7 @@ func Test_Linter(t *testing.T) {
 		g.It("Should fail when : is in the cache path", func() {
 			c := &common.Config{
 				Build: &common.Step{
-					Cache: []string{".git",".git:/../"},
+					Cache: []string{".git", ".git:/../"},
 				},
 			}
 			g.Assert(expectCacheInWorkspace(c) != nil).IsTrue()

--- a/pkg/yaml/transform/transform.go
+++ b/pkg/yaml/transform/transform.go
@@ -71,7 +71,7 @@ func RemovePrivileged(c *common.Config) {
 // Repo executes all transformers that rely on repository
 // information.
 func Repo(c *common.Config, r *common.Repo) {
-  transformWorkspace(c, r)
+	transformWorkspace(c, r)
 	transformCache(c, r)
 }
 
@@ -227,7 +227,7 @@ func transformWorkspace(c *common.Config, r *common.Repo) {
 func transformCache(c *common.Config, r *common.Repo) {
 	cacheCount := len(c.Build.Cache)
 
-  if cacheCount == 0 {
+	if cacheCount == 0 {
 		return
 	}
 
@@ -287,7 +287,7 @@ func imageNameDefault(name, defaultName string) string {
 // workspaceRoot is a helper function that determines the
 // default workspace the build runs in.
 func workspaceRoot(r *common.Repo) string {
-  return filepath.Join(buildRoot, repoPath(r))
+	return filepath.Join(buildRoot, repoPath(r))
 }
 
 // cacheRoot is a helper function that deteremines the

--- a/pkg/yaml/transform/transform_test.go
+++ b/pkg/yaml/transform/transform_test.go
@@ -151,20 +151,20 @@ func Test_Transform(t *testing.T) {
 					Config: map[string]interface{}{},
 				},
 				Build: &common.Step{
-					Cache: []string{".git","foo","bar"},
+					Cache: []string{".git", "foo", "bar"},
 				},
 				Notify:  map[string]*common.Step{},
 				Deploy:  map[string]*common.Step{},
 				Publish: map[string]*common.Step{},
 			}
 			r := &common.Repo{
-				Link: "https://github.com/drone/drone",
+				Link:     "https://github.com/drone/drone",
 				FullName: "drone/drone",
 			}
 			transformWorkspace(c, r)
 			transformCache(c, r)
 
-      cacheCount := len(c.Build.Cache)
+			cacheCount := len(c.Build.Cache)
 
 			test := func(s *common.Step) {
 				g.Assert(len(s.Volumes)).Equal(cacheCount)
@@ -176,7 +176,7 @@ func Test_Transform(t *testing.T) {
 				}
 			}
 
-      test(c.Setup)
+			test(c.Setup)
 			test(c.Clone)
 			test(c.Build)
 			testRange(c.Publish)
@@ -192,7 +192,7 @@ func Test_Transform(t *testing.T) {
 				},
 			}
 			r := &common.Repo{
-				Link: "https://github.com/drone/drone",
+				Link:     "https://github.com/drone/drone",
 				FullName: "drone/drone",
 			}
 			transformWorkspace(c, r)
@@ -209,7 +209,7 @@ func Test_Transform(t *testing.T) {
 				},
 			}
 			r := &common.Repo{
-				Link: "https://github.com/drone/drone",
+				Link:     "https://github.com/drone/drone",
 				FullName: "drone/drone",
 			}
 			transformWorkspace(c, r)

--- a/pkg/yaml/transform/transform_test.go
+++ b/pkg/yaml/transform/transform_test.go
@@ -1,6 +1,7 @@
 package transform
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/drone/drone/Godeps/_workspace/src/github.com/franela/goblin"
@@ -146,7 +147,9 @@ func Test_Transform(t *testing.T) {
 		g.It("Should have cached volumes", func() {
 			c := &common.Config{
 				Setup: &common.Step{},
-				Clone: &common.Step{},
+				Clone: &common.Step{
+					Config: map[string]interface{}{},
+				},
 				Build: &common.Step{
 					Cache: []string{".git","foo","bar"},
 				},
@@ -158,6 +161,7 @@ func Test_Transform(t *testing.T) {
 				Link: "https://github.com/drone/drone",
 				FullName: "drone/drone",
 			}
+			transformWorkspace(c, r)
 			transformCache(c, r)
 
       cacheCount := len(c.Build.Cache)
@@ -179,6 +183,38 @@ func Test_Transform(t *testing.T) {
 			testRange(c.Deploy)
 			testRange(c.Notify)
 			testRange(c.Compose)
+		})
+
+		g.It("Should have default workspace directory", func() {
+			c := &common.Config{
+				Clone: &common.Step{
+					Config: map[string]interface{}{},
+				},
+			}
+			r := &common.Repo{
+				Link: "https://github.com/drone/drone",
+				FullName: "drone/drone",
+			}
+			transformWorkspace(c, r)
+
+			g.Assert(c.Clone.Config["path"]).Equal(workspaceRoot(r))
+		})
+
+		g.It("Should use path for working directory", func() {
+			c := &common.Config{
+				Clone: &common.Step{
+					Config: map[string]interface{}{
+						"path": "foo/bar",
+					},
+				},
+			}
+			r := &common.Repo{
+				Link: "https://github.com/drone/drone",
+				FullName: "drone/drone",
+			}
+			transformWorkspace(c, r)
+
+			g.Assert(c.Clone.Config["path"]).Equal(filepath.Join(buildRoot, "foo/bar"))
 		})
 	})
 }


### PR DESCRIPTION
Either defaults to a workspace or uses the value specified in the path value of the clone plugin.