### PR TITLE
Append reponame to ssh keys

### DIFF
--- a/template/amber/repo_config.amber
+++ b/template/amber/repo_config.amber
@@ -68,7 +68,7 @@ block content
         div.row
             div.col-md-3 Public Key
             div.col-md-9
-                pre #{Key.Public}
+                pre #{Key.Public} #{Repo.Owner}-#{Repo.Name}@drone
         div.row
             div.col-md-12
                 div.alert.alert-danger


### PR DESCRIPTION
Currently drone SSH keys only show

    ssh-rsa AAA.....AAA

This PR appends a name to each repos SSH key so you can identify the key when you post it to a different service or `authorized_keys` file:

    ssh-rsa AAA.....AAA owner-repo@drone

Fixes #565