### PR TITLE
Introducing `EXTERNAL_NETWORKS` env var to connect Drone containers to additional Docker networks

### DIFF
--- a/server/hook.go
+++ b/server/hook.go
@@ -489,6 +489,7 @@ func (b *builder) Build() ([]*buildItem, error) {
 			compiler.WithProxy(),
 			// TODO ability to set global volumes for things like certs
 			compiler.WithVolumes(),
+			compiler.WithNetworks(),
 			compiler.WithWorkspaceFromURL("/drone", b.Curr.Link),
 		).Compile(parsed)
 

--- a/vendor/github.com/cncd/pipeline/pipeline/frontend/yaml/compiler/compiler.go
+++ b/vendor/github.com/cncd/pipeline/pipeline/frontend/yaml/compiler/compiler.go
@@ -18,6 +18,7 @@ type Compiler struct {
 	escalated []string
 	prefix    string
 	volumes   []string
+	networks  []string
 	env       map[string]string
 	base      string
 	path      string

--- a/vendor/github.com/cncd/pipeline/pipeline/frontend/yaml/compiler/convert.go
+++ b/vendor/github.com/cncd/pipeline/pipeline/frontend/yaml/compiler/convert.go
@@ -27,6 +27,11 @@ func (c *Compiler) createProcess(name string, container *yaml.Container) *backen
 			Aliases: c.aliases,
 		},
 	}
+	for _, network := range c.networks {
+	  networks = append(networks, backend.Conn{
+	    Name:     network,
+	  })
+	}
 
 	var volumes []string
 	if !c.local {

--- a/vendor/github.com/cncd/pipeline/pipeline/frontend/yaml/compiler/option.go
+++ b/vendor/github.com/cncd/pipeline/pipeline/frontend/yaml/compiler/option.go
@@ -143,6 +143,15 @@ func WithProxy() Option {
 	)
 }
 
+// WithNetworks configures the compiler with additionnal networks
+// to be connected to the build containers
+func WithNetworks() Option {
+	return func(compiler *Compiler) {
+		compiler.networks = strings.Split(externalNetworks, ",")
+	}
+}
+
+
 // TODO(bradrydzewski) consider an alternate approach to
 // WithProxy where the proxy strings are passed directly
 // to the function as named parameters.
@@ -164,6 +173,10 @@ var (
 	noProxy    = getenv("no_proxy")
 	httpProxy  = getenv("https_proxy")
 	httpsProxy = getenv("https_proxy")
+)
+
+var (
+	externalNetworks = getenv("external_networks")
 )
 
 // getenv returns the named environment variable.


### PR DESCRIPTION
Hi!
This patch add the ability for Drone containers to connect to existing Docker networks through an env var specified at drone server's startup: `EXTERNAL_NETWORKS`.

You can specify multiple networks by using comma as a separator: `EXTERNAL_NETWORKS=my_overlay,my_second_overlay`.

This is particularly useful if you want to use names that resolve only on a particular Docker network from inside your build containers, instead of public names/ip.

I'm using `backend.Conn` to ask Drone to connect to external networks and I'm not creating associated `backend.Network` struct. This way the patch is lighter and I don't have to make special cases to avoid Drone trying to create/delete those external networks.
Or instead, should I create `backend.Network` from the env param, and create `backend.Conn` from them in `createProcess` func, handling external and non external networks?

Is there a way I can update Drone's documentation to append this parameter?
Should I backport those changes to the `https://github.com/cncd/pipeline/` repo?

Thanks for reviewing!
