### PR TITLE
Restores the .deb structure in downloads.drone.io

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -29,7 +29,7 @@ publish:
     access_key: $$AWS_KEY
     secret_key: $$AWS_SECRET
     source: contrib/debian/drone.deb
-    target: drone/0.4
+    target: $$BRANCH/
     when:
       repo: drone/drone
 


### PR DESCRIPTION
The current `drone.deb` address is `downloads.drone.io/drone/0.4` (master branch).
It's very different from other version, for example:

* Branch 0.4.0: `downloads.drone.io/0.4.0/drone.deb`
* Branch 0.3.1: `downloads.drone.io/master/drone.deb`

I suggest to restore `target: $$BRANCH/` or update it to `target: 0.4.0/`