### PR TITLE
fix dns resolution issues due to static linking and cgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,10 @@ PACKAGES = $(shell go list ./... | grep -v /vendor/)
 
 ifneq ($(shell uname), Darwin)
 	EXTLDFLAGS = -extldflags "-static" $(null)
+	EXTFLAGS = -tags netgo
 else
 	EXTLDFLAGS =
+	EXTFLAGS =
 endif
 
 all: gen build_static
@@ -44,7 +46,7 @@ test_postgres:
 build: build_static build_cross build_tar build_sha
 
 build_static:
-	go build --ldflags '${EXTLDFLAGS}-X github.com/drone/drone/version.VersionDev=$(DRONE_BUILD_NUMBER)' -o release/drone github.com/drone/drone/drone
+	go build --ldflags '${EXTLDFLAGS}-X github.com/drone/drone/version.VersionDev=$(DRONE_BUILD_NUMBER)' $(EXTFLAGS) -o release/drone github.com/drone/drone/drone
 
 # TODO this is getting moved to a shell script, do not alter
 build_cross:


### PR DESCRIPTION
Running into issues on ubuntu 14.04 due to name resolution:

```dial tcp: lookup xx.redacted.xxx: no such host```

This was resolved by using netgo, this has been seen in:

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=63731 and https://github.com/docker/docker/issues/9449

gcc (Ubuntu 4.8.4-2ubuntu1~14.04.3) 4.8.4

