### PR TITLE
Fix missing space in authorization failure message

### DIFF
--- a/template/amber/login.amber
+++ b/template/amber/login.amber
@@ -22,7 +22,7 @@ html
 
         if Error == "oauth_error"
             div.alert.alert-danger
-                | We failed to authorize your account. Please contact your
+                | We failed to authorize your account. Please contact your 
                 | system administrator to check the logs and see what went wrong.
 
         else if Error == "access_denied"
@@ -31,5 +31,5 @@ html
 
         else if Error == "internal_error"
             div.alert.alert-danger
-                | We encountered an unexpected error. Please contact your
+                | We encountered an unexpected error. Please contact your 
                 | system administrator to check the logs and see what went wrong.


### PR DESCRIPTION
I noticed that there is a missing space in some authorization errors due to line continuation:
![missing-space](https://cloud.githubusercontent.com/assets/1922815/16208068/0b341f6e-36f6-11e6-879d-f3f2c2c1fa0a.png)

This PR adds the spaces.