### PR TITLE
fix: gitlab owner has admin privileges

### DIFF
--- a/remote/gitlab/gitlab.go
+++ b/remote/gitlab/gitlab.go
@@ -198,6 +198,13 @@ func (g *Gitlab) Perm(u *model.User, owner, name string) (*model.Perm, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// repo owner are granted full access
+	if u.Login == repo.Owner.Username {
+	   return &model.Perm{true, true, true}, nil
+	}
+
+	// check permission for users
 	m := &model.Perm{}
 	m.Admin = IsAdmin(repo)
 	m.Pull = IsRead(repo)

--- a/remote/gitlab/gitlab.go
+++ b/remote/gitlab/gitlab.go
@@ -199,12 +199,12 @@ func (g *Gitlab) Perm(u *model.User, owner, name string) (*model.Perm, error) {
 		return nil, err
 	}
 
-	// repo owner are granted full access
-	if u.Login == repo.Owner.Username {
+	// repo owner is granted full access
+	if repo.Owner != nil && repo.Owner.Username == u.Login {
 	   return &model.Perm{true, true, true}, nil
 	}
 
-	// check permission for users
+	// check permission for current user
 	m := &model.Perm{}
 	m.Admin = IsAdmin(repo)
 	m.Pull = IsRead(repo)

--- a/remote/gitlab/gitlab_test.go
+++ b/remote/gitlab/gitlab_test.go
@@ -54,13 +54,18 @@ func Test_Gitlab(t *testing.T) {
 		g.Describe("Perm", func() {
 			g.It("Should return repo permissions", func() {
 				perm, err := gitlab.Perm(&user, "diaspora", "diaspora-client")
-
 				g.Assert(err == nil).IsTrue()
 				g.Assert(perm.Admin).Equal(true)
 				g.Assert(perm.Pull).Equal(true)
 				g.Assert(perm.Push).Equal(true)
 			})
-
+			g.It("Should return repo permissions when user is admin", func() {
+				perm, err := gitlab.Perm(&user, "brightbox", "puppet")
+				g.Assert(err == nil).IsTrue()
+				g.Assert(perm.Admin).Equal(true)
+				g.Assert(perm.Pull).Equal(true)
+				g.Assert(perm.Push).Equal(true)
+			})
 			g.It("Should return error, when repo is not exist", func() {
 				_, err := gitlab.Perm(&user, "not-existed", "not-existed")
 

--- a/remote/gitlab/testdata/projects.go
+++ b/remote/gitlab/testdata/projects.go
@@ -15,6 +15,7 @@ var projectsPayload = []byte(`
 		"owner": {
 			"id": 3,
 			"name": "Diaspora",
+			"username": "some_user",
 			"created_at": "2013-09-30T13: 46: 02Z"
 		},
 		"name": "Diaspora Client",
@@ -48,8 +49,9 @@ var projectsPayload = []byte(`
 		"http_url_to_repo": "http://example.com/brightbox/puppet.git",
 		"web_url": "http://example.com/brightbox/puppet",
 		"owner": {
-			"id": 4,
+			"id": 1,
 			"name": "Brightbox",
+			"username": "test_user",
 			"created_at": "2013-09-30T13:46:02Z"
 		},
 		"name": "Puppet",
@@ -89,6 +91,7 @@ var project4Paylod = []byte(`
 	"owner": {
 		"id": 3,
 		"name": "Diaspora",
+		"username": "some_user",
 		"created_at": "2013-09-30T13: 46: 02Z"
 	},
 	"name": "Diaspora Client",
@@ -135,8 +138,9 @@ var project6Paylod = []byte(`
 	"http_url_to_repo": "http://example.com/brightbox/puppet.git",
 	"web_url": "http://example.com/brightbox/puppet",
 	"owner": {
-	"id": 4,
+		"id": 1,
 		"name": "Brightbox",
+		"username": "test_user",
 		"created_at": "2013-09-30T13:46:02Z"
 	},
 	"name": "Puppet",
@@ -160,14 +164,8 @@ var project6Paylod = []byte(`
 	},
 	"archived": false,
 	"permissions": {
-		"project_access": {
-			"access_level": 10,
-			"notification_level": 3
-		},
-		"group_access": {
-			"access_level": 50,
-			"notification_level": 3
-		}
+		"project_access": null,
+		"group_access": null
 	}
 }
 `)

--- a/remote/gitlab/testdata/testdata.go
+++ b/remote/gitlab/testdata/testdata.go
@@ -21,6 +21,9 @@ func NewServer() *httptest.Server {
 		case "/api/v3/projects/diaspora/diaspora-client":
 			w.Write(project4Paylod)
 			return
+		case "/api/v3/projects/brightbox/puppet":
+			w.Write(project6Paylod)
+			return
 		case "/api/v3/projects/diaspora/diaspora-client/services/drone-ci":
 			switch r.Method {
 			case "PUT":
@@ -38,11 +41,7 @@ func NewServer() *httptest.Server {
 			w.Write(accessTokenPayload)
 			return
 		case "/api/v3/user":
-			if r.Header.Get("Authorization") == "Bearer valid_token" {
-				w.Write(currentUserPayload)
-			} else {
-				w.WriteHeader(401)
-			}
+			w.Write(currentUserPayload)
 			return
 		}
 


### PR DESCRIPTION
**user story**
Given a gitlab user
And a project the user owns
When the user activates the repo
Then the repo should be activated. 

**problem**
Currently, gitlab project owners don't have any permissions when they should have the same privileges as admin users.

**solution**
This patch checks if the current user owns a project, and assign the user Admin, Push and Pull permissions.
