### PR TITLE
Added clone mode for gitlab, use token mode as default

### DIFF
--- a/doc/setup/gitlab.md
+++ b/doc/setup/gitlab.md
@@ -31,6 +31,7 @@ This section lists all connection options used in the connection string format. 
 * `open=false` allows users to self-register. Defaults to false for security reasons.
 * `orgs=drone,docker` restricts access to these GitLab organizations. **Optional**
 * `skip_verify=false` skip ca verification if self-signed certificate. Defaults to false for security reasons.
+* `clone_mode=token` a strategy for clone authorization, by default use repo token, but can be changed to `oauth` ( This is not secure, because your user token, with full access to your gitlab account will be written to .netrc, and it can be read by all who have access to project builds )
 
 ## Gitlab registration
 

--- a/pkg/hash/hash.go
+++ b/pkg/hash/hash.go
@@ -1,0 +1,12 @@
+package hash
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+func New(text, salt string) string {
+	hasher := sha256.New()
+	hasher.Write([]byte(text + salt))
+	return hex.EncodeToString(hasher.Sum(nil))
+}

--- a/pkg/remote/builtin/github/github.go
+++ b/pkg/remote/builtin/github/github.go
@@ -170,7 +170,7 @@ func (g *GitHub) Script(u *common.User, r *common.Repo, b *common.Build) ([]byte
 
 // Netrc returns a .netrc file that can be used to clone
 // private repositories from a remote system.
-func (g *GitHub) Netrc(u *common.User) (*common.Netrc, error) {
+func (g *GitHub) Netrc(u *common.User, r *common.Repo) (*common.Netrc, error) {
 	url_, err := url.Parse(g.URL)
 	if err != nil {
 		return nil, err

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -64,7 +64,7 @@ type Remote interface {
 
 	// Netrc returns a .netrc file that can be used to clone
 	// private repositories from a remote system.
-	Netrc(u *types.User) (*types.Netrc, error)
+	Netrc(u *types.User, r *types.Repo) (*types.Netrc, error)
 
 	// Activate activates a repository by creating the post-commit hook and
 	// adding the SSH deploy key, if applicable.

--- a/pkg/server/commits.go
+++ b/pkg/server/commits.go
@@ -166,7 +166,7 @@ func RunBuild(c *gin.Context) {
 		return
 	}
 
-	netrc, err := remote.Netrc(user)
+	netrc, err := remote.Netrc(user, repo)
 	if err != nil {
 		c.Fail(500, err)
 		return

--- a/pkg/server/gitlab.go
+++ b/pkg/server/gitlab.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 
 	"github.com/drone/drone/Godeps/_workspace/src/github.com/gin-gonic/gin"
+
+	"github.com/drone/drone/pkg/hash"
 )
 
 // RedirectSha accepts a request to retvie a redirect
@@ -78,7 +80,7 @@ func GetPullRequest(c *gin.Context) {
 	repo := ToRepo(c)
 
 	// get the token and verify the hook is authorized
-	if c.Request.FormValue("access_token") != hash(repo.FullName, repo.Hash) {
+	if c.Request.FormValue("access_token") != hash.New(repo.FullName, repo.Hash) {
 		c.AbortWithStatus(403)
 		return
 	}
@@ -117,7 +119,7 @@ func GetCommit(c *gin.Context) {
 	sha := c.Params.ByName("sha")
 
 	// get the token and verify the hook is authorized
-	if c.Request.FormValue("access_token") != hash(repo.FullName, repo.Hash) {
+	if c.Request.FormValue("access_token") != hash.New(repo.FullName, repo.Hash) {
 		c.AbortWithStatus(403)
 		return
 	}

--- a/pkg/server/hooks.go
+++ b/pkg/server/hooks.go
@@ -5,6 +5,7 @@ import (
 
 	log "github.com/drone/drone/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	"github.com/drone/drone/Godeps/_workspace/src/github.com/gin-gonic/gin"
+	"github.com/drone/drone/pkg/hash"
 	"github.com/drone/drone/pkg/queue"
 	common "github.com/drone/drone/pkg/types"
 	"github.com/drone/drone/pkg/yaml"
@@ -56,7 +57,7 @@ func PostHook(c *gin.Context) {
 	}
 
 	// get the token and verify the hook is authorized
-	if c.Request.FormValue("access_token") != hash(repo.FullName, repo.Hash) {
+	if c.Request.FormValue("access_token") != hash.New(repo.FullName, repo.Hash) {
 		log.Errorf("invalid token sent with hook.")
 		c.AbortWithStatus(403)
 		return
@@ -128,7 +129,7 @@ func PostHook(c *gin.Context) {
 		})
 	}
 
-	netrc, err := remote.Netrc(user)
+	netrc, err := remote.Netrc(user, repo)
 	if err != nil {
 		log.Errorf("failure to generate netrc for %s. %s", repo.FullName, err)
 		c.Fail(500, err)

--- a/pkg/server/repos.go
+++ b/pkg/server/repos.go
@@ -1,14 +1,13 @@
 package server
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
 	"github.com/drone/drone/Godeps/_workspace/src/github.com/gin-gonic/gin"
 	"github.com/drone/drone/Godeps/_workspace/src/github.com/gin-gonic/gin/binding"
 
+	"github.com/drone/drone/pkg/hash"
 	"github.com/drone/drone/pkg/remote"
 	common "github.com/drone/drone/pkg/types"
 	"github.com/drone/drone/pkg/utils/httputil"
@@ -209,7 +208,7 @@ func PostRepo(c *gin.Context) {
 	link := fmt.Sprintf(
 		"%s/api/hook?access_token=%s",
 		httputil.GetURL(c.Request),
-		hash(r.FullName, r.Hash),
+		hash.New(r.FullName, r.Hash),
 	)
 
 	// generate an RSA key and add to the repo
@@ -315,10 +314,4 @@ func perms(remote remote.Remote, u *common.User, r *common.Repo) *common.Perm {
 		return &common.Perm{}
 	}
 	return p
-}
-
-func hash(text, salt string) string {
-	hasher := sha256.New()
-	hasher.Write([]byte(text + salt))
-	return hex.EncodeToString(hasher.Sum(nil))
 }


### PR DESCRIPTION
- added clone_mode parameter for gitlab
- added strategies to generate `.netrc` file

I have move hash method to separate package, because it used in gitlab package too