### PR TITLE
Feature/secret concealer backend

### DIFF
--- a/drone/secret.go
+++ b/drone/secret.go
@@ -45,6 +45,10 @@ func secretAddFlags() []cli.Flag {
 			Name:  "skip-verify",
 			Usage: "skip verification for the secret",
 		},
+		cli.BoolFlag{
+			Name:  "conceal",
+			Usage: "conceal secret in build logs",
+		},
 	}
 }
 
@@ -73,6 +77,7 @@ func secretParseCmd(name string, value string, c *cli.Context) (*model.Secret, e
 	secret.Images = c.StringSlice("image")
 	secret.Events = c.StringSlice("event")
 	secret.SkipVerify = c.Bool("skip-verify")
+	secret.Conceal = c.Bool("conceal")
 
 	if len(secret.Images) == 0 {
 		return nil, fmt.Errorf("Please specify the --image parameter")
@@ -122,6 +127,7 @@ var tmplSecretList = "\x1b[33m{{ .Name }} \x1b[0m" + `
 Images: {{ list .Images }}
 Events: {{ list .Events }}
 SkipVerify: {{ .SkipVerify }}
+Conceal: {{ .Conceal }}
 `
 
 var secretFuncMap = template.FuncMap{

--- a/model/repo_secret.go
+++ b/model/repo_secret.go
@@ -23,6 +23,9 @@ type RepoSecret struct {
 
 	// whether the secret requires verification
 	SkipVerify bool `json:"skip_verify" meddler:"secret_skip_verify"`
+
+	// whether the secret should be concealed in the build log
+	Conceal bool `json:"conceal" meddler:"secret_conceal"`
 }
 
 // Secret transforms a repo secret into a simple secret.
@@ -33,6 +36,7 @@ func (s *RepoSecret) Secret() *Secret {
 		Images:     s.Images,
 		Events:     s.Events,
 		SkipVerify: s.SkipVerify,
+		Conceal:    s.Conceal,
 	}
 }
 
@@ -44,6 +48,7 @@ func (s *RepoSecret) Clone() *RepoSecret {
 		Images:     s.Images,
 		Events:     s.Events,
 		SkipVerify: s.SkipVerify,
+		Conceal:    s.Conceal,
 	}
 }
 

--- a/model/secret.go
+++ b/model/secret.go
@@ -21,6 +21,9 @@ type Secret struct {
 
 	// whether the secret requires verification
 	SkipVerify bool `json:"skip_verify"`
+
+	// whether the secret should be concealed in the build log
+	Conceal bool `json:"conceal"`
 }
 
 // Match returns true if an image and event match the restricted list.

--- a/model/team_secret.go
+++ b/model/team_secret.go
@@ -23,6 +23,9 @@ type TeamSecret struct {
 
 	// whether the secret requires verification
 	SkipVerify bool `json:"skip_verify" meddler:"team_secret_skip_verify"`
+
+	// whether the secret should be concealed in the build log
+	Conceal bool `json:"conceal" meddler:"team_secret_conceal"`
 }
 
 // Secret transforms a repo secret into a simple secret.
@@ -33,6 +36,7 @@ func (s *TeamSecret) Secret() *Secret {
 		Images:     s.Images,
 		Events:     s.Events,
 		SkipVerify: s.SkipVerify,
+		Conceal:    s.Conceal,
 	}
 }
 
@@ -44,6 +48,7 @@ func (s *TeamSecret) Clone() *TeamSecret {
 		Images:     s.Images,
 		Events:     s.Events,
 		SkipVerify: s.SkipVerify,
+		Conceal:    s.Conceal,
 	}
 }
 

