### PR TITLE
fix branch name from github webhook.

### DIFF
--- a/remote/github/convert.go
+++ b/remote/github/convert.go
@@ -161,12 +161,20 @@ func convertRepoHook(from *webhook) *model.Repo {
 // convertPushHook is a helper function used to extract the Build details
 // from a push webhook and convert to the common Drone Build structure.
 func convertPushHook(from *webhook) *model.Build {
+	branch := strings.TrimPrefix(
+		strings.TrimPrefix(
+			from.Ref,
+			"refs/heads/",
+		),
+		"refs/tags/",
+	)
+
 	build := &model.Build{
 		Event:   model.EventPush,
 		Commit:  from.Head.ID,
 		Ref:     from.Ref,
 		Link:    from.Head.URL,
-		Branch:  strings.Replace(from.Ref, "refs/heads/", "", -1),
+		Branch:  branch,
 		Message: from.Head.Message,
 		Email:   from.Head.Author.Email,
 		Avatar:  from.Sender.Avatar,

--- a/remote/github/convert_test.go
+++ b/remote/github/convert_test.go
@@ -243,6 +243,7 @@ func Test_helper(t *testing.T) {
 
 			build := convertPushHook(from)
 			g.Assert(build.Event).Equal(model.EventTag)
+			g.Assert(build.Branch).Equal("v1.0.0")
 			g.Assert(build.Ref).Equal("refs/tags/v1.0.0")
 		})
 	})


### PR DESCRIPTION
Screenshot from UI

![screen shot 2016-10-02 at 12 34 03 am](https://cloud.githubusercontent.com/assets/21979/19015493/1697c5d4-8838-11e6-9ddd-8eaeb4a1a34c.png)
![screen shot 2016-10-02 at 12 34 12 am](https://cloud.githubusercontent.com/assets/21979/19015494/169d5da0-8838-11e6-99bf-def3e1af4b5a.png)

Same as https://github.com/drone/drone/pull/1795 PR
