### PR TITLE
Publish section example for tag pushes

### DIFF
--- a/docs/build/publish.md
+++ b/docs/build/publish.md
@@ -30,4 +30,10 @@ publish:
   bintray:
     when:
       branch: feature/*
+      
+  # or only publish when a tag is pushed
+  
+  docker:
+    when:
+      event: tag
 ```


### PR DESCRIPTION
Adds an example for execution limiting publishes to situations where tags are pushed.