### PR TITLE
Allow Gogs server on a subdirectory

### DIFF
--- a/docs/setup/gogs.md
+++ b/docs/setup/gogs.md
@@ -12,7 +12,7 @@ REMOTE_CONFIG=https://gogs.hooli.com?open=false
 The following is the standard URI connection scheme:
 
 ```
-scheme://host[:port][?options]
+scheme://host[:port][/path][?options]
 ```
 
 The components of this string are:
@@ -20,6 +20,7 @@ The components of this string are:
 * `scheme` server protocol `http` or `https`.
 * `host` server address to connect to. The default value is github.com if not specified.
 * `:port` optional. The default value is :80 if not specified.
+* `/path` optional. The default value is the root directory if not specified.
 * `?options` connection specific options.
 
 ## Gogs options

--- a/remote/gogs/gogs.go
+++ b/remote/gogs/gogs.go
@@ -30,7 +30,6 @@ func Load(env envconfig.Env) *Gogs {
 		log.Fatalln("unable to parse remote dsn. %s", err)
 	}
 	params := url_.Query()
-	url_.Path = ""
 	url_.RawQuery = ""
 
 	// create the Githbub remote using parameters from


### PR DESCRIPTION
The Gogs API already supports access on a server's subdirectory through routing through apache or nginx. By not clearing the path before passing the URL, drone works with this situation as well.