### PR TITLE
Support whitelisting for Owners

### DIFF
--- a/drone/server/server.go
+++ b/drone/server/server.go
@@ -99,6 +99,11 @@ var Command = cli.Command{
 			EnvVar: "DRONE_NETWORK",
 			Name:   "network",
 		},
+		cli.StringSliceFlag{
+			EnvVar: "DRONE_WHITELIST_OWNERS",
+			Name:	"whitelist-owners",
+			Usage:	"limit Drone CI to organizations and users",
+		},
 		cli.StringFlag{
 			EnvVar: "DRONE_AGENT_SECRET,DRONE_SECRET",
 			Name:   "agent-secret",

--- a/model/settings.go
+++ b/model/settings.go
@@ -6,6 +6,7 @@ type Settings struct {
 	Secret string          // Secret token used to authenticate agents
 	Admins map[string]bool // Administrative users
 	Orgs   map[string]bool // Organization whitelist
+	WhitelistOwners map[string]bool // Whitelisted owners
 }
 
 // IsAdmin returns true if the user is a member of the administrator list.
@@ -21,4 +22,11 @@ func (c *Settings) IsMember(teams []*Team) bool {
 		}
 	}
 	return false
+}
+
+func (c *Settings) IsWhitelistedOwner(owner string) bool {
+        if len(c.WhitelistOwners) == 0 {
+                return true
+        }
+        return c.WhitelistOwners[owner]
 }

--- a/router/middleware/config.go
+++ b/router/middleware/config.go
@@ -25,6 +25,7 @@ func setupConfig(c *cli.Context) *model.Settings {
 		Secret: c.String("agent-secret"),
 		Admins: sliceToMap2(c.StringSlice("admin")),
 		Orgs:   sliceToMap2(c.StringSlice("orgs")),
+		WhitelistOwners: sliceToMap2(c.StringSlice("whitelist-owners")),
 	}
 }
 

--- a/server/repo.go
+++ b/server/repo.go
@@ -43,6 +43,15 @@ func PostRepo(c *gin.Context) {
 		return
 	}
 
+	// Check if Owner is whitelisted
+	confv := c.MustGet("config")
+	if conf, ok := confv.(*model.Settings); ok {
+		if ! conf.IsWhitelistedOwner(owner) {
+	                c.String(403, "Repository owner not whitelisted.")
+		        return
+		}
+	}
+
 	// error if the repository already exists
 	_, err = store.GetRepoOwnerName(c, owner, name)
 	if err == nil {


### PR DESCRIPTION
As a Drone admin I want to be able to limit Drone CI to certain orgs and users in my repository hosting application. 

DRONE_WHITELIST_OWNERS should accept a comma separated list of organizations and users allowed to enable the drone integration for their repository. Every other repository should fail to activated. If DRONE_WHITELIST_OWNERS is not set, all repositories should be able to get activated.