### PR TITLE
Login page instead of 404 for non-logged in users on repos page

### DIFF
--- a/router/middleware/session/repo.go
+++ b/router/middleware/session/repo.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/drone/drone/model"
 	"github.com/drone/drone/remote"
+	"github.com/drone/drone/shared/httputil"
 	"github.com/drone/drone/shared/token"
 	"github.com/drone/drone/store"
 
@@ -85,7 +86,14 @@ func SetRepo() gin.HandlerFunc {
 
 			c.HTML(http.StatusNotFound, "repo_activate.html", data)
 		} else {
-			c.HTML(http.StatusNotFound, "404.html", data)
+			if user == nil {
+				// setup the after-login path and prompt the user to login
+				currentPath := httputil.DenormalizePath(c.Request.URL.Path)
+				httputil.SetCookie(c.Writer, c.Request, "user_last", currentPath)
+				c.HTML(http.StatusNotFound, "login.html", data)
+			} else {
+				c.HTML(http.StatusNotFound, "404.html", data)
+			}
 		}
 
 		c.Abort()


### PR DESCRIPTION
Hi!

This pull request fixes #1266. Note that in order to implement the "go back after login" behavior, I needed to build some more magic on top of your router path normalization, if you see any better solution (or have any hints on how to improve this one), please let me know.

Cheers,
Marcin