### PR TITLE
Limit github authz scopes requested by drone

### DIFF
--- a/remote/github/github.go
+++ b/remote/github/github.go
@@ -21,7 +21,7 @@ import (
 const (
 	DefaultURL   = "https://github.com"
 	DefaultAPI   = "https://api.github.com"
-	DefaultScope = "repo,repo:status,user:email"
+	DefaultScope = "repo_deployment,repo:status,write:repo_hook,user:email"
 )
 
 type Github struct {


### PR DESCRIPTION
I've heard complains drone is asking for too many permissions, including direct code access.

Would the following still suffice for all the features drone currently provides for github?
![screen shot 2016-03-02 at 10 48 07 am](https://cloud.githubusercontent.com/assets/25405/13462994/1c4d50ce-e082-11e5-8de5-c0c76e927bd0.png)
