### PR TITLE
Remove the trailing / from DRONE_SERVER env in agent when it's there

### DIFF
--- a/drone/agent/agent.go
+++ b/drone/agent/agent.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
+	"strings"
 )
 
 // AgentCmd is the exported command for starting the drone agent.
@@ -157,7 +158,7 @@ func start(c *cli.Context) {
 	)
 
 	client := client.NewClientToken(
-		c.String("drone-server"),
+		strings.TrimRight(c.String("drone-server"),"/"),
 		accessToken,
 	)
 


### PR DESCRIPTION
Seems like enough people are running into this that just removing it if it exists would be worth it.
@bradrydzewski let me know if it's even worth it or if you'd rather have it somewhere else :)