### PR TITLE
populate github refspec

### DIFF
--- a/remote/bitbucket/convert.go
+++ b/remote/bitbucket/convert.go
@@ -149,10 +149,14 @@ func convertTeam(from *internal.Account) *model.Team {
 // hook to the Drone build struct holding commit information.
 func convertPullHook(from *internal.PullRequestHook) *model.Build {
 	return &model.Build{
-		Event:     model.EventPull,
-		Commit:    from.PullRequest.Dest.Commit.Hash,
-		Ref:       fmt.Sprintf("refs/heads/%s", from.PullRequest.Dest.Branch.Name),
-		Remote:    cloneLink(&from.PullRequest.Dest.Repo),
+		Event:  model.EventPull,
+		Commit: from.PullRequest.Dest.Commit.Hash,
+		Ref:    fmt.Sprintf("refs/heads/%s", from.PullRequest.Dest.Branch.Name),
+		Refspec: fmt.Sprintf("%s:%s",
+			from.PullRequest.Source.Branch.Name,
+			from.PullRequest.Dest.Branch.Name,
+		),
+		Remote:    fmt.Sprintf("https://bitbucket.org/%s", from.PullRequest.Source.Repo.FullName),
 		Link:      from.PullRequest.Links.Html.Href,
 		Branch:    from.PullRequest.Dest.Branch.Name,
 		Message:   from.PullRequest.Desc,

--- a/remote/bitbucket/convert_test.go
+++ b/remote/bitbucket/convert_test.go
@@ -139,6 +139,8 @@ func Test_helper(t *testing.T) {
 			hook.PullRequest.Dest.Commit.Hash = "73f9c44d"
 			hook.PullRequest.Dest.Branch.Name = "master"
 			hook.PullRequest.Dest.Repo.Links.Html.Href = "https://bitbucket.org/foo/bar"
+			hook.PullRequest.Source.Branch.Name = "change"
+			hook.PullRequest.Source.Repo.FullName = "baz/bar"
 			hook.PullRequest.Links.Html.Href = "https://bitbucket.org/foo/bar/pulls/5"
 			hook.PullRequest.Desc = "updated README"
 			hook.PullRequest.Updated = time.Now()
@@ -151,6 +153,8 @@ func Test_helper(t *testing.T) {
 			g.Assert(build.Branch).Equal(hook.PullRequest.Dest.Branch.Name)
 			g.Assert(build.Link).Equal(hook.PullRequest.Links.Html.Href)
 			g.Assert(build.Ref).Equal("refs/heads/master")
+			g.Assert(build.Refspec).Equal("change:master")
+			g.Assert(build.Remote).Equal("https://bitbucket.org/baz/bar")
 			g.Assert(build.Message).Equal(hook.PullRequest.Desc)
 			g.Assert(build.Timestamp).Equal(hook.PullRequest.Updated.Unix())
 		})

--- a/remote/github/convert.go
+++ b/remote/github/convert.go
@@ -28,6 +28,7 @@ const (
 const (
 	headRefs  = "refs/pull/%d/head"  // pull request unmerged
 	mergeRefs = "refs/pull/%d/merge" // pull request merged with base
+	refspec   = "%s:%s"
 )
 
 // convertStatus is a helper function used to convert a Drone status to a
@@ -229,6 +230,10 @@ func convertPullHook(from *webhook, merge bool) *model.Build {
 		Author:  from.PullRequest.User.Login,
 		Avatar:  from.PullRequest.User.Avatar,
 		Title:   from.PullRequest.Title,
+		Refspec: fmt.Sprintf(refspec,
+			from.PullRequest.Head.Ref,
+			from.PullRequest.Base.Ref,
+		),
 	}
 	if merge {
 		build.Ref = fmt.Sprintf(mergeRefs, from.PullRequest.Number)

--- a/remote/github/convert.go
+++ b/remote/github/convert.go
@@ -230,6 +230,7 @@ func convertPullHook(from *webhook, merge bool) *model.Build {
 		Author:  from.PullRequest.User.Login,
 		Avatar:  from.PullRequest.User.Avatar,
 		Title:   from.PullRequest.Title,
+		Remote:  from.PullRequest.Head.Repo.CloneURL,
 		Refspec: fmt.Sprintf(refspec,
 			from.PullRequest.Head.Ref,
 			from.PullRequest.Base.Ref,

--- a/remote/github/convert_test.go
+++ b/remote/github/convert_test.go
@@ -172,7 +172,8 @@ func Test_helper(t *testing.T) {
 
 		g.It("should convert a pull request from webhook", func() {
 			from := &webhook{}
-			from.PullRequest.Head.Ref = "master"
+			from.PullRequest.Base.Ref = "master"
+			from.PullRequest.Head.Ref = "changes"
 			from.PullRequest.Head.SHA = "f72fc19"
 			from.PullRequest.HTMLURL = "https://github.com/octocat/hello-world/pulls/42"
 			from.PullRequest.Number = 42
@@ -184,6 +185,7 @@ func Test_helper(t *testing.T) {
 			g.Assert(build.Event).Equal(model.EventPull)
 			g.Assert(build.Branch).Equal(from.PullRequest.Head.Ref)
 			g.Assert(build.Ref).Equal("refs/pull/42/merge")
+			g.Assert(build.Refspec).Equal("changes:master")
 			g.Assert(build.Commit).Equal(from.PullRequest.Head.SHA)
 			g.Assert(build.Message).Equal(from.PullRequest.Title)
 			g.Assert(build.Title).Equal(from.PullRequest.Title)

--- a/remote/github/convert_test.go
+++ b/remote/github/convert_test.go
@@ -175,6 +175,7 @@ func Test_helper(t *testing.T) {
 			from.PullRequest.Base.Ref = "master"
 			from.PullRequest.Head.Ref = "changes"
 			from.PullRequest.Head.SHA = "f72fc19"
+			from.PullRequest.Head.Repo.CloneURL = "https://github.com/octocat/hello-world-fork"
 			from.PullRequest.HTMLURL = "https://github.com/octocat/hello-world/pulls/42"
 			from.PullRequest.Number = 42
 			from.PullRequest.Title = "Updated README.md"
@@ -186,6 +187,7 @@ func Test_helper(t *testing.T) {
 			g.Assert(build.Branch).Equal(from.PullRequest.Head.Ref)
 			g.Assert(build.Ref).Equal("refs/pull/42/merge")
 			g.Assert(build.Refspec).Equal("changes:master")
+			g.Assert(build.Remote).Equal("https://github.com/octocat/hello-world-fork")
 			g.Assert(build.Commit).Equal(from.PullRequest.Head.SHA)
 			g.Assert(build.Message).Equal(from.PullRequest.Title)
 			g.Assert(build.Title).Equal(from.PullRequest.Title)

--- a/remote/github/fixtures/hooks.go
+++ b/remote/github/fixtures/hooks.go
@@ -70,6 +70,11 @@ const HookPullRequest = `
       "login": "baxterthehacker",
       "avatar_url": "https://avatars.githubusercontent.com/u/6752317?v=3"
     },
+    "base": {
+      "label": "baxterthehacker:master",
+      "ref": "master",
+      "sha": "9353195a19e45482665306e466c832c46560532d"
+    },
     "head": {
       "label": "baxterthehacker:changes",
       "ref": "changes",

--- a/remote/github/types.go
+++ b/remote/github/types.go
@@ -73,8 +73,11 @@ type webhook struct {
 		} `json:"base"`
 
 		Head struct {
-			SHA string `json:"sha"`
-			Ref string `json:"ref"`
+			SHA  string `json:"sha"`
+			Ref  string `json:"ref"`
+			Repo struct {
+				CloneURL string `json:"clone_url"`
+			} `json:"repo"`
 		} `json:"head"`
 	} `json:"pull_request"`
 }

--- a/remote/github/types.go
+++ b/remote/github/types.go
@@ -68,9 +68,13 @@ type webhook struct {
 			Avatar string `json:"avatar_url"`
 		} `json:"user"`
 
+		Base struct {
+			Ref string `json:"ref"`
+		} `json:"base"`
+
 		Head struct {
-			SHA string
-			Ref string
+			SHA string `json:"sha"`
+			Ref string `json:"ref"`
 		} `json:"head"`
 	} `json:"pull_request"`
 }

--- a/yaml/constraint.go
+++ b/yaml/constraint.go
@@ -8,6 +8,9 @@ import (
 
 // Constraints define constraints for container execution.
 type Constraints struct {
+	Repo        Constraint
+	Ref         Constraint
+	Refspec     Constraint
 	Platform    Constraint
 	Environment Constraint
 	Event       Constraint


### PR DESCRIPTION
this will populate the `refspec` field using the `<src>:<dest>` branches.

For example, lets say we have a pull request for feature branch `new-topic` that will get merged into `master`. The refspec would be stored as `new-topic:master`