### PR TITLE
Add pull_request webhook support to Gogs remote

### DIFF
--- a/remote/gogs/fixtures/hooks.go
+++ b/remote/gogs/fixtures/hooks.go
@@ -83,3 +83,55 @@ var HookPushTag = `{
     "avatar_url": "https://secure.gravatar.com/avatar/8c58a0be77ee441bb8f8595b7f1b4e87"
   }
 }`
+
+// HookPullRequest is a sample pull_request webhook payload
+var HookPullRequest = `{
+  "action": "opened",
+  "number": 1,
+  "pull_request": {
+    "html_url": "http://gogs.golang.org/gordon/hello-world/pull/1",
+    "state": "open",
+    "title": "Update the README with new information",
+    "body": "please merge",
+    "user": {
+      "id": 1,
+      "username": "gordon",
+      "full_name": "Gordon the Gopher",
+      "email": "gordon@golang.org",
+      "avatar_url": "http://gogs.golang.org///1.gravatar.com/avatar/8c58a0be77ee441bb8f8595b7f1b4e87"
+    },
+    "base": {
+      "label": "master",
+      "ref": "master",
+      "sha": "9353195a19e45482665306e466c832c46560532d"
+    },
+    "head": {
+      "label": "feature/changes",
+      "ref": "feature/changes",
+      "sha": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c"
+    }
+  },
+  "repository": {
+    "id": 35129377,
+    "name": "hello-world",
+    "full_name": "gordon/hello-world",
+    "owner": {
+      "id": 1,
+      "username": "gordon",
+      "full_name": "Gordon the Gopher",
+      "email": "gordon@golang.org",
+      "avatar_url": "https://secure.gravatar.com/avatar/8c58a0be77ee441bb8f8595b7f1b4e87"
+    },
+    "private": true,
+    "html_url": "http://gogs.golang.org/gordon/hello-world",
+    "clone_url": "https://gogs.golang.org/gordon/hello-world.git",
+    "default_branch": "master"
+  },
+  "sender": {
+      "id": 1,
+      "username": "gordon",
+      "full_name": "Gordon the Gopher",
+      "email": "gordon@golang.org",
+      "avatar_url": "https://secure.gravatar.com/avatar/8c58a0be77ee441bb8f8595b7f1b4e87"
+    }
+}`

--- a/remote/gogs/helper_test.go
+++ b/remote/gogs/helper_test.go
@@ -53,6 +53,32 @@ func Test_parse(t *testing.T) {
 			g.Assert(hook.Sender.Avatar).Equal("https://secure.gravatar.com/avatar/8c58a0be77ee441bb8f8595b7f1b4e87")
 		})
 
