### PR TITLE
Fixed REMOTE_CONFIG

### DIFF
--- a/contrib/debian/drone/etc/drone/dronerc
+++ b/contrib/debian/drone/etc/drone/dronerc
@@ -13,11 +13,8 @@ DATABASE_CONFIG="/var/lib/drone/drone.sqlite"
 
 # remote configuration
 
-CLIENT="" # oauth2 client. REQUIRED
-SECRET="" # oauth2 secret. REQUIRED
-
 REMOTE_DRIVER="github"
-REMOTE_CONFIG="https://github.com?client_id=$CLIENT&client_secret=$SECRET"
+REMOTE_CONFIG="https://github.com?client_id=<your_client_id>&client_secret=<your_secret>"
 
 # docker configuration
 

--- a/contrib/debian/drone/etc/drone/dronerc
+++ b/contrib/debian/drone/etc/drone/dronerc
@@ -2,27 +2,27 @@
 
 # server configuration
 
-SERVER_ADDR=":80"
-#SERVER_CERT=""
-#SERVER_KEY=""
+SERVER_ADDR=:80
+#SERVER_CERT=
+#SERVER_KEY=
 
 # database configuration
 
-DATABASE_DRIVER="sqlite3"
-DATABASE_CONFIG="/var/lib/drone/drone.sqlite"
+DATABASE_DRIVER=sqlite3
+DATABASE_CONFIG=/var/lib/drone/drone.sqlite
 
 # remote configuration
 
-REMOTE_DRIVER="github"
-REMOTE_CONFIG="https://github.com?client_id=<your_client_id>&client_secret=<your_secret>"
+REMOTE_DRIVER=github
+REMOTE_CONFIG=https://github.com?client_id=<your_client_id>&client_secret=<your_secret>
 
 # docker configuration
 
-DOCKER_HOST="unix:///var/run/docker.sock"
-#DOCKER_CERT=""
-#DOCKER_KEY=""
-#DOCKER_CA=""
+DOCKER_HOST=unix:///var/run/docker.sock
+#DOCKER_CERT=
+#DOCKER_KEY=
+#DOCKER_CA=
 
 # plugin configuration
 
-PLUGIN_FILTER="plugins/*"
+PLUGIN_FILTER=plugins/*


### PR DESCRIPTION
Variable interpolation does not seem to work (Drone 0.4). Using the old sample code, Drone just sent `...?client_id=%24%7BCLIENT%7D&...` to GitHub, which resulted in a 404 error.

Further, quotes in variables lead to problems - e.g. with plug-in whitelisting. So, I've removed them.

I think, many people copy the sample `dronerc` and will run into this. So it would be good to start with a working config file.