### PR TITLE
fix: missing matrix env.

### DIFF
--- a/server/hook.go
+++ b/server/hook.go
@@ -422,6 +422,10 @@ func (b *builder) Build() ([]*buildItem, error) {
 			environ[k] = v
 		}
 
+		for k, v := range axis {
+			environ[k] = v
+		}
+
 		secrets := map[string]string{}
 		for _, sec := range b.Secs {
 			if !sec.MatchEvent(b.Curr.Event) {
@@ -439,9 +443,11 @@ func (b *builder) Build() ([]*buildItem, error) {
 		}
 
 		y := b.Yaml
-		if s, err := envsubst.Eval(y, sub); err != nil {
-			y = s
+		s, err := envsubst.Eval(y, sub)
+		if err != nil {
+			return nil, err
 		}
+		y = s
 
 		parsed, err := yaml.ParseString(y)
 		if err != nil {


### PR DESCRIPTION
Fix missing matrix config.

```
workspace:
  base: /go
  path: src/gitea.com/appleboy/go-hello2

clone:
  git:
    image: plugins/git

pipeline:

  # these steps define a parallel execution
  # group and will fan out.

  foo:
    image: appleboy/golang-testing:${GO_VERSION}
    group: build
    commands:
      - echo ${A}
      - echo ${APPLEBOY}
      - echo step 1
      - sleep 10
      - echo done 1
  bar:
    image: appleboy/golang-testing
    group: build
    commands:
      - echo ${A}
      - echo step 2
      - sleep 10
      - echo done 2

  # this step is not grouped with the previous
  # steps, resulting in a fan-in.

  baz:
    image: appleboy/golang-testing
    commands:
      - echo I should execute last.
      - echo after the prior two steps finish execution.

  # these steps define a parallel execution
  # group and will fan back out.

  qux:
    image: appleboy/golang-testing
    group: test
    commands:
      - echo step 3
      - sleep 10
      - echo done 3
  quux:
    image: appleboy/golang-testing
    group: test
    commands:
      - echo step 4
      - sleep 10
      - echo done 4

matrix:
  GO_VERSION:
    - 1.8.0
    - 1.7.5
```