### PR TITLE
fixes trailing slash on DRONE_SERVER env variable

### DIFF
--- a/drone/util.go
+++ b/drone/util.go
@@ -15,7 +15,7 @@ import (
 
 func newClient(c *cli.Context) (client.Client, error) {
 	var token = c.GlobalString("token")
-	var server = c.GlobalString("server")
+	var server = strings.TrimRight(c.GlobalString("server"), "/")
 
 	// if no server url is provided we can default
 	// to the hosted Drone service.


### PR DESCRIPTION
Got stuck on this longer than I dare to admit.

Fixes accidental trailing slash in the `DRONE_SERVER` environment variable from throwing exceptions in the CLI.

If the trailing slash is present, it tries to parse the HTML of a 404 page resulting in a cryptic exception:

`invalid character '<' looking for beginning of value`

Related to https://github.com/drone/drone/pull/1756