### PR TITLE
Remove install '-t' option

### DIFF
--- a/contrib/setup-sassc.sh
+++ b/contrib/setup-sassc.sh
@@ -18,4 +18,4 @@ cd sassc
 make
 
 # isntall the sassc binary
-install -t /usr/local/bin bin/sassc
+install bin/sassc /usr/local/bin


### PR DESCRIPTION
The script to setup sassc does not work on OSX because the '-t' option
isn't available.  Remove this option so that it's more generic.