### PR TITLE
Add link from installation to upgrade instructions

### DIFF
--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -22,6 +22,8 @@ sudo docker run \
 
 Drone is now running (in the background) on `http://localhost:80`. Note that before running you should create the `--env-file` and add your Drone configuration (GitHub, Bitbucket, GitLab credentials, etc).
 
+Drone is built continuously, with updates available daily. See the [upgrading documentation](upgrade.html) for details.
+
 ## Docker options
 
 Here are some of the Docker options, explained:


### PR DESCRIPTION
This is a followup to #1274, where I didn't notice that 0.4 was a breaking release.
The upgrading documentation mentions this, but I was looking on the installation instructions page and missed the link in the sidebar.
Hopefully this change will prevent someone else from making the same mistake in the future.