--- a/store/datastore/ddl/mysql/10.sql
+++ b/store/datastore/ddl/mysql/10.sql
@@ -1,0 +1,12 @@
+-- +migrate Up
+
+ALTER TABLE secrets      ADD COLUMN secret_conceal      BOOLEAN;
+ALTER TABLE team_secrets ADD COLUMN team_secret_conceal BOOLEAN;
+
+UPDATE secrets      SET secret_conceal      = false;
+UPDATE team_secrets SET team_secret_conceal = false;
+
+-- +migrate Down
+
+ALTER TABLE secrets      DROP COLUMN secret_conceal;
+ALTER TABLE team_secrets DROP COLUMN team_secret_conceal;

--- a/store/datastore/ddl/postgres/10.sql
+++ b/store/datastore/ddl/postgres/10.sql
@@ -1,0 +1,12 @@
+-- +migrate Up
+
+ALTER TABLE secrets      ADD COLUMN secret_conceal      BOOLEAN;
+ALTER TABLE team_secrets ADD COLUMN team_secret_conceal BOOLEAN;
+
+UPDATE secrets      SET secret_conceal      = false;
+UPDATE team_secrets SET team_secret_conceal = false;
+
+-- +migrate Down
+
+ALTER TABLE secrets      DROP COLUMN secret_conceal;
+ALTER TABLE team_secrets DROP COLUMN team_secret_conceal;

--- a/store/datastore/ddl/sqlite3/10.sql
+++ b/store/datastore/ddl/sqlite3/10.sql
@@ -1,0 +1,12 @@
+-- +migrate Up
+
+ALTER TABLE secrets      ADD COLUMN secret_conceal      BOOLEAN;
+ALTER TABLE team_secrets ADD COLUMN team_secret_conceal BOOLEAN;
+
+UPDATE secrets      SET secret_conceal      = 0;
+UPDATE team_secrets SET team_secret_conceal = 0;
+
+-- +migrate Down
+
+ALTER TABLE secrets      DROP COLUMN secret_conceal;
+ALTER TABLE team_secrets DROP COLUMN team_secret_conceal;

--- a/store/datastore/repo_secret_test.go
+++ b/store/datastore/repo_secret_test.go
@@ -28,7 +28,8 @@ func TestRepoSecrets(t *testing.T) {
 				Value:      "bar",
 				Images:     []string{"docker", "gcr"},
 				Events:     []string{"push", "tag"},
-				SkipVerify: false,
+				SkipVerify: true,
+				Conceal:    true,
 			}
 			err := s.SetSecret(secret)
 			g.Assert(err == nil).IsTrue()
@@ -40,6 +41,8 @@ func TestRepoSecrets(t *testing.T) {
 			g.Assert(got.Value).Equal(secret.Value)
 			g.Assert(got.Images).Equal(secret.Images)
 			g.Assert(got.Events).Equal(secret.Events)
+			g.Assert(got.SkipVerify).Equal(secret.SkipVerify)
+			g.Assert(got.Conceal).Equal(secret.Conceal)
 		})
 
 		g.It("Should update a secret", func() {

--- a/store/datastore/team_secret_test.go
+++ b/store/datastore/team_secret_test.go
@@ -28,7 +28,8 @@ func TestTeamSecrets(t *testing.T) {
 				Value:      "bar",
 				Images:     []string{"docker", "gcr"},
 				Events:     []string{"push", "tag"},
-				SkipVerify: false,
+				SkipVerify: true,
+				Conceal:    true,
 			}
 			err := s.SetTeamSecret(secret)
 			g.Assert(err == nil).IsTrue()
@@ -40,6 +41,8 @@ func TestTeamSecrets(t *testing.T) {
 			g.Assert(got.Value).Equal(secret.Value)
 			g.Assert(got.Images).Equal(secret.Images)
 			g.Assert(got.Events).Equal(secret.Events)
+			g.Assert(got.SkipVerify).Equal(secret.SkipVerify)
+			g.Assert(got.Conceal).Equal(secret.Conceal)
 		})
 
 		g.It("Should update a secret", func() {


### PR DESCRIPTION
This adds `Conceal` to repo and team secret models. This will be used to conceal secrets within the build logs. Next step is to actually conceal the secrets according to this value.

@bradrydzewski @vaijab 