### PR TITLE
Fix to check if the repo is enabled and don’t make a call to the sett…

### DIFF
--- a/remote/bitbucketserver/internal/client.go
+++ b/remote/bitbucketserver/internal/client.go
@@ -136,7 +136,7 @@ func (c *Client) CreateHook(owner string, name string, callBackLink string) erro
 	if err != nil {
 		return err
 	}
-	hooks := make([]string, 0)
+	var hooks []string
 	if hookDetails.Enabled {
 		hookSettings, err := c.GetHooks(owner, name)
 		if err != nil {
@@ -181,13 +181,9 @@ func (c *Client) GetHookDetails(owner string, name string) (*HookPluginDetails, 
 		return nil, err
 	}
 	defer response.Body.Close()
-	contents, err := ioutil.ReadAll(response.Body)
 	hookDetails := HookPluginDetails{}
-	err = json.Unmarshal(contents, &hookDetails)
-	if err != nil {
-		return nil, err
-	}
-	return &hookDetails, nil
+	err = json.NewDecoder(response.Body).Decode(&hookDetails)
+	return &hookDetails, err
 }
 
 func (c *Client) GetHooks(owner string, name string) (*HookSettings, error) {
@@ -197,13 +193,9 @@ func (c *Client) GetHooks(owner string, name string) (*HookSettings, error) {
 		return nil, err
 	}
 	defer response.Body.Close()
-	contents, err := ioutil.ReadAll(response.Body)
 	hookSettings := HookSettings{}
-	err = json.Unmarshal(contents, &hookSettings)
-	if err != nil {
-		return nil, err
-	}
-	return &hookSettings, nil
+	err = json.NewDecoder(response.Body).Decode(&hookSettings)
+	return &hookSettings, err
 }
 
 //TODO: make these as as general do with the action
@@ -277,7 +269,7 @@ func (c *Client) paginatedRepos(start int) ([]*Repo, error) {
 }
 
 func filter(vs []string, f func(string) bool) []string {
-	vsf := make([]string, 0)
+	var vsf []string
 	for _, v := range vs {
 		if f(v) {
 			vsf = append(vsf, v)
@@ -341,7 +333,7 @@ func arrayToHookSettings(hooks []string) HookSettings {
 }
 
 func hookSettingsToArray(hookSettings *HookSettings) []string {
-	hooks := make([]string, 0)
+	var hooks []string
 
 	if hookSettings.HookURL0 != "" {
 		hooks = append(hooks, hookSettings.HookURL0)

--- a/remote/bitbucketserver/internal/client.go
+++ b/remote/bitbucketserver/internal/client.go
@@ -23,6 +23,7 @@ const (
 	pathHook         = "%s/rest/api/1.0/projects/%s/repos/%s/settings/hooks/%s"
 	pathSource       = "%s/projects/%s/repos/%s/browse/%s?at=%s&raw"
 	hookName         = "com.atlassian.stash.plugin.stash-web-post-receive-hooks-plugin:postReceiveHook"
+	pathHookDetails  = "%s/rest/api/1.0/projects/%s/repos/%s/settings/hooks/%s"
 	pathHookEnabled  = "%s/rest/api/1.0/projects/%s/repos/%s/settings/hooks/%s/enabled"
 	pathHookSettings = "%s/rest/api/1.0/projects/%s/repos/%s/settings/hooks/%s/settings"
 	pathStatus       = "%s/rest/build-status/1.0/commits/%s"
@@ -131,15 +132,23 @@ func (c *Client) FindFileForRepo(owner string, repo string, fileName string, ref
 }
 
 func (c *Client) CreateHook(owner string, name string, callBackLink string) error {
-	hookSettings, err := c.GetHooks(owner, name)
+	hookDetails , err := c.GetHookDetails(owner, name)
 	if err != nil {
 		return err
 	}
-	hooks := hookSettingsToArray(hookSettings)
+	hooks := make([]string, 0)
+	if (hookDetails.Enabled) {
+		hookSettings, err := c.GetHooks(owner, name)
+		if err != nil {
+			return err
+		}
+		hooks = hookSettingsToArray(hookSettings)
 
+	}
 	if !stringInSlice(callBackLink, hooks) {
 		hooks = append(hooks, callBackLink)
 	}
+
 	putHookSettings := arrayToHookSettings(hooks)
 	hookBytes, err := json.Marshal(putHookSettings)
 	return c.doPut(fmt.Sprintf(pathHookEnabled, c.base, owner, name, hookName), hookBytes)
@@ -163,6 +172,22 @@ func (c *Client) DeleteHook(owner string, name string, link string) error {
 	putHookSettings := arrayToHookSettings(putHooks)
 	hookBytes, err := json.Marshal(putHookSettings)
 	return c.doPut(fmt.Sprintf(pathHookEnabled, c.base, owner, name, hookName), hookBytes)
+}
+
+func (c *Client) GetHookDetails(owner string, name string) (*HookPluginDetails, error) {
+	urlString := fmt.Sprintf(pathHookDetails, c.base, owner, name, hookName)
+	response, err := c.client.Get(urlString)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	contents, err := ioutil.ReadAll(response.Body)
+	hookDetails := HookPluginDetails{}
+	err = json.Unmarshal(contents, &hookDetails)
+	if err != nil {
+		return nil, err
+	}
+	return &hookDetails, nil
 }
 
 func (c *Client) GetHooks(owner string, name string) (*HookSettings, error) {

--- a/remote/bitbucketserver/internal/client.go
+++ b/remote/bitbucketserver/internal/client.go
@@ -132,12 +132,12 @@ func (c *Client) FindFileForRepo(owner string, repo string, fileName string, ref
 }
 
 func (c *Client) CreateHook(owner string, name string, callBackLink string) error {
-	hookDetails , err := c.GetHookDetails(owner, name)
+	hookDetails, err := c.GetHookDetails(owner, name)
 	if err != nil {
 		return err
 	}
 	hooks := make([]string, 0)
-	if (hookDetails.Enabled) {
+	if hookDetails.Enabled {
 		hookSettings, err := c.GetHooks(owner, name)
 		if err != nil {
 			return err

--- a/remote/bitbucketserver/internal/types.go
+++ b/remote/bitbucketserver/internal/types.go
@@ -170,6 +170,19 @@ type RefChange struct {
 	Type     string `json:"type"`
 }
 
+type HookPluginDetails struct {
+	Details struct {
+			Key string `json:"key"`
+			Name string `json:"name"`
+			Type string `json:"type"`
+			Description string `json:"description"`
+			Version string `json:"version"`
+			ConfigFormKey string `json:"configFormKey"`
+		} `json:"details"`
+	Enabled bool `json:"enabled"`
+	Configured bool `json:"configured"`
+}
+
 type HookSettings struct {
 	HookURL0  string `json:"hook-url-0,omitempty"`
 	HookURL1  string `json:"hook-url-1,omitempty"`

--- a/remote/bitbucketserver/internal/types.go
+++ b/remote/bitbucketserver/internal/types.go
@@ -172,14 +172,14 @@ type RefChange struct {
 
 type HookPluginDetails struct {
 	Details struct {
-			Key string `json:"key"`
-			Name string `json:"name"`
-			Type string `json:"type"`
-			Description string `json:"description"`
-			Version string `json:"version"`
-			ConfigFormKey string `json:"configFormKey"`
-		} `json:"details"`
-	Enabled bool `json:"enabled"`
+		Key           string `json:"key"`
+		Name          string `json:"name"`
+		Type          string `json:"type"`
+		Description   string `json:"description"`
+		Version       string `json:"version"`
+		ConfigFormKey string `json:"configFormKey"`
+	} `json:"details"`
+	Enabled    bool `json:"enabled"`
 	Configured bool `json:"configured"`
 }
 


### PR DESCRIPTION
@bradrydzewski if you don't mind taking a look and merging as soon as you can.  I didn't realize that the hook worked different the first time you ever enable the repo vs once it's ever been enabled even if it's off :/  Right now you can't enable brand new repos but this fixes it.
