### PR TITLE
Add support for Bitbucket build status

### DIFF
--- a/remote/bitbucket/client.go
+++ b/remote/bitbucket/client.go
@@ -30,6 +30,7 @@ const (
 	pathHook   = "%s/2.0/repositories/%s/%s/hooks/%s"
 	pathHooks  = "%s/2.0/repositories/%s/%s/hooks?%s"
 	pathSource = "%s/1.0/repositories/%s/%s/src/%s/%s"
+	pathStatus = "%s/2.0/repositories/%s/%s/commit/%s/statuses/build"
 )
 
 type Client struct {
@@ -131,6 +132,11 @@ func (c *Client) FindSource(owner, name, revision, path string) (*Source, error)
 	uri := fmt.Sprintf(pathSource, base, owner, name, revision, path)
 	err := c.do(uri, get, nil, out)
 	return out, err
+}
+
+func (c *Client) CreateStatus(owner, name, revision string, status *BuildStatus) error {
+	uri := fmt.Sprintf(pathStatus, base, owner, name, revision)
+	return c.do(uri, post, status, nil)
 }
 
 func (c *Client) do(rawurl, method string, in, out interface{}) error {

--- a/remote/bitbucket/types.go
+++ b/remote/bitbucket/types.go
@@ -21,6 +21,14 @@ type AccountResp struct {
 	Values []*Account `json:"values"`
 }
 
+type BuildStatus struct {
+	State   string    `json:"state"`
+	Key     string    `json:"key"`
+	Name    string    `json:"name,omitempty"`
+	Url     string    `json:"url"`
+	Desc    string    `json:"description,omitempty"`
+}
+
 type Email struct {
 	Email       string `json:"email"`
 	IsConfirmed bool   `json:"is_confirmed"`


### PR DESCRIPTION
Adds Drone support for the [recently announced Bitbucket build status API](https://blog.bitbucket.org/2015/11/18/introducing-the-build-status-api-for-bitbucket-cloud/). 

![screenshot from 2015-11-21 17 03 51](https://cloud.githubusercontent.com/assets/226707/11317022/0079a560-9072-11e5-91b8-7b64277151ab.png)