### PR TITLE
Correct escaping of commands in YAML

### DIFF
--- a/yaml/transform/command.go
+++ b/yaml/transform/command.go
@@ -40,7 +40,7 @@ func toScript(commands []string) string {
 	var buf bytes.Buffer
 	for _, command := range commands {
 		escaped := fmt.Sprintf("%q", command)
-		escaped = strings.Replace(command, "$", `$\`, -1)
+		escaped = strings.Replace(escaped, "$", `\$`, -1)
 		buf.WriteString(fmt.Sprintf(
 			traceScript,
 			escaped,


### PR DESCRIPTION
Two changes on the line:

1. when replacing, make sure we're starting with previously escaped string.
2. use \$ to escape $ instead of $\ -- the latter works in *most cases*, but the former is more correct.

This code could be slightly refactored to make it more testable.

Any interest?