### PR TITLE
Log errors in `server.GetBuilds`

### DIFF
--- a/server/build.go
+++ b/server/build.go
@@ -23,7 +23,7 @@ func GetBuilds(c *gin.Context) {
 	repo := session.Repo(c)
 	builds, err := store.GetBuildList(c, repo)
 	if err != nil {
-		c.AbortWithStatus(http.StatusInternalServerError)
+		c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
 	c.JSON(http.StatusOK, builds)


### PR DESCRIPTION
Getting the build history for some repos on my Drone 0.5 installation fails (for more details see #1746), but the error is not logged. This PR will log the error.