### PR TITLE
When running with CANARY, avoid 'string too long', print full agreement

### DIFF
--- a/drone/server/server.go
+++ b/drone/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 	"time"
@@ -65,7 +66,7 @@ var ServeCmd = cli.Command{
 func start(c *cli.Context) error {
 
 	if c.Bool("agreement.ack") == false || c.Bool("agreement.fix") == false {
-		println(agreement)
+		fmt.Println(agreement)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
It seems that golang will print `[string too long]` when using `panic`/`println`/etc... if the string is really long.

When running with `CANARY=true`, and without accepting the agreement, we instead of getting the agreement just see `[string too long]`.  Based on https://github.com/golang/go/issues/8339 this is fixed in some places, but apparently not all, however the easy solution is to use `fmt`.