### PR TITLE
Add master build list endpoint for wall

### DIFF
--- a/controller/build.go
+++ b/controller/build.go
@@ -20,6 +20,15 @@ import (
 	"github.com/drone/drone/router/middleware/session"
 )
 
+func GetAllBuilds(c *gin.Context) {
+	builds, err := store.GetBuildMasterList(c)
+	if err != nil {
+		c.AbortWithStatus(http.StatusInternalServerError)
+		return
+	}
+	c.IndentedJSON(http.StatusOK, builds)
+}
+
 func GetBuilds(c *gin.Context) {
 	repo := session.Repo(c)
 	builds, err := store.GetBuildList(c, repo)

--- a/router/router.go
+++ b/router/router.go
@@ -59,6 +59,12 @@ func Load(middleware ...gin.HandlerFunc) http.Handler {
 		}
 	}
 
+	builds := e.Group("/api/builds")
+	{
+		builds.Use(session.MustAdmin())
+		builds.GET("", controller.GetAllBuilds)
+	}
+
 	user := e.Group("/api/user")
 	{
 		user.Use(session.MustUser())

--- a/store/builds.go
+++ b/store/builds.go
@@ -24,6 +24,9 @@ type BuildStore interface {
 	// GetLastBefore gets the last build before build number N.
 	GetLastBefore(*model.Repo, string, int64) (*model.Build, error)
 
+	// GetBuildMasterList gets a list of builds for the server
+	GetMasterList() ([]*model.Build, error)
+
 	// GetList gets a list of builds for the repository
 	GetList(*model.Repo) ([]*model.Build, error)
 
@@ -56,6 +59,10 @@ func GetBuildLast(c context.Context, repo *model.Repo, branch string) (*model.Bu
 
 func GetBuildLastBefore(c context.Context, repo *model.Repo, branch string, number int64) (*model.Build, error) {
 	return FromContext(c).Builds().GetLastBefore(repo, branch, number)
+}
+
+func GetBuildMasterList(c context.Context) ([]*model.Build, error) {
+	return FromContext(c).Builds().GetMasterList()
 }
 
 func GetBuildList(c context.Context, repo *model.Repo) ([]*model.Build, error) {

--- a/store/datastore/builds.go
+++ b/store/datastore/builds.go
@@ -48,6 +48,12 @@ func (db *buildstore) GetLastBefore(repo *model.Repo, branch string, num int64) 
 	return build, err
 }
 
+func (db *buildstore) GetMasterList() ([]*model.Build, error) {
+	var builds = []*model.Build{}
+	var err = meddler.QueryAll(db, &builds, rebind(buildMasterListQuery))
+	return builds, err
+}
+
 func (db *buildstore) GetList(repo *model.Repo) ([]*model.Build, error) {
 	var builds = []*model.Build{}
 	var err = meddler.QueryAll(db, &builds, rebind(buildListQuery), repo.ID)
@@ -81,6 +87,13 @@ func (db *buildstore) Update(build *model.Build) error {
 }
 
 const buildTable = "builds"
+
+const buildMasterListQuery = `
+SELECT *
+FROM builds
+ORDER BY build_number DESC
+LIMIT 50
+`
 
 const buildListQuery = `
 SELECT *

--- a/store/datastore/builds_test.go
+++ b/store/datastore/builds_test.go
@@ -241,5 +241,24 @@ func Test_buildstore(t *testing.T) {
 			g.Assert(builds[0].RepoID).Equal(build2.RepoID)
 			g.Assert(builds[0].Status).Equal(build2.Status)
 		})
+
+		g.It("Should get all recent Builds", func() {
+			build1 := &model.Build{
+				RepoID: 1,
+				Status: model.StatusFailure,
+			}
+			build2 := &model.Build{
+				RepoID: 1,
+				Status: model.StatusSuccess,
+			}
+			s.Builds().Create(build1, []*model.Job{}...)
+			s.Builds().Create(build2, []*model.Job{}...)
+			builds, err := s.Builds().GetMasterList()
+			g.Assert(err == nil).IsTrue()
+			g.Assert(len(builds)).Equal(2)
+			g.Assert(builds[0].ID).Equal(build2.ID)
+			g.Assert(builds[0].RepoID).Equal(build2.RepoID)
+			g.Assert(builds[0].Status).Equal(build2.Status)
+		})
 	})
 }


### PR DESCRIPTION
@bradrydzewski this adds a top level build list (similar to what we added to v3) that is necessary for drone-wall to operate.