### PR TITLE
gitgnore Jetbrains .idea dirs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ temp/
 
 vendor/google.golang.org/cloud
 vendor/github.com/bugagazavr
+
+# IDE/Editor stuff
+.idea


### PR DESCRIPTION
I think all or most of the Jetbrains IDEs stick an `.idea` directory at the root of each project. Since the IDEA Go plugin is actually pretty good, we'll probably end up with some people other than myself running into unstaged .idea dirs when committing. 

To prevent any potential mis-haps, this PR gitignores `.idea`. Because I will almost certainly end up accidentally adding/pushing it in the future otherwise :)