### PR TITLE
[github] Add modifiable context for Github status API

### DIFF
--- a/drone/server.go
+++ b/drone/server.go
@@ -100,6 +100,12 @@ var serverCmd = cli.Command{
 			Value:  "https://github.com",
 		},
 		cli.StringFlag{
+			EnvVar: "DRONE_GITHUB_CONTEXT",
+			Name:   "github-context",
+			Usage:  "github status context",
+			Value:  "continuous-integration/drone",
+		},
+		cli.StringFlag{
 			EnvVar: "DRONE_GITHUB_CLIENT",
 			Name:   "github-client",
 			Usage:  "github oauth2 client id",

--- a/remote/github/github.go
+++ b/remote/github/github.go
@@ -27,6 +27,7 @@ const (
 // Opts defines configuration options.
 type Opts struct {
 	URL         string   // GitHub server url.
+	Context     string   // Context to display in status check
 	Client      string   // GitHub oauth client id.
 	Secret      string   // GitHub oauth client secret.
 	Scopes      []string // GitHub oauth scopes
@@ -51,6 +52,7 @@ func New(opts Opts) (remote.Remote, error) {
 	remote := &client{
 		API:         defaultAPI,
 		URL:         defaultURL,
+		Context:     opts.Context,
 		Client:      opts.Client,
 		Secret:      opts.Secret,
 		Scopes:      opts.Scopes,
@@ -70,6 +72,7 @@ func New(opts Opts) (remote.Remote, error) {
 
 type client struct {
 	URL         string
+	Context     string
 	API         string
 	Client      string
 	Secret      string
@@ -261,7 +264,7 @@ func (c *client) newConfig(redirect string) *oauth2.Config {
 	return &oauth2.Config{
 		ClientID:     c.Client,
 		ClientSecret: c.Secret,
-		Scopes: c.Scopes,
+		Scopes:       c.Scopes,
 		Endpoint: oauth2.Endpoint{
 			AuthURL:  fmt.Sprintf("%s/login/oauth/authorize", c.URL),
 			TokenURL: fmt.Sprintf("%s/login/oauth/access_token", c.URL),
@@ -345,12 +348,12 @@ func (c *client) Status(u *model.User, r *model.Repo, b *model.Build, link strin
 	case "deployment":
 		return deploymentStatus(client, r, b, link)
 	default:
-		return repoStatus(client, r, b, link)
+		return repoStatus(client, r, b, link, c.Context)
 	}
 }
 
-func repoStatus(client *github.Client, r *model.Repo, b *model.Build, link string) error {
-	context := "continuous-integration/drone"
+func repoStatus(client *github.Client, r *model.Repo, b *model.Build, link, ctx string) error {
+	context := ctx
 	switch b.Event {
 	case model.EventPull:
 		context += "/pr"

--- a/remote/github/github_test.go
+++ b/remote/github/github_test.go
@@ -37,6 +37,7 @@ func Test_github(t *testing.T) {
 					Password:    "password",
 					SkipVerify:  true,
 					PrivateMode: true,
+					Context:     "continuous-integration/test",
 				})
 				g.Assert(remote.(*client).URL).Equal("http://localhost:8080")
 				g.Assert(remote.(*client).API).Equal("http://localhost:8080/api/v3/")
@@ -47,6 +48,7 @@ func Test_github(t *testing.T) {
 				g.Assert(remote.(*client).Secret).Equal("I1NiIsInR5")
 				g.Assert(remote.(*client).SkipVerify).Equal(true)
 				g.Assert(remote.(*client).PrivateMode).Equal(true)
+				g.Assert(remote.(*client).Context).Equal("continuous-integration/test")
 			})
 			g.It("Should handle malformed url", func() {
 				_, err := New(Opts{URL: "%gh&%ij"})

--- a/router/middleware/remote.go
+++ b/router/middleware/remote.go
@@ -92,6 +92,7 @@ func setupGitlab(c *cli.Context) (remote.Remote, error) {
 func setupGithub(c *cli.Context) (remote.Remote, error) {
 	return github.New(github.Opts{
 		URL:         c.String("github-server"),
+		Context:     c.String("github-context"),
 		Client:      c.String("github-client"),
 		Secret:      c.String("github-sercret"),
 		Scopes:      c.StringSlice("github-scope"),


### PR DESCRIPTION
Adds a flag (`DRONE_GITHUB_CONTEXT`) to modify the context used when reporting status check to Github, default is still `continuous-integration/drone`.