### PR TITLE
Send retain:remove before unsubscribing

### DIFF
--- a/server/queue.go
+++ b/server/queue.go
@@ -145,8 +145,8 @@ func HandleUpdate(c context.Context, message *stomp.Message) {
 	}
 
 	defer func() {
-		client.Unsubscribe(sub)
 		client.Send(dest, []byte{}, stomp.WithRetain("remove"))
+		client.Unsubscribe(sub)
 	}()
 
 	select {


### PR DESCRIPTION
When finished logging send `retain:remove` message *before* `unsubscribe`ing.

This removes a "memory leak" and greatly reduces memory usage.