### PR TITLE
Add a reference to a parent build on forks / deploys

### DIFF
--- a/model/build.go
+++ b/model/build.go
@@ -5,6 +5,7 @@ type Build struct {
 	ID        int64  `json:"id"            meddler:"build_id,pk"`
 	RepoID    int64  `json:"-"             meddler:"build_repo_id"`
 	Number    int    `json:"number"        meddler:"build_number"`
+	Parent    int    `json:"parent"        meddler:"build_parent"`
 	Event     string `json:"event"         meddler:"build_event"`
 	Status    string `json:"status"        meddler:"build_status"`
 	Enqueued  int64  `json:"enqueued_at"   meddler:"build_enqueued"`

--- a/server/build.go
+++ b/server/build.go
@@ -228,6 +228,7 @@ func PostBuild(c *gin.Context) {
 	if forkit, _ := strconv.ParseBool(fork); forkit {
 		build.ID = 0
 		build.Number = 0
+		build.Parent = num
 		for _, job := range jobs {
 			job.ID = 0
 			job.NodeID = 0

--- a/store/datastore/ddl/mysql/8.sql
+++ b/store/datastore/ddl/mysql/8.sql
@@ -1,0 +1,7 @@
+-- +migrate Up
+
+ALTER TABLE builds ADD COLUMN build_parent INTEGER DEFAULT 0;
+
+-- +migrate Down
+
+ALTER TABLE builds DROP COLUMN build_parent;

--- a/store/datastore/ddl/postgres/8.sql
+++ b/store/datastore/ddl/postgres/8.sql
@@ -1,0 +1,7 @@
+-- +migrate Up
+
+ALTER TABLE builds ADD COLUMN build_parent INTEGER DEFAULT 0;
+
+-- +migrate Down
+
+ALTER TABLE builds DROP COLUMN build_parent;

--- a/store/datastore/ddl/sqlite3/8.sql
+++ b/store/datastore/ddl/sqlite3/8.sql
@@ -1,0 +1,7 @@
+-- +migrate Up
+
+ALTER TABLE builds ADD COLUMN build_parent INTEGER DEFAULT 0;
+
+-- +migrate Down
+
+ALTER TABLE builds DROP COLUMN build_parent;


### PR DESCRIPTION
Please note that `build.Parent` is a type of `int`, if not set, its default
value will be `0`. We don't want to have a `NULL` value in a database for
`build_parent` column. Another way of doing would to have `build.Parent` of
`interface{}` type, but that's a bit smelly.

Trigger a deployment of build number 2:
```bash
> drone-trigger --repo vaijab/test --number 2 --deploy-to some-env
Follow new build status at: http:/192.168.2.215:8000/vaijab/test/8
```

Read parent build number:
```bash
> curl -s -H "Authorization: Bearer ${DRONE_TOKEN}" ${DRONE_SERVER}/api/repos/vaijab/test/builds/8 | jq .parent
2
```

We will be making another PR to surface a href to parent build in the UI too.

Fixes #1818 