### PR TITLE
Fix segfault in model.Tree(procs)

### DIFF
--- a/model/proc.go
+++ b/model/proc.go
@@ -44,16 +44,17 @@ func (p *Proc) Failing() bool {
 // Tree creates a process tree from a flat process list.
 func Tree(procs []*Proc) []*Proc {
 	var (
-		nodes  []*Proc
-		parent *Proc
+		nodes    []*Proc
+		parent   *Proc
+		children []*Proc
 	)
 	for _, proc := range procs {
 		if proc.PPID == 0 {
 			nodes = append(nodes, proc)
 			parent = proc
-			continue
+			parent.Children = children
 		} else {
-			parent.Children = append(parent.Children, proc)
+			children = append(children, proc)
 		}
 	}
 	return nodes

--- a/model/proc.go
+++ b/model/proc.go
@@ -44,17 +44,16 @@ func (p *Proc) Failing() bool {
 // Tree creates a process tree from a flat process list.
 func Tree(procs []*Proc) []*Proc {
 	var (
-		nodes    []*Proc
-		parent   *Proc
-		children []*Proc
+		nodes  []*Proc
+		parent *Proc
 	)
 	for _, proc := range procs {
 		if proc.PPID == 0 {
 			nodes = append(nodes, proc)
 			parent = proc
-			parent.Children = children
+			continue
 		} else {
-			children = append(children, proc)
+			parent.Children = append(parent.Children, proc)
 		}
 	}
 	return nodes

--- a/store/datastore/sql/postgres/files/procs.sql
+++ b/store/datastore/sql/postgres/files/procs.sql
@@ -37,6 +37,7 @@ SELECT
 ,proc_environ
 FROM procs
 WHERE proc_build_id = $1
+ORDER BY proc_pid ASC
 
 -- name: procs-find-build-pid
 

--- a/store/datastore/sql/postgres/sql_gen.go
+++ b/store/datastore/sql/postgres/sql_gen.go
@@ -164,6 +164,7 @@ SELECT
 ,proc_environ
 FROM procs
 WHERE proc_build_id = $1
+ORDER BY proc_pid ASC
 `
 
 var procsFindBuildPid = `


### PR DESCRIPTION
Fixes crash in model.Tree(procs) which occurs when the list of procs
passed, isn't in the expected order. E.g. if the first element doesn't
have `PPID == 0`, it would crash writing to the uninitialized
`parent.Children` slice.
