### PR TITLE
Changes to SSH for private repo in gogs

### DIFF
--- a/plugin/remote/gogs/gogs.go
+++ b/plugin/remote/gogs/gogs.go
@@ -121,6 +121,10 @@ func (r *Gogs) GetRepos(user *model.User) ([]*model.Repo, error) {
 			},
 		}
 
+		if repo.Private {
+			repo.CloneURL = repo.SSHURL
+		}
+
 		repos = append(repos, &repo)
 	}
 


### PR DESCRIPTION
Hi, I needed to access my private gogs repos from my own docker, therefore I just added some code from other providers (gitlab, github). There were some answers in drone/drone#860 that helped me to understand.

It works for me. But I don't know if there are other specific things I should know and code about.

But simply changing the clone url to SSH and manually copying the ssh keys from drone to gogs worked flawlessly.

And… Thanks for drone! Pretty great project!