### PR TITLE
extract email for bitbucket push requests from raw git commit

### DIFF
--- a/remote/bitbucket/convert.go
+++ b/remote/bitbucket/convert.go
@@ -2,6 +2,7 @@ package bitbucket
 
 import (
 	"fmt"
+	"regexp"
 	"net/url"
 	"strings"
 
@@ -186,5 +187,18 @@ func convertPushHook(hook *internal.PushHook, change *internal.Change) *model.Bu
 		build.Event = model.EventPush
 		build.Ref = fmt.Sprintf("refs/heads/%s", change.New.Name)
 	}
+	if len(change.New.Target.Author.Raw) != 0 {
+		build.Email = extractEmail(change.New.Target.Author.Raw)
+	}
 	return build
+}
+
+// extracts the email from a git commit author string
+func extractEmail(gitauthor string) (author string) {
+    re := regexp.MustCompile("<(.*)>")
+    matches := re.FindAllStringSubmatch(gitauthor,-1)
+    if len(matches) == 1 {
+        author = matches[0][1]
+    }
+    return
 }

--- a/remote/bitbucket/convert_test.go
+++ b/remote/bitbucket/convert_test.go
@@ -166,6 +166,7 @@ func Test_helper(t *testing.T) {
 			change.New.Target.Links.Html.Href = "https://bitbucket.org/foo/bar/commits/73f9c44d"
 			change.New.Target.Message = "updated README"
 			change.New.Target.Date = time.Now()
+			change.New.Target.Author.Raw = "Test <test@domain.tld>"
 
 			hook := internal.PushHook{}
 			hook.Actor.Login = "octocat"
@@ -173,6 +174,7 @@ func Test_helper(t *testing.T) {
 
 			build := convertPushHook(&hook, &change)
 			g.Assert(build.Event).Equal(model.EventPush)
+			g.Assert(build.Email).Equal("test@domain.tld")
 			g.Assert(build.Author).Equal(hook.Actor.Login)
 			g.Assert(build.Avatar).Equal(hook.Actor.Links.Avatar.Href)
 			g.Assert(build.Commit).Equal(change.New.Target.Hash)

--- a/remote/bitbucket/fixtures/hooks.go
+++ b/remote/bitbucket/fixtures/hooks.go
@@ -33,6 +33,7 @@ const HookPush = `
             "type": "commit",
             "hash": "709d658dc5b6d6afcd46049c2f332ee3f515a67d",
             "author": {
+              "raw": "emmap1 <email@domain.tld>",
               "username": "emmap1",
               "links": {
                 "avatar": {


### PR DESCRIPTION
A proposed solution for the missing `DRONE_COMMIT_AUTHOR_EMAIL` as mentioned in #1860 .

This solution extracts the email from the actual git author fields since bitbucket does not expose the bitbucket account email within the webhook body. This solution only works for push requests.