### PR TITLE
Adding github release deployment for cli.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,6 +3,7 @@ workspace:
   path: src/github.com/drone/drone
 
 pipeline:
+
   test:
     image: golang:1.8
     environment:
@@ -34,24 +35,22 @@ pipeline:
   #     event: push
   #     branch: master
 
-  publish:
+  publish_docker:
+    image: plugins/docker
+    repo: drone/drone
+    username: ${DOCKER_USERNAME}
+    password: ${DOCKER_PASSWORD}
+    tag: [ 0.6 ]
+    when:
+      branch: master
+      event: push
 
-    docker:
-      image: plugins/docker
-      repo: drone/drone
-      username: ${DOCKER_USERNAME}
-      password: ${DOCKER_PASSWORD}
-      tag: [ 0.6 ]
-      when:
-        branch: master
-        event: push
-
-    cli:
-      image: plugins/github-release
-      files: release/*/*/drone.tar.gz
-      checksum: [ sha256 ]
-      when:
-        event: tag
+  publish_cli:
+    image: plugins/github-release
+    files: release/*/*/drone.tar.gz
+    checksum: [ sha256 ]
+    when:
+      event: tag
 
   notify:
     image: plugins/gitter

--- a/.drone.yml
+++ b/.drone.yml
@@ -35,14 +35,23 @@ pipeline:
   #     branch: master
 
   publish:
-    image: plugins/docker
-    repo: drone/drone
-    username: ${DOCKER_USERNAME}
-    password: ${DOCKER_PASSWORD}
-    tag: [ 0.6 ]
-    when:
-      branch: master
-      event: push
+
+    docker:
+      image: plugins/docker
+      repo: drone/drone
+      username: ${DOCKER_USERNAME}
+      password: ${DOCKER_PASSWORD}
+      tag: [ 0.6 ]
+      when:
+        branch: master
+        event: push
+
+    cli:
+      image: plugins/github-release
+      files: release/*/*/drone.tar.gz
+      checksum: [ sha256 ]
+      when:
+        event: tag
 
   notify:
     image: plugins/gitter


### PR DESCRIPTION
If all goes as planned, the build should pick up the tars created in the 'compile' step, then upload that to the relevant github release.

See https://github.com/drone-plugins/drone-github-release/blob/master/DOCS.md for steps on adding the `GITHUB_RELEASE_API_KEY` secret.