### PR TITLE
Fix repo query when user has access to > 999 remotes

### DIFF
--- a/store/datastore/repos.go
+++ b/store/datastore/repos.go
@@ -28,7 +28,7 @@ func (db *datastore) GetRepoListOf(listof []*model.RepoLite) ([]*model.Repo, err
 	)
 	switch meddler.Default {
 	case meddler.PostgreSQL:
-		stmt, args = toListPosgres(listof)
+		stmt, args = toListPostgres(listof)
 	default:
 		stmt, args = toList(listof)
 	}

--- a/store/datastore/users.go
+++ b/store/datastore/users.go
@@ -35,7 +35,7 @@ func (db *datastore) GetUserFeed(listof []*model.RepoLite) ([]*model.Feed, error
 	)
 	switch meddler.Default {
 	case meddler.PostgreSQL:
-		stmt, args = toListPosgres(listof)
+		stmt, args = toListPostgres(listof)
 	default:
 		stmt, args = toList(listof)
 	}
@@ -55,7 +55,7 @@ func (db *datastore) GetUserFeedLatest(listof []*model.RepoLite) ([]*model.Feed,
 	)
 	switch meddler.Default {
 	case meddler.PostgreSQL:
-		stmt, args = toListPosgres(listof)
+		stmt, args = toListPostgres(listof)
 	default:
 		stmt, args = toList(listof)
 	}

--- a/store/datastore/utils.go
+++ b/store/datastore/utils.go
@@ -51,7 +51,7 @@ func toList(listof []*model.RepoLite) (string, []interface{}) {
 
 // helper function that converts a simple repository list
 // to a sql IN statement compatible with postgres.
-func toListPosgres(listof []*model.RepoLite) (string, []interface{}) {
+func toListPostgres(listof []*model.RepoLite) (string, []interface{}) {
 	var size = len(listof)
 	var qs = make([]string, size, size)
 	var in = make([]interface{}, size, size)

--- a/store/datastore/utils.go
+++ b/store/datastore/utils.go
@@ -40,10 +40,6 @@ func rebind(query string) string {
 // to a sql IN statment.
 func toList(listof []*model.RepoLite) (string, []interface{}) {
 	var size = len(listof)
-	if size > 999 {
-		size = 999
-		listof = listof[:999]
-	}
 	var qs = make([]string, size, size)
 	var in = make([]interface{}, size, size)
 	for i, repo := range listof {

--- a/store/datastore/utils.go
+++ b/store/datastore/utils.go
@@ -57,10 +57,6 @@ func toList(listof []*model.RepoLite) (string, []interface{}) {
 // to a sql IN statement compatible with postgres.
 func toListPosgres(listof []*model.RepoLite) (string, []interface{}) {
 	var size = len(listof)
-	if size > 999 {
-		size = 999
-		listof = listof[:999]
-	}
 	var qs = make([]string, size, size)
 	var in = make([]interface{}, size, size)
 	for i, repo := range listof {


### PR DESCRIPTION
Limiting to 999 in the query creates a few issues. 
- If a repo is the 1000th or greater remote, it disappears form the left after a page reload.
- The repo appears to be not active after a page reload (from the account page). And activating it again will not work, making it appear stuck.
- The repo never appears in drone repo ls

Issue #1776 won't be resolved until this PR or something with a similar effect gets merged.
