### PR TITLE
remove unnecessary slashes from url

### DIFF
--- a/drone/server/server.go
+++ b/drone/server/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"golang.org/x/crypto/acme/autocert"
@@ -415,7 +416,7 @@ func setupEvilGlobals(c *cli.Context, v store.Store) {
 	droneserver.Config.Server.Cert = c.String("server-cert")
 	droneserver.Config.Server.Key = c.String("server-key")
 	droneserver.Config.Server.Pass = c.String("agent-secret")
-	droneserver.Config.Server.Host = c.String("server-host")
+	droneserver.Config.Server.Host = strings.TrimRight(c.String("server-host"), "/")
 	droneserver.Config.Server.Port = c.String("server-addr")
 	droneserver.Config.Pipeline.Networks = c.StringSlice("network")
 	droneserver.Config.Pipeline.Volumes = c.StringSlice("volumes")


### PR DESCRIPTION
remove unnecessary slashes from `DRONE_HOST` URL.

![screen shot 2017-05-07 at 11 14 31 am](https://cloud.githubusercontent.com/assets/21979/25777658/62ac1946-3316-11e7-8044-0e8aba1f2b16.png)

Signed-off-by: Bo-Yi Wu <appleboy.tw@gmail.com>

