### PR TITLE
Make the build agent image name configurable

### DIFF
--- a/engine/util.go
+++ b/engine/util.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"encoding/json"
+	"os"
 )
 
 func encodeToLegacyFormat(t *Task) ([]byte, error) {
@@ -32,4 +33,12 @@ func encodeToLegacyFormat(t *Task) ([]byte, error) {
 	// 	},
 	// }
 	return json.Marshal(t)
+}
+
+func getenvDefault(varname, value string) string {
+	v := os.Getenv(varname)
+	if v == "" {
+		return value
+	}
+	return v
 }

--- a/engine/worker.go
+++ b/engine/worker.go
@@ -46,7 +46,7 @@ func (w *worker) Build(name string, stdin []byte, pr bool) (_ int, err error) {
 	args = append(args, string(stdin))
 
 	conf := &dockerclient.ContainerConfig{
-		Image:      DefaultAgent,
+		Image:      getenvDefault("AGENT", DefaultAgent),
 		Entrypoint: DefaultEntrypoint,
 		Cmd:        args,
 		HostConfig: dockerclient.HostConfig{


### PR DESCRIPTION
This should simplify things for people who want to hack on drone-exec.