### PR TITLE
When cloning pull requests, use specific branch

### DIFF
--- a/shared/build/build_test.go
+++ b/shared/build/build_test.go
@@ -594,7 +594,7 @@ func TestWriteBuildScript(t *testing.T) {
 	f.WriteEnv("CI_PULL_REQUEST", "123")
 	f.WriteHost("127.0.0.1")
 	f.WriteFile("$HOME/.ssh/id_rsa", []byte("ssh-rsa AAA..."), 600)
-	f.WriteCmd("git clone --depth=0 --recursive git://github.com/drone/drone.git /var/cache/drone/github.com/drone/drone")
+	f.WriteCmd("git clone --depth=0 --recursive --branch=master git://github.com/drone/drone.git /var/cache/drone/github.com/drone/drone")
 	f.WriteCmd("git fetch origin +refs/pull/123/head:refs/remotes/origin/pr/123")
 	f.WriteCmd("git checkout -qf -b pr/123 origin/pr/123")
 

--- a/shared/build/repo/repo.go
+++ b/shared/build/repo/repo.go
@@ -114,7 +114,7 @@ func (r *Repo) Commands() []string {
 	cmds := []string{}
 	if len(r.PR) > 0 {
 		// If a specific PR is provided then we need to clone it.
-		cmds = append(cmds, fmt.Sprintf("git clone --depth=%d --recursive %s %s", r.Depth, r.Path, r.Dir))
+		cmds = append(cmds, fmt.Sprintf("git clone --depth=%d --recursive --branch=%s %s %s", r.Depth, branch, r.Path, r.Dir))
 		cmds = append(cmds, fmt.Sprintf("git fetch origin +refs/pull/%s/head:refs/remotes/origin/pr/%s", r.PR, r.PR))
 		cmds = append(cmds, fmt.Sprintf("git checkout -qf -b pr/%s origin/pr/%s", r.PR, r.PR))
 	} else {


### PR DESCRIPTION
### Problem

When running CI against a pull request, `master` will be cloned instead of the pull request branch. This leads to problems like when the master branch has submodules on different versions than the pull request branch, and causes unecessary failures when running tests.

### Proposed solution

When cloning during PR build, clone specific branch just like with generic builds.