### PR TITLE
Fix Makefile build on OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
-.PHONY: vendor docs
+.PHONY: vendor docs build
 
 PACKAGES = $(shell go list ./... | grep -v /vendor/)
+
+ifneq ($(shell uname), Darwin)
+	EXTLDFLAGS = -extldflags "-static" #
+else
+	EXTLDFLAGS =
+endif
 
 all: gen build
 
@@ -24,10 +30,8 @@ gen_template:
 gen_migrations:
 	go generate github.com/drone/drone/store/datastore/ddl
 
-build: build_static
-
-build_static:
-	cd drone && go build --ldflags '-extldflags "-static" -X github.com/drone/drone/version.VersionDev=$(DRONE_BUILD_NUMBER)' -o drone
+build:
+	cd drone && go build --ldflags '${EXTLDFLAGS}-X github.com/drone/drone/version.VersionDev=$(DRONE_BUILD_NUMBER)' -o drone
 
 test:
 	go test -cover $(PACKAGES)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 PACKAGES = $(shell go list ./... | grep -v /vendor/)
 
 ifneq ($(shell uname), Darwin)
-	EXTLDFLAGS = -extldflags "-static" #
+	EXTLDFLAGS = -extldflags "-static" $(null)
 else
 	EXTLDFLAGS =
 endif


### PR DESCRIPTION
The ld `-static` linking in not supported on OS X. And it fails with error:
```
/usr/local/Cellar/go/1.6.1/libexec/pkg/tool/darwin_amd64/link: running clang failed: exit status 1
ld: library not found for -lcrt0.o
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```