### PR TITLE
fix(router): correct for get gitlab status

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -158,6 +158,9 @@ func normalize(h http.Handler) http.Handler {
 
 		parts := strings.Split(r.URL.Path, "/")[1:]
 		switch parts[0] {
+		case "gitlab":
+                        parts = append([]string{"", "api"}, parts...)
+                        r.URL.Path = strings.Join(parts, "/")
 		case "settings", "api", "login", "logout", "", "authorize", "hook", "static":
 			// no-op
 		default:


### PR DESCRIPTION
-/repos/gitlab/go/builds/test-drone-4/commits/e3064b865e445718d453afb94838e6ccf3454b24
+/api/gitlab/go/builds/test-drone-4/commits/e3064b865e445718d453afb94838e6ccf3454b24