### PR TITLE
allow explicit config of drone-exec image

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -296,7 +296,7 @@ func (e *engine) runJob(c context.Context, r *Task, updater *updater, client doc
 	args = append(args, string(in))
 
 	conf := &dockerclient.ContainerConfig{
-		Image:      DefaultAgent,
+		Image:      agentImage(),
 		Entrypoint: DefaultEntrypoint,
 		Cmd:        args,
 		Env:        e.envs,
@@ -400,7 +400,7 @@ func (e *engine) runJobNotify(r *Task, client dockerclient.Client) error {
 	args = append(args, string(in))
 
 	conf := &dockerclient.ContainerConfig{
-		Image:      DefaultAgent,
+		Image:      agentImage(),
 		Entrypoint: DefaultEntrypoint,
 		Cmd:        args,
 		Env:        e.envs,

--- a/engine/worker.go
+++ b/engine/worker.go
@@ -1,12 +1,6 @@
 package engine
 
-import (
-	"fmt"
-	"io"
-
-	"github.com/drone/drone/shared/docker"
-	"github.com/samalba/dockerclient"
-)
+import "os"
 
 var (
 	// name of the build agent container.
@@ -25,91 +19,10 @@ var (
 	DefaultNotifyArgs = []string{"--pull", "--notify"}
 )
 
-type worker struct {
-	client dockerclient.Client
-	build  *dockerclient.ContainerInfo
-	notify *dockerclient.ContainerInfo
-}
-
-func newWorker(client dockerclient.Client) *worker {
-	return &worker{client: client}
-}
-
-// Build executes the clone, build and deploy steps.
-func (w *worker) Build(name string, stdin []byte, pr bool) (_ int, err error) {
-	// the command line arguments passed into the
-	// build agent container.
-	args := DefaultBuildArgs
-	if pr {
-		args = DefaultPullRequestArgs
-	}
-	args = append(args, "--")
-	args = append(args, string(stdin))
-
-	conf := &dockerclient.ContainerConfig{
-		Image:      DefaultAgent,
-		Entrypoint: DefaultEntrypoint,
-		Cmd:        args,
-		HostConfig: dockerclient.HostConfig{
-			Binds: []string{"/var/run/docker.sock:/var/run/docker.sock"},
-		},
-		Volumes: map[string]struct{}{
-			"/var/run/docker.sock": struct{}{},
-		},
+func agentImage() string {
+	if os.Getenv("DRONE_EXEC_IMAGE") != "" {
+		return os.Getenv("DRONE_EXEC_IMAGE")
 	}
 
-	// TEMPORARY: always try to pull the new image for now
-	// since we'll be frequently updating the build image
-	// for the next few weeks
-	w.client.PullImage(conf.Image, nil)
-
-	w.build, err = docker.Run(w.client, conf, name)
-	if err != nil {
-		return 1, err
-	}
-	if w.build.State.OOMKilled {
-		return 1, fmt.Errorf("OOMKill received")
-	}
-	return w.build.State.ExitCode, err
-}
-
-// Notify executes the notification steps.
-func (w *worker) Notify(stdin []byte) error {
-
-	args := DefaultNotifyArgs
-	args = append(args, "--")
-	args = append(args, string(stdin))
-
-	conf := &dockerclient.ContainerConfig{
-		Image:      DefaultAgent,
-		Entrypoint: DefaultEntrypoint,
-		Cmd:        args,
-		HostConfig: dockerclient.HostConfig{},
-	}
-
-	var err error
-	w.notify, err = docker.Run(w.client, conf, "")
-	return err
-}
-
-// Logs returns a multi-reader that fetches the logs
-// from the build and deploy agents.
-func (w *worker) Logs() (io.ReadCloser, error) {
-	if w.build == nil {
-		return nil, errLogging
-	}
-	return w.client.ContainerLogs(w.build.Id, logOpts)
-}
-
-// Remove stops and removes the build, deploy and
-// notification agents created for the build task.
-func (w *worker) Remove() {
-	if w.notify != nil {
-		w.client.KillContainer(w.notify.Id, "9")
-		w.client.RemoveContainer(w.notify.Id, true, true)
-	}
-	if w.build != nil {
-		w.client.KillContainer(w.build.Id, "9")
-		w.client.RemoveContainer(w.build.Id, true, true)
-	}
+	return DefaultAgent
 }


### PR DESCRIPTION
I'd like to be able to build and pin my own `drone-exec` image tags for developing and testing new features.
