### PR TITLE
Label tag events for GitHub hooks

### DIFF
--- a/remote/github/github.go
+++ b/remote/github/github.go
@@ -345,6 +345,10 @@ func (g *Github) push(r *http.Request) (*model.Repo, *model.Build, error) {
 	if build.Ref == "refs/heads/gh-pages" {
 		return nil, nil, nil
 	}
+	if strings.HasPrefix(build.Ref, "refs/tags/") {
+		// just kidding, this is actually a tag event
+		build.Event = model.EventTag
+	}
 
 	return repo, build, nil
 }


### PR DESCRIPTION
This pull requests uses a special "tag" label for tags. This allows you to enable or disable building tags via the Repository settings. It also allows you to enable or disable build steps for tags (great for deployments and releases)