### PR TITLE
sudo issue fixed

### DIFF
--- a/plugin/publish/docker.go
+++ b/plugin/publish/docker.go
@@ -62,7 +62,7 @@ func (d *Docker) Write(f *buildfile.Buildfile) {
 
 	if len(d.DockerVersion) > 0 {
 		// Download docker binary and install it as /usr/local/bin/docker if it does not exist
-		f.WriteCmd("type -p docker || curl -sSL https://get.docker.io/builds/Linux/x86_64/docker-" +
+		f.WriteCmd("if [[ \"$(whoami)\" != \"root\" ]]; then  SUDO=\"sudo\";fi; type -p docker || curl -sSL https://get.docker.io/builds/Linux/x86_64/docker-" +
 			d.DockerVersion + ".tgz |sudo tar zxf - -C /")
 	}
 


### PR DESCRIPTION
Depending on the docker image, when running as root the sudo commands fails. This makes that the docker installation fails as well.

This is just a quick fix that avoids the root/sudo problem.