### PR TITLE
resume waiting for the container to complete

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -329,6 +329,11 @@ func (e *engine) runJob(c context.Context, r *Task, updater *updater, client doc
 	info, builderr := docker.Wait(client, name)
 
 	switch {
+	case info.State.Running:
+		// A build unblocked before actually being completed.
+		log.Errorf("incomplete build: %s", name)
+		r.Job.ExitCode = 1
+		r.Job.Status = model.StatusError
 	case info.State.ExitCode == 128:
 		r.Job.ExitCode = info.State.ExitCode
 		r.Job.Status = model.StatusKilled


### PR DESCRIPTION
This backports the resuming of tailing logs introduced in https://github.com/drone/drone-exec/pull/26 as well as the marking of incomplete builds as errors similar to https://github.com/drone/drone-exec/commit/7dc4524fc4c8115d1dcc6cc5027f75606a3069ea.