### PR TITLE
Change docker base image to busybox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,12 @@
 #
 #     docker build --rm=true -t drone/drone .
 
-FROM centurylink/ca-certs
+FROM busybox
 EXPOSE 8000
 ADD contrib/docker/etc/nsswitch.conf /etc/
+
+# Pulled from centurylin/ca-certs source.
+ADD https://raw.githubusercontent.com/CenturyLinkLabs/ca-certs-base-image/master/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 ENV DATABASE_DRIVER=sqlite3
 ENV DATABASE_CONFIG=/var/lib/drone/drone.sqlite


### PR DESCRIPTION
This changes the base image to busy box so that it can be extended
for use with /bin/sh scripts, and basic troubleshooting.

In order to keep changes to a minimum, I pulled the ca-certificates file from the centurylink/ca-certs image source.

Discussed in #1426 
