### PR TITLE
Build Docker image with Go 1.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.4.2
+FROM golang:1.5.1
 
 ENV DRONE_SERVER_PORT :80
 WORKDIR $GOPATH/src/github.com/drone/drone
@@ -16,7 +16,7 @@ RUN apt-get update                                                              
 RUN touch /tmp/drone.toml
 
 ADD . .
-RUN make bindata deps           \
-    && make build               \
+RUN go run make.go bindata deps           \
+    && go run make.go build               \
     && mv bin/* /usr/local/bin/ \
     && rm -rf bin cmd/drone-server/drone_bindata.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ CMD ["-config", "/tmp/drone.toml"]
 RUN apt-get update                                                                       \
     && apt-get install -y libsqlite3-dev                                                 \
     && git clone git://github.com/gin-gonic/gin.git $GOPATH/src/github.com/gin-gonic/gin \
-    && go get -u github.com/jteeuwen/go-bindata/...
+    && go get -u github.com/jteeuwen/go-bindata/...                                      \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN touch /tmp/drone.toml
 


### PR DESCRIPTION
Now Drone 0.4 requires Go 1.5+ to build a binary. I modified Dockerfile to use Go 1.5.1 for building.