### PR TITLE
Enable vendoring for github.com/go-swagger dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ deps:
 	go get -u github.com/franela/goblin
 	go get -u github.com/PuerkitoBio/goquery
 	go get -u github.com/russross/blackfriday
-	GO15VENDOREXPERIMENT=0 go get -u github.com/go-swagger/go-swagger/...
+	GO15VENDOREXPERIMENT=1 go get -u github.com/go-swagger/go-swagger/...
 
 gen: gen_static gen_template gen_migrations
 


### PR DESCRIPTION
Building in a Docker container based on `golang` doesn't work at `427560a`: C.f https://github.com/drone/drone/commit/2d37d66e2d5ef0de221339a7d010fabf94b12d79