### PR TITLE
Fix build errors due to changes in github.com/gogits/go-gogs-client

### DIFF
--- a/plugin/remote/gogs/gogs.go
+++ b/plugin/remote/gogs/gogs.go
@@ -164,7 +164,7 @@ func (r *Gogs) Deactivate(user *model.User, repo *model.Repo, link string) error
 func (r *Gogs) ParseHook(req *http.Request) (*model.Hook, error) {
 	defer req.Body.Close()
 	var payloadbytes, _ = ioutil.ReadAll(req.Body)
-	var payload, err = gogs.ParseHook(payloadbytes)
+	var payload, err = gogs.ParsePushHook(payloadbytes)
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +181,7 @@ func (r *Gogs) ParseHook(req *http.Request) (*model.Hook, error) {
 	return &model.Hook{
 		Owner:     payload.Repo.Owner.UserName,
 		Repo:      payload.Repo.Name,
-		Sha:       payload.Commits[0].Id,
+		Sha:       payload.Commits[0].ID,
 		Branch:    payload.Branch(),
 		Author:    payload.Commits[0].Author.UserName,
 		Timestamp: time.Now().UTC().String(),


### PR DESCRIPTION
Change names that were updated in upstream dependency github.com/gogits/go-gogs-client

Updates:
   * ParseHook -> ParsePushHook ([link](https://github.com/gogits/go-gogs-client/blob/master/repo_hooks.go#L185)),
   * PayloadCommit.Id->ID ([link](https://github.com/gogits/go-gogs-client/blob/master/repo_hooks.go#L88)).

Tested: `make deps` works after this change

Fixes #1185