### PR TITLE
Fix: key exceeds max on MariaDB (MySQL)

### DIFF
--- a/store/datastore/ddl/mysql/6.sql
+++ b/store/datastore/ddl/mysql/6.sql
@@ -2,7 +2,7 @@
 
 CREATE TABLE agents (
  agent_id       INTEGER PRIMARY KEY AUTO_INCREMENT
-,agent_addr     VARCHAR(500)
+,agent_addr     VARCHAR(255)
 ,agent_platform VARCHAR(500)
 ,agent_capacity INTEGER
 ,agent_created  INTEGER


### PR DESCRIPTION
Fixes #1805 `Specified key was too long; max key length is 767 bytes`