### PR TITLE
Add jobs property to build model

### DIFF
--- a/model/build.go
+++ b/model/build.go
@@ -27,6 +27,7 @@ type Build struct {
 	Link      string `json:"link_url"      meddler:"build_link"`
 	Signed    bool   `json:"signed"        meddler:"build_signed"`
 	Verified  bool   `json:"verified"      meddler:"build_verified"`
+	Jobs      []*Job `json:"jobs,omitempty" meddler:"-"`
 }
 
 type BuildGroup struct {


### PR DESCRIPTION
As per #1840 suggestion from @bradrydzewski, adding this property to the model to allow jobs to be accessed in the build model from the client.