### PR TITLE
Added build event and deploy to hooks

### DIFF
--- a/server/build.go
+++ b/server/build.go
@@ -359,6 +359,14 @@ func PostBuild(c *gin.Context) {
 			stomp.WithHeaders(
 				yaml.ParseLabel(raw),
 			),
+			stomp.WithHeader(
+				"event",
+				build.Event,
+			),
+			stomp.WithHeader(
+				"deploy_to",
+				build.Deploy,
+			),
 		)
 	}
 }

--- a/server/hook.go
+++ b/server/hook.go
@@ -243,6 +243,14 @@ func PostHook(c *gin.Context) {
 			stomp.WithHeaders(
 				yaml.ParseLabel(raw),
 			),
+			stomp.WithHeader(
+				"event",
+				build.Event,
+			),
+			stomp.WithHeader(
+				"deploy_to",
+				build.Deploy,
+			),
 		)
 	}
 


### PR DESCRIPTION
I have my server and main agent on my development AWS account, and have an agent on my production AWS account, and would like it to run pipelines that are `deploy` events and are deployed to `production`. In order to do that, I need to be able to use the `DRONE_FILTER`, on the agent setup with the `event` and `deploy_to` keys set to certain values.

Below is an example with labels that doesn't work because they don't support interpolation (it also looks hackish):

```
labels:
  - event=${DRONE_EVENT}
  - deploy_to=${DRONE_DEPLOY_TO}
```
And the agent having: `DRONE_FILTER="event == 'deployment' and deploy_to == 'production'"`