### PR TITLE
Add in docker shm-size option, mainly for oracle xe

### DIFF
--- a/build/docker/util.go
+++ b/build/docker/util.go
@@ -22,6 +22,7 @@ func toContainerConfig(c *yaml.Container) *dockerclient.ContainerConfig {
 			Privileged:       c.Privileged,
 			NetworkMode:      c.Network,
 			Memory:           c.MemLimit,
+		  ShmSize:          c.ShmSize,
 			CpuShares:        c.CPUShares,
 			CpuQuota:         c.CPUQuota,
 			CpusetCpus:       c.CPUSet,

--- a/build/docker/util.go
+++ b/build/docker/util.go
@@ -22,7 +22,7 @@ func toContainerConfig(c *yaml.Container) *dockerclient.ContainerConfig {
 			Privileged:       c.Privileged,
 			NetworkMode:      c.Network,
 			Memory:           c.MemLimit,
-		  ShmSize:          c.ShmSize,
+			ShmSize:          c.ShmSize,
 			CpuShares:        c.CPUShares,
 			CpuQuota:         c.CPUQuota,
 			CpusetCpus:       c.CPUSet,

--- a/yaml/container.go
+++ b/yaml/container.go
@@ -40,6 +40,7 @@ type Container struct {
 	DNSSearch      []string
 	MemSwapLimit   int64
 	MemLimit       int64
+	ShmSize        int64
 	CPUQuota       int64
 	CPUShares      int64
 	CPUSet         string
@@ -75,6 +76,7 @@ type container struct {
 	DNSSearch      types.StringOrSlice `yaml:"dns_search"`
 	MemSwapLimit   int64               `yaml:"memswap_limit"`
 	MemLimit       int64               `yaml:"mem_limit"`
+	ShmSize        int64               `yaml:"shm_size"`
 	CPUQuota       int64               `yaml:"cpu_quota"`
 	CPUShares      int64               `yaml:"cpu_shares"`
 	CPUSet         string              `yaml:"cpuset"`
@@ -144,6 +146,7 @@ func (c *containerList) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			DNSSearch:      cc.DNSSearch.Slice(),
 			MemSwapLimit:   cc.MemSwapLimit,
 			MemLimit:       cc.MemLimit,
+			ShmSize:        cc.ShmSize,
 			CPUQuota:       cc.CPUQuota,
 			CPUShares:      cc.CPUShares,
 			CPUSet:         cc.CPUSet,

--- a/yaml/transform/validate.go
+++ b/yaml/transform/validate.go
@@ -51,6 +51,9 @@ func CheckTrusted(c *yaml.Container) error {
 	if c.Privileged {
 		return fmt.Errorf("Insufficient privileges to use privileged mode")
 	}
+	if c.ShmSize != 0 {
+		return fmt.Errorf("Insufficient privileges to override shm_size")
+	}
 	if len(c.DNS) != 0 {
 		return fmt.Errorf("Insufficient privileges to use custom dns")
 	}


### PR DESCRIPTION
Based on #1798 based on the label example i was linked to, unfortunately i don't know go and i could not get drone to build with go, from what i could tell i do not need the template ? 

Got stuck with this error before i even made changes so i could not test this.

    ~/g/s/g/d/drone> make gen
    go generate github.com/drone/drone/server/template
    bindata: Create output directory: mkdir : no such file or directory
    server/template/template.go:3: running "go-bindata": exit status 1
    Makefile:26: recipe for target 'gen_template' failed
    make: *** [gen_template] Error 1
 
as its a simple change i thought some one may be able to tell if its correct or try it, or if you know what the error above is about I would like to know as this is my first try at using the go language.


