### PR TITLE
Expose GitHub machine user options.

### DIFF
--- a/drone/server.go
+++ b/drone/server.go
@@ -124,6 +124,16 @@ var serverCmd = cli.Command{
 				"read:org",
 			},
 		},
+		cli.StringFlag{
+			EnvVar: "DRONE_GITHUB_GIT_USERNAME",
+			Name:   "github-git-username",
+			Usage:  "github machine user username",
+		},
+		cli.StringFlag{
+			EnvVar: "DRONE_GITHUB_GIT_PASSWORD",
+			Name:   "github-git-password",
+			Usage:  "github machine user password",
+		},
 		cli.BoolTFlag{
 			EnvVar: "DRONE_GITHUB_MERGE_REF",
 			Name:   "github-merge-ref",


### PR DESCRIPTION
I noticed there was support for a so-called GitHub "machine user." This is a useful thing to have for when you have private repositories that depend on other private repositories.

Unfortunately, this support is just barely not publicly exposed anywhere it seems, as the option is missing from the CLI flags. This patch adds those flags. I'm currently running this in production and it seems to be doing fine. (At the very least, it is absolutely writing the username/password to netrc.) I believe it is also possible to use an OAuth token here by putting the username as a token and the password as `x-oauth-basic`, but I did not actually test this. (I can only assume that this is how it is internally handled already, since OAuth is used to begin with.)