### PR TITLE
Add ability to hide Archived projects from Gitlab

### DIFF
--- a/docs/setup/gitlab.md
+++ b/docs/setup/gitlab.md
@@ -33,6 +33,7 @@ This section lists all connection options used in the connection string format. 
 * `open=false` allows users to self-register. Defaults to false for security reasons.
 * `orgs=drone&orgs=docker` restricts access to these GitLab organizations. **Optional**
 * `skip_verify=false` skip ca verification if self-signed certificate. Defaults to false for security reasons.
+* `hide_archives=false` hide projects archived in GitLab from the listing.
 * `clone_mode=token` a strategy for clone authorization, by default use repo token, but can be changed to `oauth` ( This is not secure, because your user token, with full access to your gitlab account will be written to .netrc, and it can be read by all who have access to project builds )
 
 ## Gitlab registration

--- a/remote/gitlab/client/project.go
+++ b/remote/gitlab/client/project.go
@@ -15,12 +15,12 @@ const (
 )
 
 // Get a list of all projects owned by the authenticated user.
-func (g *Client) AllProjects() ([]*Project, error) {
+func (g *Client) AllProjects(hide_archives bool) ([]*Project, error) {
 	var per_page = 100
 	var projects []*Project
 
 	for i := 1; true; i++ {
-		contents, err := g.Projects(i, per_page)
+		contents, err := g.Projects(i, per_page, hide_archives)
 		if err != nil {
 			return projects, err
 		}
@@ -42,12 +42,17 @@ func (g *Client) AllProjects() ([]*Project, error) {
 }
 
 // Get a list of projects owned by the authenticated user.
-func (c *Client) Projects(page int, per_page int) ([]*Project, error) {
-
-	url, opaque := c.ResourceUrl(projectsUrl, nil, QMap{
+func (c *Client) Projects(page int, per_page int, hide_archives bool) ([]*Project, error) {
+	projectsOptions := QMap{
 		"page":     strconv.Itoa(page),
 		"per_page": strconv.Itoa(per_page),
-	})
+	}
+
+	if hide_archives {
+		projectsOptions["archived"] = "false"
+	}
+
+	url, opaque := c.ResourceUrl(projectsUrl, nil, projectsOptions)
 
 	var projects []*Project
 

--- a/remote/gitlab/gitlab.go
+++ b/remote/gitlab/gitlab.go
@@ -23,15 +23,16 @@ const (
 )
 
 type Gitlab struct {
-	URL         string
-	Client      string
-	Secret      string
-	AllowedOrgs []string
-	CloneMode   string
-	Open        bool
-	PrivateMode bool
-	SkipVerify  bool
-	Search      bool
+	URL         		string
+	Client      		string
+	Secret      		string
+	AllowedOrgs 		[]string
+	CloneMode   		string
+	Open        		bool
+	PrivateMode 		bool
+	SkipVerify  		bool
+	HideArchives		bool
+	Search      		bool
 }
 
 func Load(env envconfig.Env) *Gitlab {
@@ -50,6 +51,7 @@ func Load(env envconfig.Env) *Gitlab {
 	gitlab.Secret = params.Get("client_secret")
 	gitlab.AllowedOrgs = params["orgs"]
 	gitlab.SkipVerify, _ = strconv.ParseBool(params.Get("skip_verify"))
+	gitlab.HideArchives, _ = strconv.ParseBool(params.Get("hide_archives"))
 	gitlab.Open, _ = strconv.ParseBool(params.Get("open"))
 
 	switch params.Get("clone_mode") {
@@ -170,7 +172,7 @@ func (g *Gitlab) Repos(u *model.User) ([]*model.RepoLite, error) {
 
 	var repos = []*model.RepoLite{}
 
-	all, err := client.AllProjects()
+	all, err := client.AllProjects(g.HideArchives)
 	if err != nil {
 		return repos, err
 	}

--- a/remote/gitlab/gitlab_test.go
+++ b/remote/gitlab/gitlab_test.go
@@ -32,6 +32,25 @@ func Test_Gitlab(t *testing.T) {
 
 	g := goblin.Goblin(t)
 	g.Describe("Gitlab Plugin", func() {
+		// Test projects method
+		g.Describe("AllProjects", func() {
+			g.It("Should return only non-archived projects is hidden", func() {
+				gitlab.HideArchives = true
+				_projects, err := gitlab.Repos(&user)
+
+				g.Assert(err == nil).IsTrue()
+				g.Assert(len(_projects)).Equal(1)
+			})
+
+			g.It("Should return all the projects", func() {
+				gitlab.HideArchives = false
+				_projects, err := gitlab.Repos(&user)
+
+				g.Assert(err == nil).IsTrue()
+				g.Assert(len(_projects)).Equal(2)
+			})
+		})
+
 		// Test repository method
 		g.Describe("Repo", func() {
 			g.It("Should return valid repo", func() {

--- a/remote/gitlab/testdata/projects.go
+++ b/remote/gitlab/testdata/projects.go
@@ -1,7 +1,7 @@
 package testdata
 
 // sample repository list
-var projectsPayload = []byte(`
+var allProjectsPayload = []byte(`
 [
 	{
 		"id": 4,
@@ -72,6 +72,47 @@ var projectsPayload = []byte(`
 			"owner_id": 1,
 			"path": "brightbox",
 			"updated_at": "2013-09-30T13:46:02Z"
+		},
+		"archived": true
+	}
+]
+`)
+
+var notArchivedProjectsPayload = []byte(`
+[
+	{
+		"id": 4,
+		"description": null,
+		"default_branch": "master",
+		"public": false,
+		"visibility_level": 0,
+		"ssh_url_to_repo": "git@example.com:diaspora/diaspora-client.git",
+		"http_url_to_repo": "http://example.com/diaspora/diaspora-client.git",
+		"web_url": "http://example.com/diaspora/diaspora-client",
+		"owner": {
+			"id": 3,
+			"name": "Diaspora",
+			"username": "some_user",
+			"created_at": "2013-09-30T13: 46: 02Z"
+		},
+		"name": "Diaspora Client",
+		"name_with_namespace": "Diaspora / Diaspora Client",
+		"path": "diaspora-client",
+		"path_with_namespace": "diaspora/diaspora-client",
+		"issues_enabled": true,
+		"merge_requests_enabled": true,
+		"wiki_enabled": true,
+		"snippets_enabled": false,
+		"created_at": "2013-09-30T13: 46: 02Z",
+		"last_activity_at": "2013-09-30T13: 46: 02Z",
+		"namespace": {
+			"created_at": "2013-09-30T13: 46: 02Z",
+			"description": "",
+			"id": 3,
+			"name": "Diaspora",
+			"owner_id": 1,
+			"path": "diaspora",
+			"updated_at": "2013-09-30T13: 46: 02Z"
 		},
 		"archived": false
 	}

--- a/remote/gitlab/testdata/testdata.go
+++ b/remote/gitlab/testdata/testdata.go
@@ -16,7 +16,12 @@ func NewServer() *httptest.Server {
 		// evaluate the path to serve a dummy data file
 		switch r.URL.Path {
 		case "/api/v3/projects":
-			w.Write(projectsPayload)
+			if r.URL.Query().Get("archived") == "false" {
+				w.Write(notArchivedProjectsPayload)
+			} else {
+				w.Write(allProjectsPayload)
+			}
+
 			return
 		case "/api/v3/projects/diaspora/diaspora-client":
 			w.Write(project4Paylod)


### PR DESCRIPTION
I currently have a fair bit of Archived projects when using GitLab with Drone.

This PR provides a way to hide archive projects from the listing using GitLab API options. The default behaviour stay the same and it has to be voluntarily activated via the ```hide_archives``` connection string parameter.

