### PR TITLE
Use the `nonword` tokenizer in Bloodhound search

### DIFF
--- a/static/scripts/search.js
+++ b/static/scripts/search.js
@@ -2,7 +2,7 @@ var repoExpr = /.+\/.+/;
 
 var remoteRepos = new Bloodhound({
     queryTokenizer: Bloodhound.tokenizers.whitespace,
-    datumTokenizer: Bloodhound.tokenizers.obj.whitespace("full_name"),
+    datumTokenizer: Bloodhound.tokenizers.obj.nonword("full_name"),
 
 	identify: function(obj) { return obj.full_name; },
 	prefetch: '/api/user/repos/remote'


### PR DESCRIPTION
As we discussed on gitter I had a look at Bloodhound and I used the nonword tokenizer for the `datumTokenizer`. This makes the search a little more fuzzy and allows to search for only the name of repos as well as for the full name.

Note that typeahead.js caches the search in localStorage so to test this change you have to clear you localStorage.