### PR TITLE
Add pprof endpoints

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -153,6 +153,21 @@ func Load(middleware ...gin.HandlerFunc) http.Handler {
 		agents.GET("", server.GetAgents)
 	}
 
+	debug := e.Group("/api/debug")
+	{
+		debug.Use(session.MustAdmin())
+		debug.GET("/pprof/", server.IndexHandler())
+		debug.GET("/pprof/heap", server.HeapHandler())
+		debug.GET("/pprof/goroutine", server.GoroutineHandler())
+		debug.GET("/pprof/block", server.BlockHandler())
+		debug.GET("/pprof/threadcreate", server.ThreadCreateHandler())
+		debug.GET("/pprof/cmdline", server.CmdlineHandler())
+		debug.GET("/pprof/profile", server.ProfileHandler())
+		debug.GET("/pprof/symbol", server.SymbolHandler())
+		debug.POST("/pprof/symbol", server.SymbolHandler())
+		debug.GET("/pprof/trace", server.TraceHandler())
+	}
+
 	// DELETE THESE
 	// gitlab := e.Group("/gitlab/:owner/:name")
 	// {

--- a/server/debug.go
+++ b/server/debug.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"net/http/pprof"
+
+	"github.com/gin-gonic/gin"
+)
+
+// IndexHandler will pass the call from /debug/pprof to pprof
+func IndexHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		pprof.Index(c.Writer, c.Request)
+	}
+}
+
+// HeapHandler will pass the call from /debug/pprof/heap to pprof
+func HeapHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		pprof.Handler("heap").ServeHTTP(c.Writer, c.Request)
+	}
+}
+
+// GoroutineHandler will pass the call from /debug/pprof/goroutine to pprof
+func GoroutineHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		pprof.Handler("goroutine").ServeHTTP(c.Writer, c.Request)
+	}
+}
+
+// BlockHandler will pass the call from /debug/pprof/block to pprof
+func BlockHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		pprof.Handler("block").ServeHTTP(c.Writer, c.Request)
+	}
+}
+
+// ThreadCreateHandler will pass the call from /debug/pprof/threadcreate to pprof
+func ThreadCreateHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		pprof.Handler("threadcreate").ServeHTTP(c.Writer, c.Request)
+	}
+}
+
+// CmdlineHandler will pass the call from /debug/pprof/cmdline to pprof
+func CmdlineHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		pprof.Cmdline(c.Writer, c.Request)
+	}
+}
+
+// ProfileHandler will pass the call from /debug/pprof/profile to pprof
+func ProfileHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		pprof.Profile(c.Writer, c.Request)
+	}
+}
+
+// SymbolHandler will pass the call from /debug/pprof/symbol to pprof
+func SymbolHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		pprof.Symbol(c.Writer, c.Request)
+	}
+}
+
+// TraceHandler will pass the call from /debug/pprof/trace to pprof
+func TraceHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		pprof.Trace(c.Writer, c.Request)
+	}
+}


### PR DESCRIPTION
I asked in drone-dev if @bradrydzewski would be interested in adding pprof endpoints to drone and he seemed open to it.  He did call out to adding a flag for enabling it.

This PR adds the endpoints but no flag yet.  I added them following an example @ https://github.com/DeanThompson/ginpprof

I don't mind trying to figure out adding a flag for this.  But I did add `MustAdmin()` ... so I was hoping that was maybe good enough?  If not let me know and I'll followup with a commit to add a flag as well as originally asked. 😉 

Also, let me know if you prefer the endpoints to be in different paths!