### PR TITLE
Match user url against default api url

### DIFF
--- a/remote/github/helper.go
+++ b/remote/github/helper.go
@@ -58,7 +58,7 @@ func GetUserEmail(client *github.Client) (*github.User, error) {
 	// WARNING, HACK
 	// for out-of-date github enterprise editions the primary
 	// and verified fields won't exist.
-	if !strings.HasPrefix(*user.HTMLURL, DefaultURL) && len(emails) != 0 {
+	if !strings.HasPrefix(*user.URL, DefaultAPI) && len(emails) != 0 {
 		user.Email = emails[0].Email
 		return user, nil
 	}


### PR DESCRIPTION
Some GHE urls can have the github url prefix.
I.E https://github.compaq.com, this caused the GHE code not to run.
User.url is the api url for that that user
GHE urls always have /api/version at the end. Probability of a GHE url
starting with api.github is low