### PR TITLE
add command line feature for chown api endpoint

### DIFF
--- a/drone/repo.go
+++ b/drone/repo.go
@@ -10,5 +10,6 @@ var repoCmd = cli.Command{
 		repoInfoCmd,
 		repoAddCmd,
 		repoRemoveCmd,
+		repoChownCmd,
 	},
 }

--- a/drone/repo_chown.go
+++ b/drone/repo_chown.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/codegangsta/cli"
+)
+
+var repoChownCmd = cli.Command{
+	Name:  "chown",
+	Usage: "assume ownership of a repository",
+	Action: func(c *cli.Context) {
+		if err := repoChown(c); err != nil {
+			log.Fatalln(err)
+		}
+	},
+}
+
+func repoChown(c *cli.Context) error {
+	repo := c.Args().First()
+	owner, name, err := parseRepo(repo)
+	if err != nil {
+		return err
+	}
+
+	client, err := newClient(c)
+	if err != nil {
+		return err
+	}
+
+	if _, err := client.RepoChown(owner, name); err != nil {
+		return err
+	}
+	fmt.Printf("Successfully assumed ownership of repository %s/%s\n", owner, name)
+	return nil
+}


### PR DESCRIPTION
This commit exposes the clients chown api via the command line 