### PR TITLE
Expose the parent build number as DRONE_PARENT_BUILD_NUMBER

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -312,6 +312,7 @@ func toEnv(w *model.Work) map[string]string {
 	}
 	if w.Build.Event == model.EventDeploy {
 		envs["DRONE_DEPLOY_TO"] = w.Build.Deploy
+		envs["DRONE_DEPLOY_FROM"] = fmt.Sprintf("%d", w.Build.Parent)
 	}
 
 	if w.BuildLast != nil {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -291,6 +291,7 @@ func toEnv(w *model.Work) map[string]string {
 		"DRONE_BUILD_CREATED":        fmt.Sprintf("%d", w.Build.Created),
 		"DRONE_BUILD_STARTED":        fmt.Sprintf("%d", w.Build.Started),
 		"DRONE_BUILD_FINISHED":       fmt.Sprintf("%d", w.Build.Finished),
+		"DRONE_PARENT_BUILD_NUMBER":  fmt.Sprintf("%d", w.Build.Parent),
 		"DRONE_JOB_NUMBER":           fmt.Sprintf("%d", w.Job.Number),
 		"DRONE_JOB_STATUS":           w.Job.Status,
 		"DRONE_JOB_ERROR":            w.Job.Error,
@@ -312,7 +313,6 @@ func toEnv(w *model.Work) map[string]string {
 	}
 	if w.Build.Event == model.EventDeploy {
 		envs["DRONE_DEPLOY_TO"] = w.Build.Deploy
-		envs["DRONE_DEPLOY_FROM"] = fmt.Sprintf("%d", w.Build.Parent)
 	}
 
 	if w.BuildLast != nil {

--- a/drone/exec.go
+++ b/drone/exec.go
@@ -247,14 +247,14 @@ var execCmd = cli.Command{
 			EnvVar: "DRONE_BUILD_LINK",
 		},
 		cli.StringFlag{
+			Name:   "build.parent",
+			Usage:  "build parent",
+			EnvVar: "DRONE_PARENT_BUILD_NUMBER",
+		},
+		cli.StringFlag{
 			Name:   "build.deploy",
 			Usage:  "build deployment target",
 			EnvVar: "DRONE_DEPLOY_TO",
-		},
-		cli.StringFlag{
-			Name:   "build.parent",
-			Usage:  "build deployment parent",
-			EnvVar: "DRONE_DEPLOY_FROM",
 		},
 		cli.BoolTFlag{
 			Name:   "yaml.verified",

--- a/drone/exec.go
+++ b/drone/exec.go
@@ -251,6 +251,11 @@ var execCmd = cli.Command{
 			Usage:  "build deployment target",
 			EnvVar: "DRONE_DEPLOY_TO",
 		},
+		cli.StringFlag{
+			Name:   "build.parent",
+			Usage:  "build deployment parent",
+			EnvVar: "DRONE_DEPLOY_FROM",
+		},
 		cli.BoolTFlag{
 			Name:   "yaml.verified",
 			Usage:  "build yaml is verified",


### PR DESCRIPTION
I needed this so that I could use the artifacts that I put on S3 with the build number, in my deployments (so that I wouldn't have to build them again).