### PR TITLE
Reduce number of layers of Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,18 @@
 #    docker run -p 127.0.0.1:80:80 -t drone/drone
 
 FROM google/golang
+
 ENV DRONE_SERVER_PORT :80
 
 ADD . /gopath/src/github.com/drone/drone/
 WORKDIR /gopath/src/github.com/drone/drone
 
-RUN apt-get update
-RUN apt-get -y install zip libsqlite3-dev sqlite3 1> /dev/null 2> /dev/null
+RUN apt-get update && apt-get install -y \
+  zip \
+  libsqlite3-dev \
+  sqlite3 \
+  && rm -rf /var/lib/apt/lists/*
+
 RUN make deps build embed install
 
 EXPOSE 80


### PR DESCRIPTION
This commit just apply some best practices recommended for Dockerfile.
It just reduces some extra layer during the image building and finally
reduce image size.

The image size benchmark leads me to this:
```
TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
old                 d702d9366419        33 seconds ago      942.6 MB
latest              02d22ca471c5        53 seconds ago      912 MB
```
See: https://docs.docker.com/articles/dockerfile_best-practices/