### PR TITLE
Add test case with a normal matrix and an include statement

### DIFF
--- a/yaml/matrix_test.go
+++ b/yaml/matrix_test.go
@@ -40,6 +40,18 @@ func TestMatrix(t *testing.T) {
 			g.Assert(axis[0]["python_version"]).Equal("3.4")
 			g.Assert(axis[1]["python_version"]).Equal("3.4")
 		})
+
+		g.It("Should calculate permutations and included axis", func() {
+			axis, err := ParseMatrixString(fakeMatrixWithInclude)
+			g.Assert(err == nil).IsTrue()
+			g.Assert(len(axis)).Equal(3)
+			g.Assert(axis[0]["go_version"]).Equal("1.5")
+			g.Assert(axis[1]["go_version"]).Equal("1.5")
+			g.Assert(axis[2]["go_version"]).Equal("1.6")
+			g.Assert(axis[0]["python_version"]).Equal("3.3")
+			g.Assert(axis[1]["python_version"]).Equal("3.4")
+			g.Assert(axis[2]["python_version"]).Equal("3.4")
+		})
 	})
 }
 
@@ -65,6 +77,18 @@ matrix:
   include:
     - go_version: 1.5
       python_version: 3.4
+    - go_version: 1.6
+      python_version: 3.4
+`
+
+var fakeMatrixWithInclude = `
+matrix:
+  go_version:
+    - 1.5
+  python_version:
+    - 3.3
+    - 3.4
+  include:
     - go_version: 1.6
       python_version: 3.4
 `


### PR DESCRIPTION
This is how I thought the include statement would work, but it doesn't. Is this a bug or simply not wanted? Often you have a matrix and just want to extend it for some version and add a spare row to the matrix with only one cell filled.