### PR TITLE
skip build with any combination of "skip" and "ci"

### DIFF
--- a/controller/hook.go
+++ b/controller/hook.go
@@ -43,9 +43,9 @@ func PostHook(c *gin.Context) {
 
 	// skip the build if any case-insensitive combination of the words "skip" and "ci"
 	// wrapped in square brackets appear in the commit message
-	skipMatches := skipRe.FindStringSubmatch(build.Message)
-	if len(skipMatches) > 0 {
-		log.Infof("ignoring hook. %s found in %s", skipMatches[0], build.Commit)
+	skipMatch := skipRe.FindString(build.Message)
+	if len(skipMatch) > 0 {
+		log.Infof("ignoring hook. %s found in %s", skipMatch, build.Commit)
 		c.Writer.WriteHeader(204)
 		return
 	}

--- a/controller/hook.go
+++ b/controller/hook.go
@@ -20,6 +20,8 @@ import (
 	"github.com/drone/drone/yaml/matrix"
 )
 
+var skipRe = regexp.MustCompile(`\[(?i:ci *skip|skip *ci)\]`)
+
 func PostHook(c *gin.Context) {
 	remote_ := remote.FromContext(c)
 
@@ -41,7 +43,6 @@ func PostHook(c *gin.Context) {
 
 	// skip the build if any case-insensitive combination of the words "skip" and "ci"
 	// wrapped in square brackets appear in the commit message
-	skipRe := regexp.MustCompile(`\[(?i:ci *skip|skip *ci)\]`)
 	skipMatches := skipRe.FindStringSubmatch(build.Message)
 	if len(skipMatches) > 0 {
 		log.Infof("ignoring hook. %s found in %s", skipMatches[0], build.Commit)

--- a/docs/build/build.md
+++ b/docs/build/build.md
@@ -48,4 +48,5 @@ image: index.docker.io/library/golang:1.4
 
 ## Skipping builds
 
-Skip a build by including the text `[CI SKIP]` in your commit message.
+Skip a build by including any combination of `ci` and `skip` wrapped in square brackets
+in your commit message. Examples: `[skip CI]` `[ci skip]`


### PR DESCRIPTION
a commit message containing any case-insensitive variant of the above two words wrapped in square brackets will skip the build.
examples: `[ci skip]`, `[skip CI]`

this reintroduces pr #1134 and additionally logs the matched skip instruction.

i have the code, you have the tests since i don't have sufficient testing infrastructure in place.
let me know if anything's stupid.