### PR TITLE
Feature label

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -111,6 +111,8 @@ type Client interface {
 	// Pull pulls work from the server queue.
 	Pull(os, arch string) (*queue.Work, error)
 
+	PullLabels([]string) (*queue.Work, error)
+
 	// Push pushes an update to the server.
 	Push(*queue.Work) error
 

--- a/client/client_impl.go
+++ b/client/client_impl.go
@@ -20,13 +20,14 @@ import (
 )
 
 const (
-	pathPull     = "%s/api/queue/pull/%s/%s"
-	pathWait     = "%s/api/queue/wait/%d"
-	pathStream   = "%s/api/queue/stream/%d"
-	pathPush     = "%s/api/queue/status/%d"
-	pathPing     = "%s/api/queue/ping"
-	pathLogs     = "%s/api/queue/logs/%d"
-	pathLogsAuth = "%s/api/queue/logs/%d?access_token=%s"
+	pathPull      = "%s/api/queue/pull/%s/%s"
+	pathPullLabel = "%s/api/queue/pull/"
+	pathWait      = "%s/api/queue/wait/%d"
+	pathStream    = "%s/api/queue/stream/%d"
+	pathPush      = "%s/api/queue/status/%d"
+	pathPing      = "%s/api/queue/ping"
+	pathLogs      = "%s/api/queue/logs/%d"
+	pathLogsAuth  = "%s/api/queue/logs/%d?access_token=%s"
 
 	pathSelf        = "%s/api/user"
 	pathFeed        = "%s/api/user/feed"
@@ -332,6 +333,17 @@ func (c *client) Pull(os, arch string) (*queue.Work, error) {
 	out := new(queue.Work)
 	uri := fmt.Sprintf(pathPull, c.base, os, arch)
 	err := c.post(uri, nil, out)
+	return out, err
+}
+
+func (c *client) PullLabels(labels []string) (*queue.Work, error) {
+	out := new(queue.Work)
+	in := struct{
+		Labels []string `json:"labels"`
+	}
+	in.Labels = labels
+	uri := fmt.Sprintf(pathPullLabel, c.base)
+	err := c.post(uri, in, out)
 	return out, err
 }
 

--- a/client/client_impl.go
+++ b/client/client_impl.go
@@ -338,9 +338,9 @@ func (c *client) Pull(os, arch string) (*queue.Work, error) {
 
 func (c *client) PullLabels(labels []string) (*queue.Work, error) {
 	out := new(queue.Work)
-	in := struct{
+	in := struct {
 		Labels []string `json:"labels"`
-	}
+	}{}
 	in.Labels = labels
 	uri := fmt.Sprintf(pathPullLabel, c.base)
 	err := c.post(uri, in, out)

--- a/client/client_impl.go
+++ b/client/client_impl.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	pathPull      = "%s/api/queue/pull/%s/%s"
-	pathPullLabel = "%s/api/queue/pull/"
+	pathPullLabel = "%s/api/queue/pull"
 	pathWait      = "%s/api/queue/wait/%d"
 	pathStream    = "%s/api/queue/stream/%d"
 	pathPush      = "%s/api/queue/status/%d"

--- a/drone/agent/agent.go
+++ b/drone/agent/agent.go
@@ -127,7 +127,7 @@ var AgentCmd = cli.Command{
 			Name:   "labels",
 			Usage:  "agent labels",
 			Value: &cli.StringSlice{
-				"default",
+				"*",
 			},
 		},
 		cli.StringFlag{

--- a/drone/agent/agent.go
+++ b/drone/agent/agent.go
@@ -11,9 +11,10 @@ import (
 	"github.com/drone/drone/shared/token"
 	"github.com/samalba/dockerclient"
 
+	"strings"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
-	"strings"
 )
 
 // AgentCmd is the exported command for starting the drone agent.
@@ -121,6 +122,14 @@ var AgentCmd = cli.Command{
 				"plugins/ecr:*",
 			},
 		},
+		cli.StringSliceFlag{
+			EnvVar: "DRONE_AGENT_LABEL",
+			Name:   "labels",
+			Usage:  "agent labels",
+			Value: &cli.StringSlice{
+				"default",
+			},
+		},
 		cli.StringFlag{
 			EnvVar: "DRONE_PLUGIN_NAMESPACE",
 			Name:   "namespace",
@@ -194,6 +203,7 @@ func start(c *cli.Context) {
 					privileged: c.StringSlice("privileged"),
 					pull:       c.BoolT("pull"),
 					logs:       int64(c.Int("max-log-size")) * 1000000,
+					labels:     c.StringSlice("labels"),
 				},
 			}
 			for {

--- a/drone/agent/exec.go
+++ b/drone/agent/exec.go
@@ -20,6 +20,7 @@ type config struct {
 	pull       bool
 	logs       int64
 	timeout    time.Duration
+	labels     []string
 }
 
 type pipeline struct {
@@ -29,7 +30,7 @@ type pipeline struct {
 }
 
 func (r *pipeline) run() error {
-	w, err := r.drone.Pull("linux", "amd64")
+	w, err := r.drone.PullLabels(r.config.labels)
 	if err != nil {
 		return err
 	}

--- a/drone/agent/exec.go
+++ b/drone/agent/exec.go
@@ -31,6 +31,7 @@ type pipeline struct {
 
 func (r *pipeline) run() error {
 	w, err := r.drone.PullLabels(r.config.labels)
+
 	if err != nil {
 		return err
 	}

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -13,7 +13,7 @@ import (
 var ErrNotFound = errors.New("queue item not found")
 
 const (
-	DefaultLabel = "default"
+	DefaultLabel = "*"
 )
 
 type Queue interface {

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -12,6 +12,10 @@ import (
 // exist in the queue.
 var ErrNotFound = errors.New("queue item not found")
 
+const (
+	DefaultLabel = "default"
+)
+
 type Queue interface {
 	// Publish inserts work at the tail of this queue, waiting for
 	// space to become available if the queue is full.
@@ -25,11 +29,15 @@ type Queue interface {
 	// waiting if necessary until work becomes available.
 	Pull() *Work
 
+	PullWithLabels([]string) *Work
+
 	// PullClose retrieves and removes the head of this queue,
 	// waiting if necessary until work becomes available. The
 	// CloseNotifier should be provided to clone the channel
 	// if the subscribing client terminates its connection.
 	PullClose(CloseNotifier) *Work
+
+	PullCloseWithLabels([]string, CloseNotifier) *Work
 }
 
 // Publish inserts work at the tail of this queue, waiting for
@@ -50,12 +58,20 @@ func Pull(c context.Context) *Work {
 	return FromContext(c).Pull()
 }
 
+func PullWithLabels(c context.Context, labels []string) *Work {
+	return FromContext(c).PullWithLabels(labels)
+}
+
 // PullClose retrieves and removes the head of this queue,
 // waiting if necessary until work becomes available. The
 // CloseNotifier should be provided to clone the channel
 // if the subscribing client terminates its connection.
 func PullClose(c context.Context, cn CloseNotifier) *Work {
 	return FromContext(c).PullClose(cn)
+}
+
+func PullCloseWithLabels(c context.Context, labels []string, cn CloseNotifier) *Work {
+	return FromContext(c).PullCloseWithLabels(labels, cn)
 }
 
 // CloseNotifier defines a datastructure that is capable of notifying

--- a/queue/queue_impl.go
+++ b/queue/queue_impl.go
@@ -1,12 +1,15 @@
 package queue
 
-import "sync"
+import (
+	"reflect"
+	"sync"
+)
 
 type queue struct {
 	sync.Mutex
 
 	items map[*Work]struct{}
-	itemc chan *Work
+	itemc map[string]chan *Work
 }
 
 func New() Queue {
@@ -16,15 +19,21 @@ func New() Queue {
 func newQueue() *queue {
 	return &queue{
 		items: make(map[*Work]struct{}),
-		itemc: make(chan *Work, 999),
+		itemc: make(map[string]chan *Work),
 	}
 }
 
 func (q *queue) Publish(work *Work) error {
 	q.Lock()
+	if work.Label == "" {
+		work.Label = DefaultLabel
+	}
+	if _, ok := q.itemc[work.Label]; !ok {
+		q.itemc[work.Label] = make(chan *Work, 999)
+	}
 	q.items[work] = struct{}{}
 	q.Unlock()
-	q.itemc <- work
+	q.itemc[work.Label] <- work
 	return nil
 }
 
@@ -43,7 +52,7 @@ func (q *queue) Remove(work *Work) error {
 drain:
 	for {
 		select {
-		case item := <-q.itemc:
+		case item := <-q.itemc[work.Label]:
 			items = append(items, item)
 		default:
 			break drain
@@ -57,29 +66,44 @@ drain:
 			delete(q.items, work)
 			continue
 		}
-		q.itemc <- item
+		q.itemc[work.Label] <- item
 	}
 	return nil
 }
 
-func (q *queue) Pull() *Work {
-	work := <-q.itemc
-	q.Lock()
-	delete(q.items, work)
-	q.Unlock()
+func (q *queue) PullWithLabels(labels []string) *Work {
+	cases := make([]reflect.SelectCase, 0)
+	for _, label := range labels {
+		if _, ok := q.itemc[label]; ok {
+			cases = append(cases, reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(q.itemc[label])})
+		}
+	}
+	_, value, _ := reflect.Select(cases)
+	work := value.Interface().(*Work)
 	return work
 }
 
+func (q *queue) Pull() *Work {
+	return q.PullWithLabels([]string{DefaultLabel})
+}
+
 func (q *queue) PullClose(cn CloseNotifier) *Work {
-	for {
-		select {
-		case <-cn.CloseNotify():
-			return nil
-		case work := <-q.itemc:
-			q.Lock()
-			delete(q.items, work)
-			q.Unlock()
-			return work
+	return q.PullCloseWithLabels([]string{DefaultLabel}, cn)
+}
+
+func (q *queue) PullCloseWithLabels(labels []string, cn CloseNotifier) *Work {
+	cases := make([]reflect.SelectCase, 0)
+	for _, label := range labels {
+		if _, ok := q.itemc[label]; ok {
+			cases = append(cases, reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(q.itemc[label])})
 		}
+	}
+	cases = append(cases, reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(cn.CloseNotify())})
+	sel, value, _ := reflect.Select(cases)
+	if sel == len(cases)-1 {
+		return nil
+	} else {
+		work := value.Interface().(*Work)
+		return work
 	}
 }

--- a/queue/types.go
+++ b/queue/types.go
@@ -18,4 +18,5 @@ type Work struct {
 	System    *model.System   `json:"system"`
 	Secrets   []*model.Secret `json:"secrets"`
 	User      *model.User     `json:"user"`
+	Label     string
 }

--- a/server/hook.go
+++ b/server/hook.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 
 	"github.com/gin-gonic/gin"
-	"github.com/square/go-jose"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/drone/drone/bus"
@@ -150,6 +149,8 @@ func PostHook(c *gin.Context) {
 		return
 	}
 
+	label := yaml.ParseLabel(raw)
+
 	// verify the branches can be built vs skipped
 	branches := yaml.ParseBranch(raw)
 	if !branches.Match(build.Branch) && build.Event != model.EventTag && build.Event != model.EventDeploy {
@@ -225,6 +226,7 @@ func PostHook(c *gin.Context) {
 			Yaml:      string(raw),
 			Secrets:   secs,
 			System:    &model.System{Link: httputil.GetURL(c.Request)},
+			Label:     label,
 		})
 	}
 

--- a/server/hook.go
+++ b/server/hook.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	jose "github.com/square/go-jose"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/drone/drone/bus"
 	"github.com/drone/drone/model"

--- a/server/queue.go
+++ b/server/queue.go
@@ -26,10 +26,11 @@ func Pull(c *gin.Context) {
 	labels := &struct {
 		Labels []string `json:"labels"`
 	}{}
+
+	c.BindJSON(labels)
 	if len(labels.Labels) == 0 {
 		labels.Labels = []string{queue.DefaultLabel}
 	}
-	c.BindJSON(labels)
 
 	w := queue.PullCloseWithLabels(c, labels.Labels, c.Writer)
 	if w == nil {

--- a/server/queue.go
+++ b/server/queue.go
@@ -23,7 +23,15 @@ import (
 func Pull(c *gin.Context) {
 	logrus.Debugf("Agent %s connected.", c.ClientIP())
 
-	w := queue.PullClose(c, c.Writer)
+	labels := &struct{
+		Labels []string `json:"labels"`
+	}
+	if len(labels.Labels) == 0{
+		labels.Labels = []string{DefaultLabel}
+	}
+	c.BindJSON(labels)
+
+	w := queue.PullCloseWithLabels(c,  labels.Labels, c.Writer)
 	if w == nil {
 		logrus.Debugf("Agent %s could not pull work.", c.ClientIP())
 	} else {

--- a/server/queue.go
+++ b/server/queue.go
@@ -23,15 +23,15 @@ import (
 func Pull(c *gin.Context) {
 	logrus.Debugf("Agent %s connected.", c.ClientIP())
 
-	labels := &struct{
+	labels := &struct {
 		Labels []string `json:"labels"`
-	}
-	if len(labels.Labels) == 0{
-		labels.Labels = []string{DefaultLabel}
+	}{}
+	if len(labels.Labels) == 0 {
+		labels.Labels = []string{queue.DefaultLabel}
 	}
 	c.BindJSON(labels)
 
-	w := queue.PullCloseWithLabels(c,  labels.Labels, c.Writer)
+	w := queue.PullCloseWithLabels(c, labels.Labels, c.Writer)
 	if w == nil {
 		logrus.Debugf("Agent %s could not pull work.", c.ClientIP())
 	} else {

--- a/yaml/config.go
+++ b/yaml/config.go
@@ -12,6 +12,7 @@ type Workspace struct {
 type Config struct {
 	Image     string
 	Build     *Build
+	Label     string
 	Workspace *Workspace
 	Pipeline  []*Container
 	Services  []*Container
@@ -29,6 +30,7 @@ func Parse(data []byte) (*Config, error) {
 	v := struct {
 		Image     string
 		Build     *Build
+		Label     string
 		Workspace *Workspace
 		Services  containerList
 		Pipeline  containerList
@@ -48,6 +50,7 @@ func Parse(data []byte) (*Config, error) {
 	return &Config{
 		Image:     v.Image,
 		Build:     v.Build,
+		Label:     v.Label,
 		Workspace: v.Workspace,
 		Services:  v.Services.containers,
 		Pipeline:  v.Pipeline.containers,
@@ -59,6 +62,7 @@ func Parse(data []byte) (*Config, error) {
 type config struct {
 	Image     string
 	Build     *Build
+	Label     string
 	Workspace *Workspace
 	Services  containerList
 	Pipeline  containerList

--- a/yaml/label.go
+++ b/yaml/label.go
@@ -1,0 +1,18 @@
+package yaml
+
+import "gopkg.in/yaml.v2"
+
+// ParseBranch parses the branch section of the Yaml document.
+func ParseLabel(in []byte) string {
+	out := struct {
+		Label string `yaml:"label"`
+	}{}
+
+	yaml.Unmarshal(in, &out)
+	return out.Label
+}
+
+// ParseBranchString parses the branch section of the Yaml document.
+func ParseLabelString(in string) string {
+	return ParseLabel([]byte(in))
+}

--- a/yaml/label_test.go
+++ b/yaml/label_test.go
@@ -1,0 +1,21 @@
+package yaml
+
+import (
+	"testing"
+
+	"github.com/franela/goblin"
+)
+
+func TestLabel(t *testing.T) {
+	g := goblin.Goblin(t)
+
+	g.Describe("Parser", func() {
+		g.Describe("Given a yaml file", func() {
+
+			g.It("Should parse a label", func() {
+				out := ParseLabelString("label: test")
+				g.Assert(out).Equal("test")
+			})
+		})
+	})
+}


### PR DESCRIPTION
add label support
1. work has label, default "*"
2. agent has support labels, default ["*"]
3. agent pull from server will register a support label 
4. server publish will add work to labeled queue, if label not support , work will go to  queue with label "*"
5. so, work with label "a" will run on agent contains label "a", if no agent support "a", work will run on agent  contains label "*".