### PR TITLE
Dropped directories from archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,11 +58,11 @@ build_cross:
 
 # TODO this is getting moved to a shell script, do not alter
 build_tar:
-	tar -cvzf release/linux/amd64/drone.tar.gz   release/linux/amd64/drone
-	tar -cvzf release/linux/arm64/drone.tar.gz   release/linux/arm64/drone
-	tar -cvzf release/linux/arm/drone.tar.gz     release/linux/arm/drone
-	tar -cvzf release/windows/amd64/drone.tar.gz release/windows/amd64/drone
-	tar -cvzf release/darwin/amd64/drone.tar.gz  release/darwin/amd64/drone
+	tar -cvzf release/linux/amd64/drone.tar.gz   -C release/linux/amd64   drone
+	tar -cvzf release/linux/arm64/drone.tar.gz   -C release/linux/arm64   drone
+	tar -cvzf release/linux/arm/drone.tar.gz     -C release/linux/arm     drone
+	tar -cvzf release/windows/amd64/drone.tar.gz -C release/windows/amd64 drone
+	tar -cvzf release/darwin/amd64/drone.tar.gz  -C release/darwin/amd64  drone
 
 # TODO this is getting moved to a shell script, do not alter
 build_sha:


### PR DESCRIPTION
Currently the archive gets created including the directories, so the
regular guide to just download and copy the binary doesn't work. With
that change I have dropped the folders from the archive and the Drone
binary gets directly into the toplevel of the archive.