### PR TITLE
Proxy values should not be made uppercase

### DIFF
--- a/yaml/transform/environ.go
+++ b/yaml/transform/environ.go
@@ -32,15 +32,15 @@ func Environ(c *yaml.Config, envs map[string]string) error {
 		}
 		if httpProxy != "" {
 			p.Environment["HTTP_PROXY"] = httpProxy
-			p.Environment["http_proxy"] = strings.ToUpper(httpProxy)
+			p.Environment["http_proxy"] = httpProxy
 		}
 		if httpsProxy != "" {
 			p.Environment["HTTPS_PROXY"] = httpsProxy
-			p.Environment["https_proxy"] = strings.ToUpper(httpsProxy)
+			p.Environment["https_proxy"] = httpsProxy
 		}
 		if noProxy != "" {
 			p.Environment["NO_PROXY"] = noProxy
-			p.Environment["no_proxy"] = strings.ToUpper(noProxy)
+			p.Environment["no_proxy"] = noProxy
 		}
 	}
 	return nil

--- a/yaml/transform/environ.go
+++ b/yaml/transform/environ.go
@@ -2,7 +2,6 @@ package transform
 
 import (
 	"os"
-	"strings"
 
 	"github.com/drone/drone/yaml"
 )


### PR DESCRIPTION
The value of `HTTP_PROXY` and `http_proxy` should be the same. URLs are actually case sensitive so this transformation should not happen. https://www.w3.org/TR/WD-html40-970708/htmlweb.html

This is actually breaking me in the docker plugin as alpine doesn't like the uppercase proxy name. Could be the case for other scenarios.