### PR TITLE
OAuth2 GHE Always Register BustedURL

### DIFF
--- a/remote/github/github.go
+++ b/remote/github/github.go
@@ -67,6 +67,9 @@ func New(opts Opts) (remote.Remote, error) {
 		remote.URL = strings.TrimSuffix(opts.URL, "/")
 		remote.API = remote.URL + "/api/v3/"
 	}
+
+	// Hack to enable oauth2 access in older GHE
+	oauth2.RegisterBrokenAuthHeaderProvider(remote.URL)
 	return remote, nil
 }
 


### PR DESCRIPTION
When going through the oauth2 module in go, there is a list of "busted" URLs which don't implement OAuth2 properly.

Github is on that list, however Github Enterprise(GHE) uses different URLs for each instance. Instead of adding all of these to the global list in the oauth module, we can simply flag all of our tokens as broken until github updates their API.