### PR TITLE
Enable all webhook events by default for Gogs remote

### DIFF
--- a/remote/gogs/gogs.go
+++ b/remote/gogs/gogs.go
@@ -224,6 +224,7 @@ func (c *client) Activate(u *model.User, r *model.Repo, link string) error {
 	hook := gogs.CreateHookOption{
 		Type:   "gogs",
 		Config: config,
+		Events: []string{"push", "create", "pull_request"},
 		Active: true,
 	}
 


### PR DESCRIPTION
This PR enables all webhook events by default for Gogs and Gitea remotes. Since Drone now has support for all of these events, it makes sense to enable them in the webhook config.

This will save users the hassle of enabling these hooks every time they activate a repository in Drone.