### PR TITLE
added scopes to the oauth2 config

### DIFF
--- a/remote/github/github.go
+++ b/remote/github/github.go
@@ -53,7 +53,7 @@ func New(opts Opts) (remote.Remote, error) {
 		URL:         defaultURL,
 		Client:      opts.Client,
 		Secret:      opts.Secret,
-		Scope:       strings.Join(opts.Scopes, ","),
+		Scopes:      opts.Scopes,
 		PrivateMode: opts.PrivateMode,
 		SkipVerify:  opts.SkipVerify,
 		MergeRef:    opts.MergeRef,
@@ -73,7 +73,7 @@ type client struct {
 	API         string
 	Client      string
 	Secret      string
-	Scope       string
+	Scopes      []string
 	Machine     string
 	Username    string
 	Password    string
@@ -261,6 +261,7 @@ func (c *client) newConfig(redirect string) *oauth2.Config {
 	return &oauth2.Config{
 		ClientID:     c.Client,
 		ClientSecret: c.Secret,
+		Scopes: c.Scopes,
 		Endpoint: oauth2.Endpoint{
 			AuthURL:  fmt.Sprintf("%s/login/oauth/authorize", c.URL),
 			TokenURL: fmt.Sprintf("%s/login/oauth/access_token", c.URL),


### PR DESCRIPTION

Now the request after redirect to github now contains scope:
https://github.<enterprise location>/login/oauth/authorize?client_id=...etc...&scope=%5Brepo+repo%3Astatus+user%3Aemail+read%3Aorg+gist+repo_deployment%5D&state=drone

I see there aren't tests yet for this, so i'm not sure you all plan to validate these going forward...?