### PR TITLE
Corrects CC Menu url

### DIFF
--- a/controller/badge.go
+++ b/controller/badge.go
@@ -1,9 +1,12 @@
 package controller
 
 import (
+	"fmt"
+
 	"github.com/gin-gonic/gin"
 
 	"github.com/drone/drone/model"
+	"github.com/drone/drone/shared/httputil"
 	"github.com/drone/drone/store"
 )
 
@@ -73,6 +76,7 @@ func GetCC(c *gin.Context) {
 		return
 	}
 
-	cc := model.NewCC(repo, builds[0], "")
+	url := fmt.Sprintf("%s/%s/%d", httputil.GetURL(c.Request), repo.FullName, builds[0].Number)
+	cc := model.NewCC(repo, builds[0], url)
 	c.XML(200, cc)
 }


### PR DESCRIPTION
CC Menu URL was an empty placeholder. This completes it with the URL of the build.