### PR TITLE
Avoid warning about deprecated build paramaters within make.go

### DIFF
--- a/make.go
+++ b/make.go
@@ -87,7 +87,7 @@ func build() error {
 		{"github.com/drone/drone/cmd/drone-build", "bin/drone-build"},
 	}
 	for _, bin := range bins {
-		ldf := fmt.Sprintf("-X main.revision %s -X main.version %s", sha, version)
+		ldf := fmt.Sprintf("-X main.revision=%s -X main.version=%s", sha, version)
 		cmd := exec.Command("go", "build", "-o", bin.output, "-ldflags", ldf, bin.input)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr


### PR DESCRIPTION
Without this pull request you will get this output on `go run make.go build`

```
+ go build -o bin/drone -ldflags -X main.revision 27004bd -X main.version 0.4 github.com/drone/drone/cmd/drone-server
# github.com/drone/drone/cmd/drone-server
link: warning: option -X main.revision 27004bd may not work in future releases; use -X main.revision=27004bd
link: warning: option -X main.version 0.4 may not work in future releases; use -X main.version=0.4
+ go build -o bin/drone-agent -ldflags -X main.revision 27004bd -X main.version 0.4 github.com/drone/drone/cmd/drone-agent
# github.com/drone/drone/cmd/drone-agent
link: warning: option -X main.revision 27004bd may not work in future releases; use -X main.revision=27004bd
link: warning: option -X main.version 0.4 may not work in future releases; use -X main.version=0.4
+ go build -o bin/drone-build -ldflags -X main.revision 27004bd -X main.version 0.4 github.com/drone/drone/cmd/drone-build
# github.com/drone/drone/cmd/drone-build
link: warning: option -X main.revision 27004bd may not work in future releases; use -X main.revision=27004bd
link: warning: option -X main.version 0.4 may not work in future releases; use -X main.version=0.4
```