### PR TITLE
Adding SkipVerify to Secrets

### DIFF
--- a/model/repo_secret.go
+++ b/model/repo_secret.go
@@ -20,25 +20,30 @@ type RepoSecret struct {
 
 	// the secret is restricted to this list of events.
 	Events []string `json:"event,omitempty" meddler:"secret_events,json"`
+
+	// whether the secret requires verification
+	SkipVerify bool `json:"skip_verify" meddler:"secret_skip_verify"`
 }
 
 // Secret transforms a repo secret into a simple secret.
 func (s *RepoSecret) Secret() *Secret {
 	return &Secret{
-		Name:   s.Name,
-		Value:  s.Value,
-		Images: s.Images,
-		Events: s.Events,
+		Name:       s.Name,
+		Value:      s.Value,
+		Images:     s.Images,
+		Events:     s.Events,
+		SkipVerify: s.SkipVerify,
 	}
 }
 
 // Clone provides a repo secrets clone without the value.
 func (s *RepoSecret) Clone() *RepoSecret {
 	return &RepoSecret{
-		ID:     s.ID,
-		Name:   s.Name,
-		Images: s.Images,
-		Events: s.Events,
+		ID:         s.ID,
+		Name:       s.Name,
+		Images:     s.Images,
+		Events:     s.Events,
+		SkipVerify: s.SkipVerify,
 	}
 }
 

--- a/model/secret.go
+++ b/model/secret.go
@@ -18,6 +18,9 @@ type Secret struct {
 
 	// the secret is restricted to this list of events.
 	Events []string `json:"event,omitempty"`
+
+	// whether the secret requires verification
+	SkipVerify bool `json:"skip_verify"`
 }
 
 // Match returns true if an image and event match the restricted list.

--- a/model/team_secret.go
+++ b/model/team_secret.go
@@ -20,25 +20,30 @@ type TeamSecret struct {
 
 	// the secret is restricted to this list of events.
 	Events []string `json:"event,omitempty" meddler:"team_secret_events,json"`
+
+	// whether the secret requires verification
+	SkipVerify bool `json:"skip_verify" meddler:"team_secret_skip_verify"`
 }
 
 // Secret transforms a repo secret into a simple secret.
 func (s *TeamSecret) Secret() *Secret {
 	return &Secret{
-		Name:   s.Name,
-		Value:  s.Value,
-		Images: s.Images,
-		Events: s.Events,
+		Name:       s.Name,
+		Value:      s.Value,
+		Images:     s.Images,
+		Events:     s.Events,
+		SkipVerify: s.SkipVerify,
 	}
 }
 
 // Clone provides a repo secrets clone without the value.
 func (s *TeamSecret) Clone() *TeamSecret {
 	return &TeamSecret{
-		ID:     s.ID,
-		Name:   s.Name,
-		Images: s.Images,
-		Events: s.Events,
+		ID:         s.ID,
+		Name:       s.Name,
+		Images:     s.Images,
+		Events:     s.Events,
+		SkipVerify: s.SkipVerify,
 	}
 }
 

--- a/store/datastore/ddl/mysql/9.sql
+++ b/store/datastore/ddl/mysql/9.sql
@@ -1,0 +1,12 @@
+-- +migrate Up
+
+ALTER TABLE secrets      ADD COLUMN secret_skip_verify      BOOLEAN;
+ALTER TABLE team_secrets ADD COLUMN team_secret_skip_verify BOOLEAN;
+
+UPDATE secrets      SET secret_skip_verify      = false;
+UPDATE team_secrets SET team_secret_skip_verify = false;
+
+-- +migrate Down
+
+ALTER TABLE secrets      DROP COLUMN secret_skip_verify;
+ALTER TABLE team_secrets DROP COLUMN team_secret_skip_verify;

--- a/store/datastore/ddl/postgres/9.sql
+++ b/store/datastore/ddl/postgres/9.sql
@@ -1,0 +1,12 @@
+-- +migrate Up
+
+ALTER TABLE secrets      ADD COLUMN secret_skip_verify      BOOLEAN;
+ALTER TABLE team_secrets ADD COLUMN team_secret_skip_verify BOOLEAN;
+
+UPDATE secrets      SET secret_skip_verify      = false;
+UPDATE team_secrets SET team_secret_skip_verify = false;
+
+-- +migrate Down
+
+ALTER TABLE secrets      DROP COLUMN secret_skip_verify;
+ALTER TABLE team_secrets DROP COLUMN team_secret_skip_verify;

--- a/store/datastore/ddl/sqlite3/9.sql
+++ b/store/datastore/ddl/sqlite3/9.sql
@@ -1,0 +1,12 @@
+-- +migrate Up
+
+ALTER TABLE secrets      ADD COLUMN secret_skip_verify      BOOLEAN;
+ALTER TABLE team_secrets ADD COLUMN team_secret_skip_verify BOOLEAN;
+
+UPDATE secrets      SET secret_skip_verify      = 0;
+UPDATE team_secrets SET team_secret_skip_verify = 0;
+
+-- +migrate Down
+
+ALTER TABLE secrets      DROP COLUMN secret_skip_verify;
+ALTER TABLE team_secrets DROP COLUMN team_secret_skip_verify;

--- a/store/datastore/repo_secret_test.go
+++ b/store/datastore/repo_secret_test.go
@@ -23,11 +23,12 @@ func TestRepoSecrets(t *testing.T) {
 
 		g.It("Should set and get a secret", func() {
 			secret := &model.RepoSecret{
-				RepoID: 1,
-				Name:   "foo",
-				Value:  "bar",
-				Images: []string{"docker", "gcr"},
-				Events: []string{"push", "tag"},
+				RepoID:     1,
+				Name:       "foo",
+				Value:      "bar",
+				Images:     []string{"docker", "gcr"},
+				Events:     []string{"push", "tag"},
+				SkipVerify: false,
 			}
 			err := s.SetSecret(secret)
 			g.Assert(err == nil).IsTrue()

--- a/store/datastore/team_secret_test.go
+++ b/store/datastore/team_secret_test.go
@@ -23,11 +23,12 @@ func TestTeamSecrets(t *testing.T) {
 
 		g.It("Should set and get a secret", func() {
 			secret := &model.TeamSecret{
-				Key:    "octocat",
-				Name:   "foo",
-				Value:  "bar",
-				Images: []string{"docker", "gcr"},
-				Events: []string{"push", "tag"},
+				Key:        "octocat",
+				Name:       "foo",
+				Value:      "bar",
+				Images:     []string{"docker", "gcr"},
+				Events:     []string{"push", "tag"},
+				SkipVerify: false,
 			}
 			err := s.SetTeamSecret(secret)
 			g.Assert(err == nil).IsTrue()


### PR DESCRIPTION
First step in allowing YAML verification to be skipped for on-prem deploys.