### PR TITLE
Deliver drone UI from subfolder

### DIFF
--- a/cmd/drone-server/drone.go
+++ b/cmd/drone-server/drone.go
@@ -37,6 +37,7 @@ var conf = struct {
 		addr string
 		cert string
 		key  string
+		root string
 	}
 
 	docker struct {
@@ -70,6 +71,7 @@ func main() {
 	flag.StringVar(&conf.server.addr, "server-addr", ":8080", "")
 	flag.StringVar(&conf.server.cert, "server-cert", "", "")
 	flag.StringVar(&conf.server.key, "server-key", "", "")
+	flag.StringVar(&conf.server.root, "server-root", "/", "")
 	flag.StringVar(&conf.remote.driver, "remote-driver", "github", "")
 	flag.StringVar(&conf.remote.config, "remote-config", "https://github.com", "")
 	flag.StringVar(&conf.database.driver, "database-driver", "sqlite3", "")
@@ -208,11 +210,13 @@ func main() {
 
 	r.SetHTMLTemplate(index())
 	r.NoRoute(func(c *gin.Context) {
-		c.HTML(200, "index.html", nil)
+		c.HTML(200, "index.html", gin.H{
+			"root": conf.server.root
+		})
 	})
 
-	http.Handle("/static/", static())
-	http.Handle("/", r)
+	http.Handle(conf.server.root + "static/", static())
+	http.Handle(conf.server.root, r)
 
 	if len(conf.server.cert) == 0 {
 		err = http.ListenAndServe(conf.server.addr, nil)

--- a/cmd/drone-server/drone.go
+++ b/cmd/drone-server/drone.go
@@ -215,7 +215,7 @@ func main() {
 		})
 	})
 
-	http.Handle(conf.server.root + "static/", static())
+	http.Handle(conf.server.root+"static/", static(conf.server.root))
 	http.Handle(conf.server.root, r)
 
 	if len(conf.server.cert) == 0 {
@@ -231,7 +231,7 @@ func main() {
 
 // static is a helper function that will setup handlers
 // for serving static files.
-func static() http.Handler {
+func static(root string) http.Handler {
 	// default file server is embedded
 	var handler = http.FileServer(&assetfs.AssetFS{
 		Asset:    Asset,
@@ -243,7 +243,7 @@ func static() http.Handler {
 			http.Dir("cmd/drone-server/static"),
 		)
 	}
-	return http.StripPrefix("/static/", handler)
+	return http.StripPrefix(root+"static/", handler)
 }
 
 // index is a helper function that will setup a template

--- a/cmd/drone-server/drone.go
+++ b/cmd/drone-server/drone.go
@@ -211,7 +211,7 @@ func main() {
 	r.SetHTMLTemplate(index())
 	r.NoRoute(func(c *gin.Context) {
 		c.HTML(200, "index.html", gin.H{
-			"root": conf.server.root
+			"root": conf.server.root,
 		})
 	})
 

--- a/cmd/drone-server/drone.go
+++ b/cmd/drone-server/drone.go
@@ -103,8 +103,9 @@ func main() {
 
 	r := gin.Default()
 
-	api := r.Group("/api")
+	api := r.Group(conf.server.root+"api")
 	api.Use(server.SetHeaders())
+	api.Use(server.SetRoot(conf.server.root))
 	api.Use(server.SetBus(eventbus_))
 	api.Use(server.SetDatastore(store))
 	api.Use(server.SetRemote(remote))
@@ -184,17 +185,19 @@ func main() {
 
 	}
 
-	auth := r.Group("/authorize")
+	auth := r.Group(conf.server.root+"authorize")
 	{
 		auth.Use(server.SetHeaders())
+		auth.Use(server.SetRoot(conf.server.root))
 		auth.Use(server.SetDatastore(store))
 		auth.Use(server.SetRemote(remote))
 		auth.GET("", server.GetLogin)
 		auth.POST("", server.GetLogin)
 	}
 
-	gitlab := r.Group("/gitlab/:owner/:name")
+	gitlab := r.Group(conf.server.root+"gitlab/:owner/:name")
 	{
+		gitlab.Use(server.SetRoot(conf.server.root))
 		gitlab.Use(server.SetDatastore(store))
 		gitlab.Use(server.SetRepo())
 

--- a/cmd/drone-server/static/index.html
+++ b/cmd/drone-server/static/index.html
@@ -1,18 +1,18 @@
 <!DOCTYPE html>
-<html ng-app="drone" lang="en">
+<html ng-app="drone" ng-root="{{.root}}" lang="en">
 <head>
 
   <base href="/"/>
-  <link rel="stylesheet" href="/static/styles/reset.css" />
-  <link rel="stylesheet" href="/static/styles/fonts.css" />
-  <link rel="stylesheet" href="/static/styles/alert.css" />
-  <link rel="stylesheet" href="/static/styles/blankslate.css" />
-  <link rel="stylesheet" href="/static/styles/list.css" />
-  <link rel="stylesheet" href="/static/styles/label.css" />
-  <link rel="stylesheet" href="/static/styles/range.css" />
-  <link rel="stylesheet" href="/static/styles/switch.css" />
-  <link rel="stylesheet" href="/static/styles/main.css" />
-  <link rel="icon" href="/static/favicon.png">
+  <link rel="stylesheet" href="{{.root}}static/styles/reset.css" />
+  <link rel="stylesheet" href="{{.root}}static/styles/fonts.css" />
+  <link rel="stylesheet" href="{{.root}}static/styles/alert.css" />
+  <link rel="stylesheet" href="{{.root}}static/styles/blankslate.css" />
+  <link rel="stylesheet" href="{{.root}}static/styles/list.css" />
+  <link rel="stylesheet" href="{{.root}}static/styles/label.css" />
+  <link rel="stylesheet" href="{{.root}}static/styles/range.css" />
+  <link rel="stylesheet" href="{{.root}}static/styles/switch.css" />
+  <link rel="stylesheet" href="{{.root}}static/styles/main.css" />
+  <link rel="icon" href="{{.root}}static/favicon.png">
 </head>
 <body>
 <div ui-view="layout"></div>
@@ -25,22 +25,22 @@
 <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.6.0/moment.min.js"></script>
 
 <!-- main javascript application -->
-<script src="/static/scripts/term.js"></script>
-<script src="/static/scripts/drone.js"></script>
-<script src="/static/scripts/controllers/repos.js"></script>
-<script src="/static/scripts/controllers/builds.js"></script>
-<script src="/static/scripts/controllers/users.js"></script>
+<script src="{{.root}}static/scripts/term.js"></script>
+<script src="{{.root}}static/scripts/drone.js"></script>
+<script src="{{.root}}static/scripts/controllers/repos.js"></script>
+<script src="{{.root}}static/scripts/controllers/builds.js"></script>
+<script src="{{.root}}static/scripts/controllers/users.js"></script>
 
-<script src="/static/scripts/services/repos.js"></script>
-<script src="/static/scripts/services/builds.js"></script>
-<script src="/static/scripts/services/users.js"></script>
-<script src="/static/scripts/services/logs.js"></script>
-<script src="/static/scripts/services/tokens.js"></script>
-<script src="/static/scripts/services/feed.js"></script>
+<script src="{{.root}}static/scripts/services/repos.js"></script>
+<script src="{{.root}}static/scripts/services/builds.js"></script>
+<script src="{{.root}}static/scripts/services/users.js"></script>
+<script src="{{.root}}static/scripts/services/logs.js"></script>
+<script src="{{.root}}static/scripts/services/tokens.js"></script>
+<script src="{{.root}}static/scripts/services/feed.js"></script>
 
-<script src="/static/scripts/filters/filter.js"></script>
-<script src="/static/scripts/filters/gravatar.js"></script>
-<script src="/static/scripts/filters/time.js"></script>
+<script src="{{.root}}static/scripts/filters/filter.js"></script>
+<script src="{{.root}}static/scripts/filters/gravatar.js"></script>
+<script src="{{.root}}static/scripts/filters/time.js"></script>
 
 </body>
 </html>

--- a/cmd/drone-server/static/index.html
+++ b/cmd/drone-server/static/index.html
@@ -1,18 +1,18 @@
 <!DOCTYPE html>
-<html ng-app="drone" ng-root="{{.root}}" lang="en">
+<html ng-app="drone" lang="en">
 <head>
 
-  <base href="/"/>
-  <link rel="stylesheet" href="{{.root}}static/styles/reset.css" />
-  <link rel="stylesheet" href="{{.root}}static/styles/fonts.css" />
-  <link rel="stylesheet" href="{{.root}}static/styles/alert.css" />
-  <link rel="stylesheet" href="{{.root}}static/styles/blankslate.css" />
-  <link rel="stylesheet" href="{{.root}}static/styles/list.css" />
-  <link rel="stylesheet" href="{{.root}}static/styles/label.css" />
-  <link rel="stylesheet" href="{{.root}}static/styles/range.css" />
-  <link rel="stylesheet" href="{{.root}}static/styles/switch.css" />
-  <link rel="stylesheet" href="{{.root}}static/styles/main.css" />
-  <link rel="icon" href="{{.root}}static/favicon.png">
+  <base href="{{.root}}" />
+  <link rel="stylesheet" href="static/styles/reset.css" />
+  <link rel="stylesheet" href="static/styles/fonts.css" />
+  <link rel="stylesheet" href="static/styles/alert.css" />
+  <link rel="stylesheet" href="static/styles/blankslate.css" />
+  <link rel="stylesheet" href="static/styles/list.css" />
+  <link rel="stylesheet" href="static/styles/label.css" />
+  <link rel="stylesheet" href="static/styles/range.css" />
+  <link rel="stylesheet" href="static/styles/switch.css" />
+  <link rel="stylesheet" href="static/styles/main.css" />
+  <link rel="icon" href="static/favicon.png">
 </head>
 <body>
 <div ui-view="layout"></div>
@@ -25,22 +25,22 @@
 <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.6.0/moment.min.js"></script>
 
 <!-- main javascript application -->
-<script src="{{.root}}static/scripts/term.js"></script>
-<script src="{{.root}}static/scripts/drone.js"></script>
-<script src="{{.root}}static/scripts/controllers/repos.js"></script>
-<script src="{{.root}}static/scripts/controllers/builds.js"></script>
-<script src="{{.root}}static/scripts/controllers/users.js"></script>
+<script src="static/scripts/term.js"></script>
+<script src="static/scripts/drone.js"></script>
+<script src="static/scripts/controllers/repos.js"></script>
+<script src="static/scripts/controllers/builds.js"></script>
+<script src="static/scripts/controllers/users.js"></script>
 
-<script src="{{.root}}static/scripts/services/repos.js"></script>
-<script src="{{.root}}static/scripts/services/builds.js"></script>
-<script src="{{.root}}static/scripts/services/users.js"></script>
-<script src="{{.root}}static/scripts/services/logs.js"></script>
-<script src="{{.root}}static/scripts/services/tokens.js"></script>
-<script src="{{.root}}static/scripts/services/feed.js"></script>
+<script src="static/scripts/services/repos.js"></script>
+<script src="static/scripts/services/builds.js"></script>
+<script src="static/scripts/services/users.js"></script>
+<script src="static/scripts/services/logs.js"></script>
+<script src="static/scripts/services/tokens.js"></script>
+<script src="static/scripts/services/feed.js"></script>
 
-<script src="{{.root}}static/scripts/filters/filter.js"></script>
-<script src="{{.root}}static/scripts/filters/gravatar.js"></script>
-<script src="{{.root}}static/scripts/filters/time.js"></script>
+<script src="static/scripts/filters/filter.js"></script>
+<script src="static/scripts/filters/gravatar.js"></script>
+<script src="static/scripts/filters/time.js"></script>
 
 </body>
 </html>

--- a/cmd/drone-server/static/scripts/controllers/repos.js
+++ b/cmd/drone-server/static/scripts/controllers/repos.js
@@ -64,13 +64,13 @@
   /**
    * RepoEditCtrl responsible for editing a repository.
    */
-  function RepoEditCtrl($scope, $window, $location, $stateParams, repos, users) {
+  function RepoEditCtrl($scope, $state, $location, $stateParams, repos, users) {
     var owner = $stateParams.owner;
     var name = $stateParams.name;
     var fullName = owner + '/' + name;
 
-    // Inject window for composing url
-    $scope.window = $window;
+    // Inject absolute url for composing links
+    $scope.absolute_root = $state.href('app.index', {}, { absolute: true });
 
     // Gets the currently authenticated user
     users.getCached().then(function (payload) {

--- a/cmd/drone-server/static/scripts/drone.js
+++ b/cmd/drone-server/static/scripts/drone.js
@@ -53,7 +53,7 @@
         abstract: true,
         views: {
           'layout': {
-            templateUrl: '/static/scripts/views/layout.html',
+            templateUrl: 'static/scripts/views/layout.html',
             controller: function ($scope, $routeParams, repos, users) {
               users.getCached().then(function (payload) {
                 if (payload && payload.data) {
@@ -68,10 +68,10 @@
         url: '/',
         views: {
           'toolbar': {
-            templateUrl: '/static/scripts/views/repos/index/toolbar.html'
+            templateUrl: 'static/scripts/views/repos/index/toolbar.html'
           },
           'content': {
-            templateUrl: '/static/scripts/views/repos/index/content.html',
+            templateUrl: 'static/scripts/views/repos/index/content.html',
             controller: 'ReposCtrl',
             resolve: resolveUser
           }
@@ -82,7 +82,7 @@
         url: '/login',
         views: {
           'layout': {
-            templateUrl: '/static/scripts/views/login.html',
+            templateUrl: 'static/scripts/views/login.html',
             controller: 'UserLoginCtrl',
             resolve: resolveUser
           }
@@ -93,7 +93,7 @@
         url: '/logout',
         views: {
           'layout': {
-            templateUrl: '/static/scripts/views/login.html',
+            templateUrl: 'static/scripts/views/login.html',
             controller: 'UserLogoutCtrl',
             resolve: resolveUser
           }
@@ -103,9 +103,9 @@
       .state('app.profile', {
         url: '/profile',
         views: {
-          'toolbar': {templateUrl: '/static/scripts/views/profile/toolbar.html'},
+          'toolbar': {templateUrl: 'static/scripts/views/profile/toolbar.html'},
           'content': {
-            templateUrl: '/static/scripts/views/profile/content.html',
+            templateUrl: 'static/scripts/views/profile/content.html',
             controller: 'UserCtrl',
             resolve: resolveUser
           }
@@ -115,9 +115,9 @@
       .state('app.users', {
         url: '/users',
         views: {
-          'toolbar': {templateUrl: '/static/scripts/views/users/toolbar.html'},
+          'toolbar': {templateUrl: 'static/scripts/views/users/toolbar.html'},
           'content': {
-            templateUrl: '/static/scripts/views/users/content.html',
+            templateUrl: 'static/scripts/views/users/content.html',
             controller: 'UsersCtrl',
             resolve: resolveUser
           }
@@ -128,12 +128,12 @@
         url: '/:owner/:name',
         views: {
           'toolbar': {
-            templateUrl: '/static/scripts/views/builds/index/toolbar.html',
+            templateUrl: 'static/scripts/views/builds/index/toolbar.html',
             controller: 'UserHeaderCtrl',
             resolve: resolveUser
           },
           'content': {
-            templateUrl: '/static/scripts/views/builds/index/content.html',
+            templateUrl: 'static/scripts/views/builds/index/content.html',
             controller: 'BuildsCtrl'
           }
         },
@@ -143,12 +143,12 @@
         url: '/:owner/:name/edit',
         views: {
           'toolbar': {
-            templateUrl: '/static/scripts/views/repos/toolbar.html',
+            templateUrl: 'static/scripts/views/repos/toolbar.html',
             controller: 'UserHeaderCtrl',
             resolve: resolveUser
           },
           'content': {
-            templateUrl: '/static/scripts/views/repos/edit.html',
+            templateUrl: 'static/scripts/views/repos/edit.html',
             controller: 'RepoEditCtrl',
             resolve: resolveUser
           }
@@ -159,12 +159,12 @@
         url: '/:owner/:name/delete',
         views: {
           'toolbar': {
-            templateUrl: '/static/scripts/views/repos/toolbar.html',
+            templateUrl: 'static/scripts/views/repos/toolbar.html',
             controller: 'UserHeaderCtrl',
             resolve: resolveUser
           },
           'content': {
-            templateUrl: '/static/scripts/views/repos/del.html',
+            templateUrl: 'static/scripts/views/repos/del.html',
             controller: 'RepoEditCtrl',
             resolve: resolveUser
           }
@@ -175,12 +175,12 @@
         url: '/:owner/:name/edit/env',
         views: {
           'toolbar': {
-            templateUrl: '/static/scripts/views/repos/toolbar.html',
+            templateUrl: 'static/scripts/views/repos/toolbar.html',
             controller: 'UserHeaderCtrl',
             resolve: resolveUser
           },
           'content': {
-            templateUrl: '/static/scripts/views/repos/env.html',
+            templateUrl: 'static/scripts/views/repos/env.html',
             controller: 'RepoEditCtrl',
             resolve: resolveUser
           }
@@ -191,12 +191,12 @@
         url: '/:owner/:name/secure',
         views: {
           'toolbar': {
-            templateUrl: '/static/scripts/views/repos/toolbar.html',
+            templateUrl: 'static/scripts/views/repos/toolbar.html',
             controller: 'UserHeaderCtrl',
             resolve: resolveUser
           },
           'content': {
-            templateUrl: '/static/scripts/views/repos/secure.html',
+            templateUrl: 'static/scripts/views/repos/secure.html',
             controller: 'RepoEditCtrl',
             resolve: resolveUser
           }
@@ -207,12 +207,12 @@
         url: '/:owner/:name/:number',
         views: {
           'toolbar': {
-            templateUrl: '/static/scripts/views/builds/show/toolbar.html',
+            templateUrl: 'static/scripts/views/builds/show/toolbar.html',
             controller: 'UserHeaderCtrl',
             resolve: resolveUser
           },
           'content': {
-            templateUrl: '/static/scripts/views/builds/show/content.html',
+            templateUrl: 'static/scripts/views/builds/show/content.html',
             controller: 'BuildOutCtrl',
             resolve: resolveUser
           }
@@ -223,12 +223,12 @@
         url: '/:owner/:name/:number/:step',
         views: {
           'toolbar': {
-            templateUrl: '/static/scripts/views/builds/show/toolbar.html',
+            templateUrl: 'static/scripts/views/builds/show/toolbar.html',
             controller: 'UserHeaderCtrl',
             resolve: resolveUser
           },
           'content': {
-            templateUrl: '/static/scripts/views/builds/show/content.html',
+            templateUrl: 'static/scripts/views/builds/show/content.html',
             controller: 'BuildOutCtrl',
             resolve: resolveUser
           }
@@ -248,7 +248,7 @@
     $httpProvider.interceptors.push(function ($q, $location) {
       return {
         'responseError': function (rejection) {
-          if (rejection.status === 401 && rejection.config.url !== "/api/user") {
+          if (rejection.status === 401 && rejection.config.url !== "api/user") {
             $location.path('/login');
           }
           if (rejection.status === 0) {

--- a/cmd/drone-server/static/scripts/services/builds.js
+++ b/cmd/drone-server/static/scripts/services/builds.js
@@ -14,7 +14,7 @@
 		 * @param {string} Name of the repository.
 		 */
 		this.list = function(repoName) {
-			return $http.get('/api/repos/'+repoName+'/builds');
+			return $http.get('api/repos/'+repoName+'/builds');
 		};
 
 		/**
@@ -24,7 +24,7 @@
 		 * @param {number} Number of the build.
 		 */
 		this.get = function(repoName, buildNumber) {
-			return $http.get('/api/repos/'+repoName+'/builds/'+buildNumber);
+			return $http.get('api/repos/'+repoName+'/builds/'+buildNumber);
 		};
 
 		/**
@@ -34,7 +34,7 @@
 		 * @param {number} Number of the build.
 		 */
 		this.restart = function(repoName, buildNumber) {
-			return $http.post('/api/repos/' + repoName+'/builds/'+buildNumber);
+			return $http.post('api/repos/' + repoName+'/builds/'+buildNumber);
 		};
 
 		/**
@@ -44,7 +44,7 @@
 		 * @param {number} Number of the build.
 		 */
 		this.cancel = function(repoName, buildNumber) {
-			return $http.delete('/api/repos/'+repoName+'/builds/'+buildNumber);
+			return $http.delete('api/repos/'+repoName+'/builds/'+buildNumber);
 		};
 	}
 

--- a/cmd/drone-server/static/scripts/services/feed.js
+++ b/cmd/drone-server/static/scripts/services/feed.js
@@ -2,7 +2,7 @@
 
 (function () {
 
-	function FeedService($http, $window) {
+	function FeedService($http, $window, $state) {
 
 		var callback,
 			websocket,
@@ -12,7 +12,7 @@
 			callback = _callback;
 
 			var proto = ($window.location.protocol === 'https:' ? 'wss' : 'ws'),
-				route = [proto, "://", $window.location.host, 'api/stream/user?access_token=', token].join('');
+				route = [proto, "://", $window.location.host, $state.href('app.index'), 'api/stream/user?access_token=', token].join('');
 
 			websocket = new WebSocket(route);
 			websocket.onmessage = function (event) {

--- a/cmd/drone-server/static/scripts/services/feed.js
+++ b/cmd/drone-server/static/scripts/services/feed.js
@@ -12,7 +12,7 @@
 			callback = _callback;
 
 			var proto = ($window.location.protocol === 'https:' ? 'wss' : 'ws'),
-				route = [proto, "://", $window.location.host, '/api/stream/user?access_token=', token].join('');
+				route = [proto, "://", $window.location.host, 'api/stream/user?access_token=', token].join('');
 
 			websocket = new WebSocket(route);
 			websocket.onmessage = function (event) {

--- a/cmd/drone-server/static/scripts/services/logs.js
+++ b/cmd/drone-server/static/scripts/services/logs.js
@@ -16,7 +16,7 @@
 		 * @param {number} Number of the task.
 		 */
 		this.get = function(repoName, number, step) {
-			return $http.get('/api/repos/'+repoName+'/logs/'+number+'/'+step);
+			return $http.get('api/repos/'+repoName+'/logs/'+number+'/'+step);
 		};
 
 		var callback,
@@ -26,7 +26,7 @@
 		this.subscribe = function (repoName, number, step, _callback) {
 			callback = _callback;
 
-			var route = ['/api/stream/', repoName, '/', number, '/', step, '?access_token=', token].join('')
+			var route = ['api/stream/', repoName, '/', number, '/', step, '?access_token=', token].join('')
 			events = new EventSource(route, { withCredentials: true });
 			events.onmessage = function (event) {
 				if (callback !== undefined) {

--- a/cmd/drone-server/static/scripts/services/repos.js
+++ b/cmd/drone-server/static/scripts/services/repos.js
@@ -16,7 +16,7 @@
      * Gets a list of all repositories.
      */
     this.list = function () {
-      return $http.get('/api/user/repos');
+      return $http.get('api/user/repos');
     };
 
     /**
@@ -25,7 +25,7 @@
      * @param {string} Name of the repository.
      */
     this.get = function (repoName) {
-      return $http.get('/api/repos/' + repoName);
+      return $http.get('api/repos/' + repoName);
     };
 
     /**
@@ -34,7 +34,7 @@
      * @param {object} JSON representation of a repository.
      */
     this.post = function (repoName) {
-      return $http.post('/api/repos/' + repoName);
+      return $http.post('api/repos/' + repoName);
     };
 
     /**
@@ -43,7 +43,7 @@
      * @param {object} JSON representation of a repository.
      */
     this.update = function (repo) {
-      return $http.patch('/api/repos/' + repo.full_name, repo);
+      return $http.patch('api/repos/' + repo.full_name, repo);
     };
 
     /**
@@ -52,7 +52,7 @@
      * @param {string} Name of the repository.
      */
     this.delete = function (repoName) {
-      return $http.delete('/api/repos/' + repoName);
+      return $http.delete('api/repos/' + repoName);
     };
 
     /**
@@ -61,7 +61,7 @@
      * @param {string} Name of the repository.
      */
     this.watch = function (repoName) {
-      return $http.post('/api/repos/' + repoName + '/watch');
+      return $http.post('api/repos/' + repoName + '/watch');
     };
 
     /**
@@ -70,7 +70,7 @@
      * @param {string} Name of the repository.
      */
     this.unwatch = function (repoName) {
-      return $http.delete('/api/repos/' + repoName + '/unwatch');
+      return $http.delete('api/repos/' + repoName + '/unwatch');
     };
 
     /**
@@ -86,7 +86,7 @@
         }
       }
 
-      return $http.post('/api/repos/' + repoName + '/encrypt', btoa(plaintext), conf);
+      return $http.post('api/repos/' + repoName + '/encrypt', btoa(plaintext), conf);
     };
 
     var callback,
@@ -101,7 +101,7 @@
     this.subscribe = function (repo, _callback) {
       callback = _callback;
 
-      events = new EventSource("/api/stream/" + repo + "?access_token=" + token, {withCredentials: true});
+      events = new EventSource("api/stream/" + repo + "?access_token=" + token, {withCredentials: true});
       events.onmessage = function (event) {
         if (callback !== undefined) {
           callback(angular.fromJson(event.data));

--- a/cmd/drone-server/static/scripts/services/tokens.js
+++ b/cmd/drone-server/static/scripts/services/tokens.js
@@ -12,7 +12,7 @@
 		 * Generates a user API token.
 		 */
 		this.post = function(token) {
-			return $http.post('/api/user/token');
+			return $http.post('api/user/token');
 		};
 	}
 

--- a/cmd/drone-server/static/scripts/services/users.js
+++ b/cmd/drone-server/static/scripts/services/users.js
@@ -17,42 +17,42 @@
 		 * Gets a list of all users.
 		 */
 		this.list = function() {
-			return $http.get('/api/users');
+			return $http.get('api/users');
 		};
 
 		/**
 		 * Gets a user by login.
 		 */
 		this.get = function(login) {
-			return $http.get('/api/users/'+login);
+			return $http.get('api/users/'+login);
 		};
 
 		/**
 		 * Gets the currently authenticated user.
 		 */
 		this.getCurrent = function() {
-			return $http.get('/api/user');
+			return $http.get('api/user');
 		};
 
 		/**
 		 * Updates an existing user
 		 */
 		this.post = function(user) {
-			return $http.post('/api/users/'+user);
+			return $http.post('api/users/'+user);
 		};
 
 		/**
 		 * Updates an existing user
 		 */
 		this.put = function(user) {
-			return $http.patch('/api/users/'+user.login, user);
+			return $http.patch('api/users/'+user.login, user);
 		};
 
 		/**
 		 * Deletes a user.
 		 */
 		this.delete = function(user) {
-			return $http.delete('/api/users/'+user.login);
+			return $http.delete('api/users/'+user.login);
 		};
 
 		/**

--- a/cmd/drone-server/static/scripts/views/builds/index/content.html
+++ b/cmd/drone-server/static/scripts/views/builds/index/content.html
@@ -10,10 +10,10 @@
         <button type="button" ng-click="watch(repo)" ng-if="!repo.starred && user">
           <i class="material-icons">visibility_off</i>
         </button>
-        <a href="/{{ repo.full_name }}/edit" ng-if="repo.permissions.push">
+        <a href="{{ repo.full_name }}/edit" ng-if="repo.permissions.push">
           <i class="material-icons">tune</i>
         </a>
-      </menu> 
+      </menu>
     </section>
 
     <div class="blankslate" ng-show="!builds.length && !loading && !error">
@@ -28,7 +28,7 @@
 
     <div>
       <div class="list">
-        <a ng-repeat="build in builds | orderBy:'-number' | filter: search_text" ng-href="/{{ repo.full_name }}/{{ build.number}}">
+        <a ng-repeat="build in builds | orderBy:'-number' | filter: search_text" ng-href="{{ repo.full_name }}/{{ build.number}}">
           <div class="column-status">
             <div class="status {{ build.status }}">
               <i class="material-icons">{{ build.status | icon }}</i>

--- a/cmd/drone-server/static/scripts/views/builds/index/toolbar.html
+++ b/cmd/drone-server/static/scripts/views/builds/index/toolbar.html
@@ -1,6 +1,6 @@
 <ol>
   <li>
-    <a href="/">
+    <a ui-sref="app.index">
       <i class="material-icons">arrow_back</i>
     </a>
   </li>

--- a/cmd/drone-server/static/scripts/views/builds/show/toolbar.html
+++ b/cmd/drone-server/static/scripts/views/builds/show/toolbar.html
@@ -1,6 +1,6 @@
 <ol>
   <li>
-    <a ng-href="/{{ full_name }}">
+    <a ng-href="{{ full_name }}">
       <i class="material-icons">arrow_back</i>
     </a>
   </li>

--- a/cmd/drone-server/static/scripts/views/builds/step/toolbar.html
+++ b/cmd/drone-server/static/scripts/views/builds/step/toolbar.html
@@ -1,16 +1,16 @@
 <div class="breadcrumb" style="position:relative;top:0px;">
-  <a ng-href="/{{ repo.full_name }}/{{ build.sequence }}" class="icon icon-home">
+  <a ng-href="{{ repo.full_name }}/{{ build.sequence }}" class="icon icon-home">
     <i class="material-icons md-18">home</i>
   </a>
-  <a ng-href="/{{ repo.full_name }}">{{ repo.owner }} / {{ repo.name }}</a>
+  <a ng-href="{{ repo.full_name }}">{{ repo.owner }} / {{ repo.name }}</a>
   <span class="spacer">&nbsp;</span>
-  <a ng-href="/{{ repo.full_name }}/{{ build.number }}">Build # {{ build.number }}</a>
+  <a ng-href="{{ repo.full_name }}/{{ build.number }}">Build # {{ build.number }}</a>
   <span class="spacer"></span>
   <a href="#">Job #{{ task.number }}</a>
 </div>
 
 <div class="menu">
-  <a ng-href="/{{ repo.full_name }}/edit" class="nav-item settings float-right" ng-if="repo.permissions.pull">
+  <a ng-href="{{ repo.full_name }}/edit" class="nav-item settings float-right" ng-if="repo.permissions.pull">
     <i class="material-icons md-18">edit</i>
   </a>
   <button ng-click="watch(repo)" ng-if="!repo.starred && user" class="nav-item star float-right">

--- a/cmd/drone-server/static/scripts/views/layout.html
+++ b/cmd/drone-server/static/scripts/views/layout.html
@@ -23,7 +23,7 @@
 
   <ul ng-if="!user">
     <li>
-      <a href="/login" class="button button-login">Login</a>
+      <a href="login" class="button button-login">Login</a>
     </li>
   </ul>
 </header>

--- a/cmd/drone-server/static/scripts/views/layout.html
+++ b/cmd/drone-server/static/scripts/views/layout.html
@@ -13,9 +13,9 @@
       <div class="backdrop" ng-show="show" ng-click="show=false"></div>
       <div class="dropdown" ng-show="show" ng-click="show=false">
         <ul>
-          <li><a href="/profile">Profile</a></li>
-          <li><a href="/users">Users</a></li>
-          <li><a href="/logout">Logout</a></li>
+          <li><a href="profile">Profile</a></li>
+          <li><a href="users">Users</a></li>
+          <li><a href="logout">Logout</a></li>
         </ul>
       </div>
     </li>

--- a/cmd/drone-server/static/scripts/views/login.html
+++ b/cmd/drone-server/static/scripts/views/login.html
@@ -1,6 +1,4 @@
 <style>
-
-
   a.box {
     background: #FFF;
     width: 250px;
@@ -18,7 +16,7 @@
   }
 
   div.login-logo {
-    background: url(/static/images/logo.svg) no-repeat center center;
+    background: url(static/images/logo.svg) no-repeat center center;
     background-size: 72px;
     height: 150px;
     -webkit-transition: all .5s;
@@ -51,7 +49,7 @@
   }
 </style>
 
-<a href="/authorize" target="_self" class="box">
+<a href="authorize" target="_self" class="box">
   <div class="login-logo"></div>
   <div ng-switch="error" class="alert alert-error" ng-if="error">
     <div ng-switch-when="internal_error">Oops. There was an unexpected error. Please try again.</div>

--- a/cmd/drone-server/static/scripts/views/profile/toolbar.html
+++ b/cmd/drone-server/static/scripts/views/profile/toolbar.html
@@ -1,6 +1,6 @@
 <ol>
   <li>
-    <a href="/">
+    <a ui-sref="app.index">
       <i class="material-icons">arrow_back</i>
     </a>
   </li>

--- a/cmd/drone-server/static/scripts/views/repos/edit.html
+++ b/cmd/drone-server/static/scripts/views/repos/edit.html
@@ -34,13 +34,13 @@
     <div class="row">
       <div>Badge</div>
       <div>
-        <pre class="snippet">[![Build Status]({{ window.location.origin }}/api/badges/{{ repo.full_name }}/status.svg)]({{ window.location.origin }}/{{ repo.full_name }})</pre>
+        <pre class="snippet">[![Build Status]({{ absolute_root }}api/badges/{{ repo.full_name }}/status.svg)]({{ absolute_root }}{{ repo.full_name }})</pre>
       </div>
     </div>
     <div class="row">
       <div>CCMenu</div>
       <div>
-        <pre class="snippet">{{ window.location.origin }}/api/badges/{{ repo.full_name }}/cc.xml</pre>
+        <pre class="snippet">{{ absolute_root }}api/badges/{{ repo.full_name }}/cc.xml</pre>
       </div>
     </div>
     <div class="row">

--- a/cmd/drone-server/static/scripts/views/repos/index/content.html
+++ b/cmd/drone-server/static/scripts/views/repos/index/content.html
@@ -24,7 +24,7 @@
     </div>
 
     <ul class="list cozy" ng-show="!waiting && !error">
-      <a class="row row-repo" ng-repeat="repo in repos | orderBy:'full_name' | filter: search_text" ng-href="/{{ repo.full_name }}">
+      <a class="row row-repo" ng-repeat="repo in repos | orderBy:'full_name' | filter: search_text" ng-href="{{ repo.full_name }}">
         <div class="column-avatar">
           <img ng-src="{{ repo.avatar_url }}" />
         </div>

--- a/cmd/drone-server/static/scripts/views/repos/index/toolbar.html
+++ b/cmd/drone-server/static/scripts/views/repos/index/toolbar.html
@@ -1,1 +1,1 @@
-<a href="/" class="logo"></a>
+<a ui-sref="app.index" class="logo"></a>

--- a/cmd/drone-server/static/scripts/views/repos/toolbar.html
+++ b/cmd/drone-server/static/scripts/views/repos/toolbar.html
@@ -1,6 +1,6 @@
 <ol>
   <li>
-    <a ng-href="/{{ full_name}}">
+    <a ng-href="{{ full_name}}">
       <i class="material-icons">arrow_back</i>
     </a>
   </li>

--- a/cmd/drone-server/static/scripts/views/users/toolbar.html
+++ b/cmd/drone-server/static/scripts/views/users/toolbar.html
@@ -1,6 +1,6 @@
 <ol>
   <li>
-    <a href="/">
+    <a ui-sref="app.index">
       <i class="material-icons">arrow_back</i>
     </a>
   </li>

--- a/pkg/server/gitlab.go
+++ b/pkg/server/gitlab.go
@@ -22,6 +22,7 @@ func RedirectSha(c *gin.Context) {
 
 	store := ToDatastore(c)
 	repo := ToRepo(c)
+	rootPath := ToRoot(c)
 	sha := c.Params.ByName("sha")
 
 	branch = c.Request.FormValue("branch")
@@ -31,11 +32,11 @@ func RedirectSha(c *gin.Context) {
 
 	build, err := store.BuildSha(repo, sha, branch)
 	if err != nil {
-		c.Redirect(301, "/")
+		c.Redirect(301, fmt.Sprintf("%s/", rootPath))
 		return
 	}
 
-	c.Redirect(301, fmt.Sprintf("/%s/%s/%d", repo.Owner, repo.Name, build.ID))
+	c.Redirect(301, fmt.Sprintf("%s/%s/%s/%d", rootPath, repo.Owner, repo.Name, build.ID))
 	return
 }
 
@@ -51,19 +52,20 @@ func RedirectSha(c *gin.Context) {
 func RedirectPullRequest(c *gin.Context) {
 	store := ToDatastore(c)
 	repo := ToRepo(c)
+	rootPath := ToRoot(c)
 	num, err := strconv.Atoi(c.Params.ByName("number"))
 	if err != nil {
-		c.Redirect(301, "/")
+		c.Redirect(301, fmt.Sprintf("%s/", rootPath))
 		return
 	}
 
 	build, err := store.BuildPullRequestNumber(repo, num)
 	if err != nil {
-		c.Redirect(301, "/")
+		c.Redirect(301, fmt.Sprintf("%s/", rootPath))
 		return
 	}
 
-	c.Redirect(301, fmt.Sprintf("/%s/%s/%d", repo.Owner, repo.Name, build.ID))
+	c.Redirect(301, fmt.Sprintf("%s/%s/%s/%d", rootPath, repo.Owner, repo.Name, build.ID))
 	return
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/drone/drone/Godeps/_workspace/src/github.com/gin-gonic/gin"
@@ -43,6 +44,24 @@ func ToBus(c *gin.Context) bus.Bus {
 		return nil
 	}
 	return v.(bus.Bus)
+}
+
+func ToRoot(c *gin.Context) string {
+	v, ok := c.Get("root")
+	if !ok {
+		return "/"
+	}
+	return v.(string)
+}
+
+func SetRoot(r string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		trimmedRoot := strings.TrimSuffix(r, "/")
+
+		c.Request.Header.Add("X-Drone-Root", trimmedRoot)
+		c.Set("root", trimmedRoot)
+		c.Next()
+	}
 }
 
 func ToRemote(c *gin.Context) remote.Remote {

--- a/pkg/utils/httputil/httputil.go
+++ b/pkg/utils/httputil/httputil.go
@@ -66,11 +66,23 @@ func GetHost(r *http.Request) string {
 	}
 }
 
+// GetPAth is a helper function that evaluates the http.Request
+// and returns our custom header for getting the correct path to
+// the drone root folder.
+func GetPath(r *http.Request) string {
+	switch {
+	case len(r.Header.Get("X-Drone-Root")) != 0:
+		return r.Header.Get("X-Drone-Root")
+	default:
+		return ""
+	}
+}
+
 // GetURL is a helper function that evaluates the http.Request
 // and returns the URL as a string. Only the scheme + hostname
 // are included; the path is excluded.
 func GetURL(r *http.Request) string {
-	return GetScheme(r) + "://" + GetHost(r)
+	return GetScheme(r) + "://" + GetHost(r) + GetPath(r)
 }
 
 // GetCookie retrieves and verifies the cookie value.


### PR DESCRIPTION
To be able to use multiple instances of drone within different subfolders I have started this pull request. In my case i want to ship drone through `https://ci.example.com/github` and `https://ci.example.com/gitlab`, to be able to do that we need the option to respond to these paths.

It's currently WIP because we need to find a proper way how to handover the folder to the angular application. As you can see i have added an `ng-root` attribute to the `body`. What do you prefer to access this attribute?

Please comment @bradrydzewski, I really need this feature :)