### PR TITLE
Return 200 even if non-action webhook is come

### DIFF
--- a/server/handler/hook.go
+++ b/server/handler/hook.go
@@ -40,6 +40,11 @@ func PostHook(c web.C, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if hook == nil {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
 	// in some cases we have neither a hook nor error. An example
 	// would be GitHub sending a ping request to the URL, in which
 	// case we'll just exit quiely with an 'OK'


### PR DESCRIPTION
When Drone receives Github ping webhook, it returns 502 and webhook is failed because of reference to `nil` object. This should not be expected behavior I think.

In this PR I modified the code to return `200 OK` to make webhook success.

#### Error message

```
Sep 11 17:15:12 core-01 docker[1655]: 2015/09/11 08:15:12 http: panic serving 172.17.8.1:58845: runtime error: invalid memory address or nil pointer dereference
Sep 11 17:15:12 core-01 docker[1655]: goroutine 148 [running]:
Sep 11 17:15:12 core-01 docker[1655]: net/http.func·011()
Sep 11 17:15:12 core-01 docker[1655]: /usr/local/go/src/pkg/net/http/server.go:1100 +0xb7
Sep 11 17:15:12 core-01 docker[1655]: runtime.panic(0xb42de0, 0x11b98d3)
Sep 11 17:15:12 core-01 docker[1655]: /usr/local/go/src/pkg/runtime/panic.c:248 +0x18d
Sep 11 17:15:12 core-01 docker[1655]: github.com/drone/drone/server/handler.PostHook(0xc2089804b0, 0xc2089803f0, 0x7f850aec79f8, 0xc20872a1e0, 0xc2081c11e0)
Sep 11 17:15:12 core-01 docker[1655]: /var/cache/drone/src/github.com/drone/drone/server/handler/hook.go:46 +0xfdb
Sep 11 17:15:12 core-01 docker[1655]: github.com/zenazn/goji/web.handlerFuncWrap.ServeHTTPC(0xd5d430, 0xc2089804b0, 0xc2089803f0, 0x7f850aec79f8, 0xc20872a1e0, 0xc2081c11e0)
Sep 11 17:15:12 core-01 docker[1655]: /var/cache/drone/src/github.com/zenazn/goji/web/handler.go:25 +0x54
Sep 11 17:15:12 core-01 docker[1655]: github.com/zenazn/goji/web.(*router).route(0xc2080271b8, 0xc2081bbd70, 0x7f850aec79f8, 0xc20872a1e0, 0xc2081c11e0)
Sep 11 17:15:12 core-01 docker[1655]: /var/cache/drone/src/github.com/zenazn/goji/web/router.go:119 +0x143
Sep 11 17:15:12 core-01 docker[1655]: github.com/zenazn/goji/web.func·002(0x7f850aec79f8, 0xc20872a1e0, 0xc2081c11e0)
Sep 11 17:15:12 core-01 docker[1655]: /var/cache/drone/src/github.com/zenazn/goji/web/middleware.go:88 +0x5f
Sep 11 17:15:12 core-01 docker[1655]: net/http.HandlerFunc.ServeHTTP(0xc2081a5460, 0x7f850aec79f8, 0xc20872a1e0, 0xc2081c11e0)
Sep 11 17:15:12 core-01 docker[1655]: /usr/local/go/src/pkg/net/http/server.go:1235 +0x40
Sep 11 17:15:12 core-01 docker[1655]: github.com/drone/drone/server/middleware.func·006(0x7f850aec79f8, 0xc20872a1e0, 0xc2081c11e0)
Sep 11 17:15:12 core-01 docker[1655]: /var/cache/drone/src/github.com/drone/drone/server/middleware/user.go:21 +0x1a6
Sep 11 17:15:12 core-01 docker[1655]: net/http.HandlerFunc.ServeHTTP(0xc2081a5480, 0x7f850aec79f8, 0xc20872a1e0, 0xc2081c11e0)
Sep 11 17:15:12 core-01 docker[1655]: /usr/local/go/src/pkg/net/http/server.go:1235 +0x40
Sep 11 17:15:12 core-01 docker[1655]: github.com/drone/drone/server/middleware.func·001(0x7f850aec79f8, 0xc20872a1e0, 0xc2081c11e0)
Sep 11 17:15:12 core-01 docker[1655]: /var/cache/drone/src/github.com/drone/drone/server/middleware/header.go:28 +0x4e9
Sep 11 17:15:12 core-01 docker[1655]: net/http.HandlerFunc.ServeHTTP(0xc20811fe20, 0x7f850aec79f8, 0xc20872a1e0, 0xc2081c11e0)
Sep 11 17:15:12 core-01 docker[1655]: /usr/local/go/src/pkg/net/http/server.go:1235 +0x40
Sep 11 17:15:12 core-01 docker[1655]: main.func·002(0x7f850aec79f8, 0xc20872a1e0, 0xc2081c11e0)
Sep 11 17:15:12 core-01 docker[1655]: /var/cache/drone/src/github.com/drone/drone/server/main.go:176 +0x721
Sep 11 17:15:12 core-01 docker[1655]: net/http.HandlerFunc.ServeHTTP(0xc2081a54a0, 0x7f850aec79f8, 0xc20872a1e0, 0xc2081c11e0)
Sep 11 17:15:12 core-01 docker[1655]: /usr/local/go/src/pkg/net/http/server.go:1235 +0x40
Sep 11 17:15:12 core-01 docker[1655]: github.com/drone/drone/server/middleware.func·002(0x7f850aec79f8, 0xc20872a1e0, 0xc2081c11e0)
Sep 11 17:15:12 core-01 docker[1655]: /var/cache/drone/src/github.com/drone/drone/server/middleware/options.go:22 +0x261
Sep 11 17:15:12 core-01 docker[1655]: net/http.HandlerFunc.ServeHTTP(0xc20811fe50, 0x7f850aec79f8, 0xc20872a1e0, 0xc2081c11e0)
Sep 11 17:15:12 core-01 docker[1655]: /usr/local/go/src/pkg/net/http/server.go:1235 +0x40
Sep 11 17:15:12 core-01 docker[1655]: github.com/zenazn/goji/web.(*cStack).ServeHTTP(0xc2081bbd70, 0x7f850aec79f8, 0xc20872a1e0, 0xc2081c11e0)
Sep 11 17:15:12 core-01 docker[1655]: /var/cache/drone/src/github.com/zenazn/goji/web/middleware.go:46 +0x7f
Sep 11 17:15:12 core-01 docker[1655]: github.com/zenazn/goji/web.(*Mux).ServeHTTP(0xc208027180, 0x7f850aec79f8, 0xc20872a1e0, 0xc2081c11e0)
Sep 11 17:15:12 core-01 docker[1655]: /var/cache/drone/src/github.com/zenazn/goji/web/mux.go:45 +0x5f
Sep 11 17:15:12 core-01 docker[1655]: net/http.(*ServeMux).ServeHTTP(0xc208020930, 0x7f850aec79f8, 0xc20872a1e0, 0xc2081c11e0)
Sep 11 17:15:12 core-01 docker[1655]: /usr/local/go/src/pkg/net/http/server.go:1511 +0x1a3
Sep 11 17:15:12 core-01 docker[1655]: net/http.serverHandler.ServeHTTP(0xc208005c80, 0x7f850aec79f8, 0xc20872a1e0, 0xc2081c11e0)
Sep 11 17:15:12 core-01 docker[1655]: /usr/local/go/src/pkg/net/http/server.go:1673 +0x19f
Sep 11 17:15:12 core-01 docker[1655]: net/http.(*conn).serve(0xc208974280)
Sep 11 17:15:12 core-01 docker[1655]: /usr/local/go/src/pkg/net/http/server.go:1174 +0xa7e
Sep 11 17:15:12 core-01 docker[1655]: created by net/http.(*Server).Serve
Sep 11 17:15:12 core-01 docker[1655]: /usr/local/go/src/pkg/net/http/server.go:1721 +0x313
```

#### Ping Webhook fails

![webhook_-_http___eeceb0c8_ngrok_io_api_hook_github_com_b0otnhbapydw1yqj6inrlvw5pepvioyyuriu7isx](https://cloud.githubusercontent.com/assets/680124/9812582/48e3e6b2-58b9-11e5-8676-84c0c8655fc4.png)
