### PR TITLE
RFC7239 : Standard header for SSL proxy forwarding

### DIFF
--- a/shared/httputil/httputil.go
+++ b/shared/httputil/httputil.go
@@ -5,6 +5,15 @@ import (
 	"strings"
 )
 
+func hasHttpsForwarded(r *http.Request) bool {
+	forwardedHeader := r.Header["Forwarded"]
+	for _, w := range forwardedHeader {
+		strings.Contains(w, "proto=https")
+		return true
+	}
+	return false
+}
+
 // IsHttps is a helper function that evaluates the http.Request
 // and returns True if the Request uses HTTPS. It is able to detect,
 // using the X-Forwarded-Proto, if the original request was HTTPS and
@@ -17,7 +26,7 @@ func IsHttps(r *http.Request) bool {
 		return true
 	case strings.HasPrefix(r.Proto, "HTTPS"):
 		return true
-	case r.Header.Get("X-Forwarded-Proto") == "https":
+	case hasHttpsForwarded(r):
 		return true
 	default:
 		return false
@@ -29,18 +38,10 @@ func IsHttps(r *http.Request) bool {
 // using the X-Forwarded-Proto, if the original request was HTTPS
 // and routed through a reverse proxy with SSL termination.
 func GetScheme(r *http.Request) string {
-	switch {
-	case r.URL.Scheme == "https":
+	if IsHttps(r) {
 		return "https"
-	case r.TLS != nil:
-		return "https"
-	case strings.HasPrefix(r.Proto, "HTTPS"):
-		return "https"
-	case r.Header.Get("X-Forwarded-Proto") == "https":
-		return "https"
-	default:
-		return "http"
 	}
+	return "http"
 }
 
 // GetHost is a helper function that evaluates the http.Request


### PR DESCRIPTION
Hi,
Having misconfigured my nginx headers, my gogs instance didn't get the right webhook URL. It was registered with the "http://" scheme.
Trying to understand how to fix it, I found http://stackoverflow.com/questions/13111080/what-is-a-full-specification-of-x-forwarded-proto-http-header . Since this RFC dates from 2014, I guess it could be a good thing to comply to it.

Keeping the old header to it could also be done, but I guess it is better to move forward, or else we should even implement all the possibilities in the wild : http://stackoverflow.com/questions/16042647/whats-the-de-facto-standard-for-a-reverse-proxy-to-tell-the-backend-ssl-is-used

What do you think?