### PR TITLE
Don't allow "logging" messages after eof is received

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -67,11 +67,15 @@ func LogStream(c *gin.Context) {
 
 	logs := make(chan []byte)
 	done := make(chan bool)
+	var eof bool
 	dest := fmt.Sprintf("/topic/logs.%d", job.ID)
 	client, _ := stomp.FromContext(c)
 	sub, err := client.Subscribe(dest, stomp.HandlerFunc(func(m *stomp.Message) {
 		if m.Header.GetBool("eof") {
+			eof = true
 			done <- true
+		} else if eof {
+			return
 		} else {
 			logs <- m.Body
 		}


### PR DESCRIPTION
This is an attempt to fix #1932 

After more troubleshooting the root of the issue seems to be that an `eof` message is received.  Between the time that the `done` channel is set and `return`s to cause "clean" from the `defer` (unsubscribe, close channels) another message is received that is **not** eof and attempted to be processed.  This causes a write to happen to `logs` and shortly after `close(logs)` to be called from `defer` while the write is still in progress.

Hope this all makes sense.

I've been testing this in my dev environment with NO issues so far.  I plan to role out to my prod shortly.