### PR TITLE
Display full name of repository in list

### DIFF
--- a/template/amber/repos.amber
+++ b/template/amber/repos.amber
@@ -32,8 +32,7 @@ block content
                                     else
                                         img.avatar[src="/static/images/dummy.png"]
                                 div.card-block
-                                    h3.login #{$repo.Name}
-                                    div.full_name.hidden #{$repo.FullName}
+                                    h3.full_name #{$repo.FullName}
 
 block append scripts
     if len(Repos) != 0


### PR DESCRIPTION
Consider the following:

![Drone CI dashboard, with a search for "small-label-frontend" entered. Two different repositories have come up, both with the name "Small-Label-Frontend" and no way to tell the two apart.](https://cloud.githubusercontent.com/assets/2261204/11002858/41be41da-847d-11e5-92c8-1c6000b5bc9e.png)

One of these is the main repository; the other one is my personal fork. There's no way of telling which is which without hovering over them and looking at the URL.

Drone 0.3 did not have this problem, as it showed the full repository name, with group. This patch changes the dashboard in 0.4 to do the same thing.