### PR TITLE
Add --env flag to drone exec for passing custom ENV vars

### DIFF
--- a/drone/exec/exec.go
+++ b/drone/exec/exec.go
@@ -280,7 +280,7 @@ var Command = cli.Command{
 func parseEnvVars(envs []string) (map[string]string, error) {
 	envVars := map[string]string{}
 	for _, env := range envs {
-		e := strings.Split(env, "=")
+		e := strings.SplitN(env, "=", 2)
 		if len(e) != 2 {
 			return nil, fmt.Errorf("failed to parse environment variable: %s", env)
 		}

--- a/drone/exec/exec.go
+++ b/drone/exec/exec.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -69,6 +70,10 @@ var Command = cli.Command{
 				"plugins/gcr",
 				"plugins/ecr",
 			},
+		},
+		cli.StringSliceFlag{
+			Name:  "env, e",
+			Usage: "environment variables",
 		},
 
 		//
@@ -270,6 +275,20 @@ var Command = cli.Command{
 	},
 }
 
+// parseEnvVars parses a list of envVars of the format 'NAME=value' into a
+// map[string]string.
+func parseEnvVars(envs []string) (map[string]string, error) {
+	envVars := map[string]string{}
+	for _, env := range envs {
+		e := strings.Split(env, "=")
+		if len(e) != 2 {
+			return nil, fmt.Errorf("failed to parse environment variable: %s", env)
+		}
+		envVars[e[0]] = e[1]
+	}
+	return envVars, nil
+}
+
 func exec(c *cli.Context) error {
 	file := c.Args().First()
 	if file == "" {
@@ -290,6 +309,11 @@ func exec(c *cli.Context) error {
 			Name:  k,
 			Value: v,
 		})
+	}
+
+	envVars, err := parseEnvVars(c.StringSlice("env"))
+	if err != nil {
+		return err
 	}
 
 	tmpl, err := envsubst.ParseFile(file)
@@ -352,6 +376,7 @@ func exec(c *cli.Context) error {
 		),
 		compiler.WithMetadata(metadata),
 		compiler.WithSecret(secrets...),
+		compiler.WithEnviron(envVars),
 	).Compile(conf)
 
 	engine, err := docker.NewEnv()


### PR DESCRIPTION
This adds the possibility to pass custom ENV vars to the build when running `drone exec`. I use the same naming as in docker `--env, -e`, but I don't mind changing it if you prefer something else.

My use case for this is that I'm running `drone exec` in my companies custom build system, and need to pass env vars like `BUILD_NUMBER` from the build system so they are available in the drone pipeline steps.