### PR TITLE
Update comments in shared.build.Builder

### DIFF
--- a/shared/build/build.go
+++ b/shared/build/build.go
@@ -41,11 +41,11 @@ func New(dockerClient *docker.Client) *Builder {
 // Builder represents a build process being prepared
 // to run.
 type Builder struct {
-	// Image specifies the Docker Image that will be
-	// used to virtualize the Build process.
+	// Build specifies the configuration details for building,
+	// testing and deploying code.
 	Build *script.Build
 
-	// Source specifies the Repository path of the code
+	// Repo specifies the repository details for the code that
 	// that we are testing.
 	//
 	// The source repository may be a local repository


### PR DESCRIPTION
They were previously referring to fields with different names. New comments are taken from the type declaration of `shared.build.script.Build` and what seems appropriate for `shared.build.repo.Repo` (sending separate PR).