### PR TITLE
Fix: DRONE_SERVER_PORT isn't valid for drone 0.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.4.2
 
-ENV DRONE_SERVER_PORT :80
+ENV SERVER_ADDR :80
 WORKDIR $GOPATH/src/github.com/drone/drone
 
 EXPOSE 80


### PR DESCRIPTION
Signed-off-by: Chengwei Yang <yangchengwei@qiyi.com>