### PR TITLE
Prevent github repo duplicates

### DIFF
--- a/remote/github/helper.go
+++ b/remote/github/helper.go
@@ -75,6 +75,9 @@ func GetRepo(client *github.Client, owner, repo string) (*github.Repository, err
 // GetAllRepos is a helper function that returns an aggregated list
 // of all user and organization repositories.
 func GetAllRepos(client *github.Client) ([]github.Repository, error) {
+	var filteredRepos []github.Repository
+	var repoList = map[string]github.Repository{}
+
 	orgs, err := GetOrgs(client)
 	if err != nil {
 		return nil, err
@@ -93,7 +96,17 @@ func GetAllRepos(client *github.Client) ([]github.Repository, error) {
 		repos = append(repos, list...)
 	}
 
-	return repos, nil
+	for _, repo := range repos {
+		if len(*repo.FullName) > 0 {
+			repoList[*repo.FullName] = repo
+		}
+	}
+
+	for _, repo := range repoList {
+		filteredRepos = append(filteredRepos, repo)
+	}
+
+	return filteredRepos, nil
 }
 
 // GetSubscriptions is a helper function that returns an aggregated list


### PR DESCRIPTION
## Problem:

`GetUserRepos(client)` - returns not only repos owned by user, but and repos when user registred as developer, then drone try to get list of organizations, and list of repos belongs to organization.

And we got a duplicates of repositories in drone cache, because we have the same repos in **user_repos** and **organization_repos**

## Solution:

Use map with key `repo.FullName`, to prevent duplicates, and then convert this to array with unique elements