### PR TITLE
Add public mode

### DIFF
--- a/router/middleware/session/repo.go
+++ b/router/middleware/session/repo.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"net/http"
+	"os"
 
 	"github.com/drone/drone/model"
 	"github.com/drone/drone/remote"
@@ -104,6 +105,8 @@ func Perm(c *gin.Context) *model.Perm {
 }
 
 func SetPerm() gin.HandlerFunc {
+	PUBLIC_MODE := os.Getenv("PUBLIC_MODE")
+
 	return func(c *gin.Context) {
 		user := User(c)
 		repo := Repo(c)
@@ -162,6 +165,11 @@ func SetPerm() gin.HandlerFunc {
 			if err != nil && repo.IsPrivate == false {
 				perm.Pull = true
 			}
+		}
+
+		// all build logs are visible in public mode
+		if PUBLIC_MODE != "" {
+			perm.Pull = true
 		}
 
 		if user != nil {

--- a/router/middleware/session/repo_test.go
+++ b/router/middleware/session/repo_test.go
@@ -1,0 +1,44 @@
+package session
+
+import (
+	"os"
+	"testing"
+
+	"github.com/drone/drone/model"
+	"github.com/franela/goblin"
+	"github.com/gin-gonic/gin"
+)
+
+func TestSetPerm(t *testing.T) {
+	g := goblin.Goblin(t)
+	g.Describe("SetPerm", func() {
+		g.BeforeEach(func() {
+			os.Unsetenv("PUBLIC_MODE")
+		})
+		g.It("Should set pull to false (private repo, user not logged in)", func() {
+			c := gin.Context{}
+			c.Set("repo", &model.Repo{
+				IsPrivate: true,
+			})
+			SetPerm()(&c)
+			v, ok := c.Get("perm")
+			g.Assert(ok).IsTrue("perm was not set")
+			p, ok := v.(*model.Perm)
+			g.Assert(ok).IsTrue("perm was the wrong type")
+			g.Assert(p.Pull).IsFalse("pull should be false")
+		})
+		g.It("Should set pull to true (private repo, user not logged in, public mode)", func() {
+			os.Setenv("PUBLIC_MODE", "true")
+			c := gin.Context{}
+			c.Set("repo", &model.Repo{
+				IsPrivate: true,
+			})
+			SetPerm()(&c)
+			v, ok := c.Get("perm")
+			g.Assert(ok).IsTrue("perm was not set")
+			p, ok := v.(*model.Perm)
+			g.Assert(ok).IsTrue("perm was the wrong type")
+			g.Assert(p.Pull).IsTrue("pull should be true")
+		})
+	})
+}


### PR DESCRIPTION
This change adds a public mode, which makes build logs visible to users who are not logged in. To activate public mode, set the environment variable `PUBLIC_MODE=true`

In my current setup (Gitlab & Drone running behind a corporate firewall) most users don't care about Drone or logging into Drone, they just want to get their changes merged. In the case of a failed build I would like to be able to link to the build logs without the "confusion" of having them log in.

This allows me to send a build log link to a staff member who is not be a Gitlab user.