### PR TITLE
Override ansi-to-hml default background color

### DIFF
--- a/static/styles_gen/style.css
+++ b/static/styles_gen/style.css
@@ -134,7 +134,7 @@ input[type=range]:focus::-ms-fill-upper { background: #367ebd; }
 
 #output { background: #0d1926; color: #d9e6f2; margin-right: 15px; font-size: 13px; color: #eff1f5; border-radius: 2px; background: #2b303b; white-space: pre-wrap; word-wrap: break-word; box-sizing: border-box; padding: 35px 40px; font-family: "Roboto Mono"; min-height: calc(100vh - 205px); }
 
-#output > span { background: #0d1926 !important; }
+#output span { background: #0d1926 !important; }
 
 #follow { position: absolute; }
 

--- a/static/styles_gen/style.css
+++ b/static/styles_gen/style.css
@@ -134,6 +134,8 @@ input[type=range]:focus::-ms-fill-upper { background: #367ebd; }
 
 #output { background: #0d1926; color: #d9e6f2; margin-right: 15px; font-size: 13px; color: #eff1f5; border-radius: 2px; background: #2b303b; white-space: pre-wrap; word-wrap: break-word; box-sizing: border-box; padding: 35px 40px; font-family: "Roboto Mono"; min-height: calc(100vh - 205px); }
 
+#output > span { background: #0d1926 !important; }
+
 #follow { position: absolute; }
 
 .build-summary { padding-left: 20px; }


### PR DESCRIPTION
Simple patch for nicer output in console.
Obviously you could configure the ANSI-to-HTML package [see here](https://github.com/rburns/ansi-to-html/blob/master/src/ansi_to_html.coffee#L72) to do this.

<img width="465" alt="capture d ecran 2016-04-29 a 19 24 43" src="https://cloud.githubusercontent.com/assets/4642448/14923876/19b4822e-0e40-11e6-981e-6693de2b362f.png">