### PR TITLE
Make the cc.xml CCMenu include a Project entry per Branch

### DIFF
--- a/model/cc.go
+++ b/model/cc.go
@@ -24,8 +24,10 @@ type CCProject struct {
 func NewCC(r *Repo, bs []*Build, link string) *CCProjects {
 	projs := &CCProjects{Projects: []*CCProject{}}
 
-	branches := []string{}
+	pz := NewCCProject(r, bs[0], r.FullName, link)
+	projs.Projects = append(projs.Projects, pz)
 
+	branches := []string{}
 BuildLoop:
 	for _, b := range bs {
 		for _, br := range branches {
@@ -34,35 +36,39 @@ BuildLoop:
 			}
 		}
 
-		proj := &CCProject{
-			Name:            r.FullName + " " + b.Branch,
-			WebURL:          link,
-			Activity:        "Building",
-			LastBuildStatus: "Unknown",
-			LastBuildLabel:  "Unknown",
-		}
+		p := NewCCProject(r, b, r.FullName+" "+b.Branch, link)
 
-		// if the build is not currently running then
-		// we can return the latest build status.
-		if b.Status != StatusPending &&
-			b.Status != StatusRunning {
-			proj.Activity = "Sleeping"
-			proj.LastBuildTime = time.Unix(b.Started, 0).Format(time.RFC3339)
-			proj.LastBuildLabel = strconv.Itoa(b.Number)
-		}
-
-		// ensure the last build Status accepts a valid
-		// ccmenu enumeration
-		switch b.Status {
-		case StatusError, StatusKilled:
-			proj.LastBuildStatus = "Exception"
-		case StatusSuccess:
-			proj.LastBuildStatus = "Success"
-		case StatusFailure:
-			proj.LastBuildStatus = "Failure"
-		}
-
+		projs.Projects = append(projs.Projects, p)
 		branches = append(branches, b.Branch)
 	}
 	return projs
+}
+
+func NewCCProject(r *Repo, b *Build, name, link string) *CCProject {
+	proj := &CCProject{
+		Name:            name,
+		WebURL:          link,
+		Activity:        "Building",
+		LastBuildStatus: "Unknown",
+		LastBuildLabel:  "Unknown",
+	}
+	// if the build is not currently running then
+	// we can return the latest build status.
+	if b.Status != StatusPending &&
+		b.Status != StatusRunning {
+		proj.Activity = "Sleeping"
+		proj.LastBuildTime = time.Unix(b.Started, 0).Format(time.RFC3339)
+		proj.LastBuildLabel = strconv.Itoa(b.Number)
+	}
+	// ensure the last build Status accepts a valid
+	// ccmenu enumeration
+	switch b.Status {
+	case StatusError, StatusKilled:
+		proj.LastBuildStatus = "Exception"
+	case StatusSuccess:
+		proj.LastBuildStatus = "Success"
+	case StatusFailure:
+		proj.LastBuildStatus = "Failure"
+	}
+	return proj
 }

--- a/server/badge.go
+++ b/server/badge.go
@@ -79,6 +79,6 @@ func GetCC(c *gin.Context) {
 	}
 
 	url := fmt.Sprintf("%s/%s/%d", httputil.GetURL(c.Request), repo.FullName, builds[0].Number)
-	cc := model.NewCC(repo, builds[0], url)
+	cc := model.NewCC(repo, builds, url)
 	c.XML(200, cc)
 }


### PR DESCRIPTION
CCMenu xml responses are able to include multiple projects. We often have multiple branches running at the same time and right now we only get one ccmenu status back.

This leaves the existing CCProject entry and adds additional Project rows for the individual branches.

It'd be nice for me to be able to just track our `dev` and `master` branches separately, so I've altered the cc.go to allow this.

I have not yet altered the tests, I wanted to make sure there was actual interest in doing this first, but I'd certainly be happy to.