### PR TITLE
Speedup local build iterations by reusing built packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,8 @@ test_postgres:
 build: build_static build_cross build_tar build_sha
 
 build_static:
-	go build --ldflags '${EXTLDFLAGS}-X github.com/drone/drone/version.VersionDev=$(DRONE_BUILD_NUMBER)' -o release/drone github.com/drone/drone/drone
+	go install -ldflags '${EXTLDFLAGS}-X github.com/drone/drone/version.VersionDev=$(DRONE_BUILD_NUMBER)' github.com/drone/drone/drone
+	cp $(GOPATH)/bin/drone release/drone
 
 # TODO this is getting moved to a shell script, do not alter
 build_cross:


### PR DESCRIPTION
Before cold and hot runs are the same:

```
$ rm -rf $GOPATH/pkg
```

```
$ time make
go generate github.com/drone/drone/server/template
go generate github.com/drone/drone/store/datastore/ddl
go build --ldflags '-X github.com/drone/drone/version.VersionDev=' -o release/drone github.com/drone/drone/drone

real   	0m43.638s
user   	0m48.990s
sys    	0m5.480s
```

```
$ time make
go generate github.com/drone/drone/server/template
go generate github.com/drone/drone/store/datastore/ddl
go build --ldflags '-X github.com/drone/drone/version.VersionDev=' -o release/drone github.com/drone/drone/drone

real   	0m46.950s
user   	0m49.506s
sys    	0m6.086s
```

After hot builds are much faster:

```
$ rm -rf $GOPATH/pkg
```

```
$ rm -rf $GOPATH/pkg && time make
go generate github.com/drone/drone/server/template
go generate github.com/drone/drone/store/datastore/ddl
go install -ldflags '-X github.com/drone/drone/version.VersionDev=' github.com/drone/drone/drone
cp /Users/bobrik/projects/drone/bin/drone release/drone

real   	0m44.735s
user   	0m51.049s
sys    	0m4.517s
```

```
$ time make
go generate github.com/drone/drone/server/template
go generate github.com/drone/drone/store/datastore/ddl
go install -ldflags '-X github.com/drone/drone/version.VersionDev=' github.com/drone/drone/drone
cp /Users/bobrik/projects/drone/bin/drone release/drone

real   	0m3.364s
user   	0m2.934s
sys    	0m0.808s
```