### PR TITLE
Use latest samalba/dockerclient to provide compatibility with Docker 1.9.1

### DIFF
--- a/vendor/github.com/samalba/dockerclient/types.go
+++ b/vendor/github.com/samalba/dockerclient/types.go
@@ -91,7 +91,7 @@ type HostConfig struct {
 	VolumeDriver         string
 	OomScoreAdj          int
 	Tmpfs                map[string]string
-	ShmSize              int64
+	ShmSize              int64 `json:"omitempty"`
 	BlkioWeightDevice    []WeightDevice
 	BlkioDeviceReadBps   []ThrottleDevice
 	BlkioDeviceWriteBps  []ThrottleDevice
@@ -195,6 +195,10 @@ func (s *State) String() string {
 		return "Dead"
 	}
 
+	if s.StartedAt.IsZero() {
+		return "Created"
+	}
+
 	if s.FinishedAt.IsZero() {
 		return ""
 	}
@@ -217,6 +221,10 @@ func (s *State) StateString() string {
 
 	if s.Dead {
 		return "dead"
+	}
+
+	if s.StartedAt.IsZero() {
+		return "created"
 	}
 
 	return "exited"
@@ -536,12 +544,14 @@ type BuildImage struct {
 	CpuSetMems     string
 	CgroupParent   string
 	BuildArgs      map[string]string
+	Labels         map[string]string // Labels hold metadata about the image
 }
 
 type Volume struct {
-	Name       string // Name is the name of the volume
-	Driver     string // Driver is the Driver name used to create the volume
-	Mountpoint string // Mountpoint is the location on disk of the volume
+	Name       string            // Name is the name of the volume
+	Driver     string            // Driver is the Driver name used to create the volume
+	Mountpoint string            // Mountpoint is the location on disk of the volume
+	Labels     map[string]string // Labels hold metadata about the volume
 }
 
 type VolumesListResponse struct {
@@ -552,6 +562,7 @@ type VolumeCreateRequest struct {
 	Name       string            // Name is the requested name of the volume
 	Driver     string            // Driver is the name of the driver that should be used to create the volume
 	DriverOpts map[string]string // DriverOpts holds the driver specific options to use for when creating the volume.
+	Labels     map[string]string // Labels hold metadata about the volume
 }
 
 // IPAM represents IP Address Management
@@ -585,6 +596,7 @@ type NetworkResource struct {
 	//Internal   bool
 	Containers map[string]EndpointResource
 	Options    map[string]string
+	Labels     map[string]string // Labels hold metadata about the network
 }
 
 // EndpointResource contains network resources allocated and used for a container in a network
@@ -604,6 +616,7 @@ type NetworkCreate struct {
 	IPAM           IPAM
 	Internal       bool
 	Options        map[string]string
+	Labels         map[string]string // Labels hold metadata about the network
 }
 
 // NetworkCreateResponse is the response message sent by the server for network create call

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -171,9 +171,11 @@
 			"revisionTime": "2013-09-19T15:23:15-06:00"
 		},
 		{
+			"checksumSHA1": "+HvW+k8YkDaPKwF0Lwcz+Tf2A+E=",
+			"origin": "github.com/drone/drone/vendor/github.com/samalba/dockerclient",
 			"path": "github.com/samalba/dockerclient",
-			"revision": "f274bbd0e2eb35ad1444dc6e6660214f9fbbc08c",
-			"revisionTime": "2016-02-22T16:23:45-08:00"
+			"revision": "91d7393ff85980ba3a8966405871a3d446ca28f2",
+			"revisionTime": "2016-04-14T17:47:13Z"
 		},
 		{
 			"path": "github.com/square/go-jose",
@@ -246,5 +248,6 @@
 			"revision": "5d6f7e02b7cdad63b06ab3877915532cd30073b4",
 			"revisionTime": "2015-01-19T16:55:52-02:00"
 		}
-	]
+	],
+	"rootPath": "github.com/drone/drone"
 }


### PR DESCRIPTION
In Docker 1.9.1, an SHMSize of 0 is invalid and results in an error rather than being replaced by the default value.

Dockerclient used to send a default value of 0 for SHMSize rendering Drone incompatible with Docker 1.9.1.

[This commit](https://github.com/samalba/dockerclient/pull/237/commits/68422895eb3138de2c0586fb0a89c2da49efd040) to samalba/dockerclient mitigates this issue.

Thanks