### PR TITLE
Add docker build command in Makefile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-# docker build --rm=true -t drone/drone .
-
 FROM centurylink/ca-certs
 EXPOSE 8000
 

--- a/Makefile
+++ b/Makefile
@@ -69,3 +69,6 @@ build_sha:
 	sha256sum release/linux/arm/drone.tar.gz     > release/linux/arm/drone.sha256
 	sha256sum release/windows/amd64/drone.tar.gz > release/windows/amd64/drone.sha256
 	sha256sum release/darwin/amd64/drone.tar.gz  > release/darwin/amd64/drone.sha256
+
+docker:
+	docker build --rm -t drone/drone .

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ export GO15VENDOREXPERIMENT=1
 make deps    # Download required dependencies
 make gen     # Generate code
 make build   # Build the binary
+make docker  # Build the docker image
 ```
 
 If you are having trouble building this project please reference its `.drone.yml` file. Everything you need to know about building Drone is defined in that file.


### PR DESCRIPTION
Add docker build command in Makefile so developer can build docker images as the following command.

```bash
$ make all docker
```

Signed-off-by: Bo-Yi Wu <appleboy.tw@gmail.com>