### PR TITLE
controller: Properly parse "full" query in GetBuildLogs.

### DIFF
--- a/controller/build.go
+++ b/controller/build.go
@@ -82,7 +82,7 @@ func GetBuildLogs(c *gin.Context) {
 
 	// the user may specify to stream the full logs,
 	// or partial logs, capped at 2MB.
-	full, _ := strconv.ParseBool(c.Params.ByName("full"))
+	full, _ := strconv.ParseBool(c.DefaultQuery("full", "false"))
 
 	// parse the build number and job sequence number from
 	// the repquest parameter.


### PR DESCRIPTION
Hi,

This is related to https://github.com/drone/drone/issues/1429#issuecomment-176020154

I guess most Drone users doesn't build large projects like gcc ;)
We use Drone to build many large projects like gcc, and it expose bugs like logs more than 2MB ;)

See https://github.com/gin-gonic/gin#querystring-parameters for correct usage to parse a query with gin.

Thanks for the great job on Drone!