### PR TITLE
Direct support requests to the Discourse forum

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Documentation is published to [readme.drone.io](http://readme.drone.io)
 
 ### Community, Help
 
-Contributions, questions, and comments are welcomed and encouraged. Drone developers hang out in the [drone/drone](https://gitter.im/drone/drone) room on gitter. We ask that you please post your questions to [gitter](https://gitter.im/drone/drone) before creating an issue.
+Contributions, questions, and comments are welcomed and encouraged. We ask that you please post user support questions to the [community forum](http://discourse.drone.io/), before creating Github issues. Drone developers hang out in the [drone/drone](https://gitter.im/drone/drone) room on Gitter.
 
 ### Installation
 


### PR DESCRIPTION
As the Gitter room advises users to go to the Discourse forum for posting
end-user support questions, best that the README points them to the right
place in the first case.

