### PR TITLE
Add support for `drone build start foo/bar last`

### DIFF
--- a/drone/build_start.go
+++ b/drone/build_start.go
@@ -35,14 +35,26 @@ func buildStart(c *cli.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	number, err := strconv.Atoi(c.Args().Get(1))
-	if err != nil {
-		return err
-	}
 
 	client, err := newClient(c)
 	if err != nil {
 		return err
+	}
+
+	buildArg := c.Args().Get(1)
+	var number int
+	if buildArg == "last" {
+		// Fetch the build number from the last build
+		build, err := client.BuildLast(owner, name, "")
+		if err != nil {
+			return err
+		}
+		number = build.Number
+	} else {
+		number, err = strconv.Atoi(buildArg)
+		if err != nil {
+			return err
+		}
 	}
 
 	params := parseKVPairs(c.StringSlice("param"))


### PR DESCRIPTION
This starts the last build on the default branch.

Alternatively: should it default to the last build when the arg is explicitly omitted?