+		g.It("Should parse pull_request hook payload", func() {
+			buf := bytes.NewBufferString(fixtures.HookPullRequest)
+			hook, err := parsePullRequest(buf)
+			g.Assert(err == nil).IsTrue()
+			g.Assert(hook.Action).Equal("opened")
+			g.Assert(hook.Number).Equal(int64(1))
+
+			g.Assert(hook.Repo.Name).Equal("hello-world")
+			g.Assert(hook.Repo.URL).Equal("http://gogs.golang.org/gordon/hello-world")
+			g.Assert(hook.Repo.FullName).Equal("gordon/hello-world")
+			g.Assert(hook.Repo.Owner.Email).Equal("gordon@golang.org")
+			g.Assert(hook.Repo.Owner.Username).Equal("gordon")
+			g.Assert(hook.Repo.Private).Equal(true)
+			g.Assert(hook.Sender.Username).Equal("gordon")
+			g.Assert(hook.Sender.Avatar).Equal("https://secure.gravatar.com/avatar/8c58a0be77ee441bb8f8595b7f1b4e87")
+
+			g.Assert(hook.PullRequest.Title).Equal("Update the README with new information")
+			g.Assert(hook.PullRequest.Body).Equal("please merge")
+			g.Assert(hook.PullRequest.State).Equal("open")
+			g.Assert(hook.PullRequest.User.Username).Equal("gordon")
+			g.Assert(hook.PullRequest.Base.Label).Equal("master")
+			g.Assert(hook.PullRequest.Base.Ref).Equal("master")
+			g.Assert(hook.PullRequest.Head.Label).Equal("feature/changes")
+			g.Assert(hook.PullRequest.Head.Ref).Equal("feature/changes")
+		})
+
 		g.It("Should return a Build struct from a push hook", func() {
 			buf := bytes.NewBufferString(fixtures.HookPush)
 			hook, _ := parsePush(buf)
@@ -72,6 +98,31 @@ func Test_parse(t *testing.T) {
 			buf := bytes.NewBufferString(fixtures.HookPush)
 			hook, _ := parsePush(buf)
 			repo := repoFromPush(hook)
+			g.Assert(repo.Name).Equal(hook.Repo.Name)
+			g.Assert(repo.Owner).Equal(hook.Repo.Owner.Username)
+			g.Assert(repo.FullName).Equal("gordon/hello-world")
+			g.Assert(repo.Link).Equal(hook.Repo.URL)
+		})
+
+		g.It("Should return a Build struct from a pull_request hook", func() {
+			buf := bytes.NewBufferString(fixtures.HookPullRequest)
+			hook, _ := parsePullRequest(buf)
+			build := buildFromPullRequest(hook)
+			g.Assert(build.Event).Equal(model.EventPull)
+			g.Assert(build.Commit).Equal(hook.PullRequest.Head.Sha)
+			g.Assert(build.Ref).Equal("refs/pull/1/head")
+			g.Assert(build.Link).Equal(hook.PullRequest.URL)
+			g.Assert(build.Branch).Equal("master")
+			g.Assert(build.Message).Equal(hook.PullRequest.Title)
+			g.Assert(build.Avatar).Equal("http://1.gravatar.com/avatar/8c58a0be77ee441bb8f8595b7f1b4e87")
+			g.Assert(build.Author).Equal(hook.PullRequest.User.Username)
+
+		})
+
+		g.It("Should return a Repo struct from a pull_request hook", func() {
+			buf := bytes.NewBufferString(fixtures.HookPullRequest)
+			hook, _ := parsePullRequest(buf)
+			repo := repoFromPullRequest(hook)
 			g.Assert(repo.Name).Equal(hook.Repo.Name)
 			g.Assert(repo.Owner).Equal(hook.Repo.Owner.Username)
 			g.Assert(repo.FullName).Equal("gordon/hello-world")

--- a/remote/gogs/parse.go
+++ b/remote/gogs/parse.go
@@ -8,9 +8,15 @@ import (
 )
 
 const (
-	hookEvent   = "X-Gogs-Event"
-	hookPush    = "push"
-	hookCreated = "create"
+	hookEvent       = "X-Gogs-Event"
+	hookPush        = "push"
+	hookCreated     = "create"
+	hookPullRequest = "pull_request"
+
+	actionOpen = "opened"
+	actionSync = "synchronize"
+
+	stateOpen = "open"
 
 	refBranch = "branch"
 	refTag    = "tag"
@@ -24,6 +30,8 @@ func parseHook(r *http.Request) (*model.Repo, *model.Build, error) {
 		return parsePushHook(r.Body)
 	case hookCreated:
 		return parseCreatedHook(r.Body)
+	case hookPullRequest:
+		return parsePullRequestHook(r.Body)
 	}
 	return nil, nil, nil
 }
@@ -70,5 +78,30 @@ func parseCreatedHook(payload io.Reader) (*model.Repo, *model.Build, error) {
 
 	repo = repoFromPush(push)
 	build = buildFromTag(push)
+	return repo, build, err
+}
+
+// parsePullRequestHook parses a pull_request hook and returns the Repo and Build details.
+func parsePullRequestHook(payload io.Reader) (*model.Repo, *model.Build, error) {
+	var (
+		repo  *model.Repo
+		build *model.Build
+	)
+
+	pr, err := parsePullRequest(payload)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Don't trigger builds for non-code changes, or if PR is not open
+	if pr.Action != actionOpen && pr.Action != actionSync {
+		return nil, nil, nil
+	}
+	if pr.PullRequest.State != stateOpen {
+		return nil, nil, nil
+	}
+
+	repo = repoFromPullRequest(pr)
+	build = buildFromPullRequest(pr)
 	return repo, build, err
 }

--- a/remote/gogs/types.go
+++ b/remote/gogs/types.go
@@ -40,3 +40,85 @@ type pushHook struct {
 		Avatar   string `json:"avatar_url"`
 	} `json:"sender"`
 }
+
+type pullRequestHook struct {
+	Action      string `json:"action"`
+	Number      int64  `json:"number"`
+	PullRequest struct {
+		ID   int64 `json:"id"`
+		User struct {
+			ID       int64  `json:"id"`
+			Username string `json:"username"`
+			Name     string `json:"full_name"`
+			Email    string `json:"email"`
+			Avatar   string `json:"avatar_url"`
+		} `json:"user"`
+		Title     string   `json:"title"`
+		Body      string   `json:"body"`
+		Labels    []string `json:"labels"`
+		State     string   `json:"state"`
+		URL       string   `json:"html_url"`
+		Mergeable bool     `json:"mergeable"`
+		Merged    bool     `json:"merged"`
+		MergeBase string   `json:"merge_base"`
+		Base      struct {
+			Label string `json:"label"`
+			Ref   string `json:"ref"`
+			Sha   string `json:"sha"`
+			Repo  struct {
+				ID       int64  `json:"id"`
+				Name     string `json:"name"`
+				FullName string `json:"full_name"`
+				URL      string `json:"html_url"`
+				Private  bool   `json:"private"`
+				Owner    struct {
+					ID       int64  `json:"id"`
+					Username string `json:"username"`
+					Name     string `json:"full_name"`
+					Email    string `json:"email"`
+					Avatar   string `json:"avatar_url"`
+				} `json:"owner"`
+			} `json:"repo"`
+		} `json:"base"`
+		Head struct {
+			Label string `json:"label"`
+			Ref   string `json:"ref"`
+			Sha   string `json:"sha"`
+			Repo  struct {
+				ID       int64  `json:"id"`
+				Name     string `json:"name"`
+				FullName string `json:"full_name"`
+				URL      string `json:"html_url"`
+				Private  bool   `json:"private"`
+				Owner    struct {
+					ID       int64  `json:"id"`
+					Username string `json:"username"`
+					Name     string `json:"full_name"`
+					Email    string `json:"email"`
+					Avatar   string `json:"avatar_url"`
+				} `json:"owner"`
+			} `json:"repo"`
+		} `json:"head"`
+	} `json:"pull_request"`
+	Repo struct {
+		ID       int64  `json:"id"`
+		Name     string `json:"name"`
+		FullName string `json:"full_name"`
+		URL      string `json:"html_url"`
+		Private  bool   `json:"private"`
+		Owner    struct {
+			ID       int64  `json:"id"`
+			Username string `json:"username"`
+			Name     string `json:"full_name"`
+			Email    string `json:"email"`
+			Avatar   string `json:"avatar_url"`
+		} `json:"owner"`
+	} `json:"repository"`
+	Sender struct {
+		ID       int64  `json:"id"`
+		Username string `json:"username"`
+		Name     string `json:"full_name"`
+		Email    string `json:"email"`
+		Avatar   string `json:"avatar_url"`
+	} `json:"sender"`
+}


### PR DESCRIPTION
This PR adds support for pull_request type webhooks from Gogs and Gitea to the Gogs remote.

This will fix #1605.