### PR TITLE
Temporary bandaid to fix Bitbucket case sensitivity.

### DIFF
--- a/remote/bitbucket/helper.go
+++ b/remote/bitbucket/helper.go
@@ -11,8 +11,8 @@ import (
 // repository structure to the common Drone repository structure.
 func convertRepo(from *Repo) *model.Repo {
 	repo := model.Repo{
-		Owner:     from.Owner.Login,
-		Name:      from.Name,
+		Owner:     strings.Split(from.FullName, "/")[0],
+		Name:      strings.Split(from.FullName, "/")[1],
 		FullName:  from.FullName,
 		Link:      from.Links.Html.Href,
 		IsPrivate: from.IsPrivate,
@@ -93,8 +93,8 @@ func cloneLink(repo Repo) string {
 // repository structure to the simplified Drone repository structure.
 func convertRepoLite(from *Repo) *model.RepoLite {
 	return &model.RepoLite{
-		Owner:    from.Owner.Login,
-		Name:     from.Name,
+		Owner:    strings.Split(from.FullName, "/")[0],
+		Name:     strings.Split(from.FullName, "/")[1],
 		FullName: from.FullName,
 		Avatar:   from.Owner.Links.Avatar.Href,
 	}


### PR DESCRIPTION
As per #1345, Bitbucket repos that have uppercase letters are currently failing. This PR splits on FullName, which is lowercase. This will avoid the issues inherent with concatenating owner + Name (which can have mixed case which causes the API errors).

**Limitations:**
* All bitbucket repositories will now show up as lowercase in Drone.