### PR TITLE
Make GitHub status API context congruous

### DIFF
--- a/remote/github/github.go
+++ b/remote/github/github.go
@@ -230,7 +230,7 @@ func (g *Github) Status(u *model.User, r *model.Repo, b *model.Build, link strin
 	status := getStatus(b.Status)
 	desc := getDesc(b.Status)
 	data := github.RepoStatus{
-		Context:     github.String("Drone"),
+		Context:     github.String("continuous-integration/drone"),
 		State:       github.String(status),
 		Description: github.String(desc),
 		TargetURL:   github.String(link),


### PR DESCRIPTION
Tiny change to make the status api message congruous with all the other CI services out there.