### PR TITLE
Remove /refs/tags or /refs/heads from Gogs remote File() when using build.Ref

### DIFF
--- a/remote/gogs/fixtures/handler.go
+++ b/remote/gogs/fixtures/handler.go
@@ -30,13 +30,13 @@ func getRepo(c *gin.Context) {
 }
 
 func getRepoFile(c *gin.Context) {
-  if c.Param("file") == "file_not_found" {
-    c.String(404, "")
-  }
-  if c.Param("commit") == "v1.0.0" || c.Param("commit") == "9ecad50" {
-    c.String(200, repoFilePayload)
-  }
-  c.String(404, "")
+	if c.Param("file") == "file_not_found" {
+		c.String(404, "")
+	}
+	if c.Param("commit") == "v1.0.0" || c.Param("commit") == "9ecad50" {
+		c.String(200, repoFilePayload)
+	}
+	c.String(404, "")
 }
 
 func createRepoHook(c *gin.Context) {

--- a/remote/gogs/fixtures/handler.go
+++ b/remote/gogs/fixtures/handler.go
@@ -30,12 +30,13 @@ func getRepo(c *gin.Context) {
 }
 
 func getRepoFile(c *gin.Context) {
-	switch c.Param("file") {
-	case "file_not_found":
-		c.String(404, "")
-	default:
-		c.String(200, repoFilePayload)
-	}
+  if c.Param("file") == "file_not_found" {
+    c.String(404, "")
+  }
+  if c.Param("commit") == "v1.0.0" || c.Param("commit") == "9ecad50" {
+    c.String(200, repoFilePayload)
+  }
+  c.String(404, "")
 }
 
 func createRepoHook(c *gin.Context) {

--- a/remote/gogs/gogs.go
+++ b/remote/gogs/gogs.go
@@ -177,13 +177,14 @@ func (c *client) File(u *model.User, r *model.Repo, b *model.Build, f string) ([
 	client := c.newClientToken(u.Token)
 	buildRef := b.Commit
 	if buildRef == "" {
-		buildRef = b.Ref
-
 		// Remove refs/tags or refs/heads, Gogs needs a short ref
-		refPath := strings.SplitAfterN(b.Ref, "/", 3)
-		if len(refPath) > 0 {
-			buildRef = refPath[len(refPath)-1]
-		}
+		buildRef = strings.TrimPrefix(
+			strings.TrimPrefix(
+				b.Ref,
+				"refs/heads/",
+			),
+			"refs/tags/",
+		)
 	}
 	cfg, err := client.GetFile(r.Owner, r.Name, buildRef, f)
 	return cfg, err

--- a/remote/gogs/gogs.go
+++ b/remote/gogs/gogs.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+  "strings"
 
 	"github.com/drone/drone/model"
 	"github.com/drone/drone/remote"
@@ -177,6 +178,12 @@ func (c *client) File(u *model.User, r *model.Repo, b *model.Build, f string) ([
 	buildRef := b.Commit
 	if buildRef == "" {
 		buildRef = b.Ref
+
+		// Remove refs/tags or refs/heads, Gogs needs a short ref
+		refPath := strings.SplitAfterN(b.Ref, "/", 3)
+		if len(refPath) > 0 {
+			buildRef = refPath[len(refPath)-1]
+		}
 	}
 	cfg, err := client.GetFile(r.Owner, r.Name, buildRef, f)
 	return cfg, err

--- a/remote/gogs/gogs.go
+++ b/remote/gogs/gogs.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-  "strings"
+	"strings"
 
 	"github.com/drone/drone/model"
 	"github.com/drone/drone/remote"

--- a/remote/gogs/gogs_test.go
+++ b/remote/gogs/gogs_test.go
@@ -128,11 +128,11 @@ func Test_gogs(t *testing.T) {
 			g.Assert(string(raw)).Equal("{ platform: linux/amd64 }")
 		})
 
-    g.It("Should return a repository file from a ref", func() {
-      raw, err := c.File(fakeUser, fakeRepo, fakeBuildWithRef, ".drone.yml")
+		g.It("Should return a repository file from a ref", func() {
+			raw, err := c.File(fakeUser, fakeRepo, fakeBuildWithRef, ".drone.yml")
 			g.Assert(err == nil).IsTrue()
 			g.Assert(string(raw)).Equal("{ platform: linux/amd64 }")
-    })
+		})
 
 		g.Describe("Given an authentication request", func() {
 			g.It("Should redirect to login form")
@@ -185,7 +185,7 @@ var (
 		Commit: "9ecad50",
 	}
 
-  fakeBuildWithRef = &model.Build{
-    Ref: "refs/tags/v1.0.0",
-  }
+	fakeBuildWithRef = &model.Build{
+		Ref: "refs/tags/v1.0.0",
+	}
 )

--- a/remote/gogs/gogs_test.go
+++ b/remote/gogs/gogs_test.go
@@ -128,6 +128,12 @@ func Test_gogs(t *testing.T) {
 			g.Assert(string(raw)).Equal("{ platform: linux/amd64 }")
 		})
 
+    g.It("Should return a repository file from a ref", func() {
+      raw, err := c.File(fakeUser, fakeRepo, fakeBuildWithRef, ".drone.yml")
+			g.Assert(err == nil).IsTrue()
+			g.Assert(string(raw)).Equal("{ platform: linux/amd64 }")
+    })
+
 		g.Describe("Given an authentication request", func() {
 			g.It("Should redirect to login form")
 			g.It("Should create an access token")
@@ -178,4 +184,8 @@ var (
 	fakeBuild = &model.Build{
 		Commit: "9ecad50",
 	}
+
+  fakeBuildWithRef = &model.Build{
+    Ref: "refs/tags/v1.0.0",
+  }
 )


### PR DESCRIPTION
Drone incorrectly used the full Git ref to retrieve a file using the Gogs API.
This is now fixed by removing the path from the ref (when a ref is used to retrieve a file). Behavior when using a Sha is not changed.

This PR fixes issue #1870.