### PR TITLE
Expose parent build number

### DIFF
--- a/drone/exec/exec.go
+++ b/drone/exec/exec.go
@@ -144,6 +144,10 @@ var Command = cli.Command{
 			Name:   "build-number",
 			EnvVar: "DRONE_BUILD_NUMBER",
 		},
+		cli.IntFlag{
+			Name:   "parent-build-number",
+			EnvVar: "DRONE_PARENT_BUILD_NUMBER",
+		},
 		cli.Int64Flag{
 			Name:   "build-created",
 			EnvVar: "DRONE_BUILD_CREATED",
@@ -389,6 +393,7 @@ func metadataFromContext(c *cli.Context) frontend.Metadata {
 		},
 		Curr: frontend.Build{
 			Number:   c.Int("build-number"),
+			Parent:   c.Int("parent-build-number"),
 			Created:  c.Int64("build-created"),
 			Started:  c.Int64("build-started"),
 			Finished: c.Int64("build-finished"),

--- a/server/hook.go
+++ b/server/hook.go
@@ -329,6 +329,7 @@ func metadataFromStruct(repo *model.Repo, build, last *model.Build, proc *model.
 		},
 		Curr: frontend.Build{
 			Number:   build.Number,
+			Parent:   build.Parent,
 			Created:  build.Created,
 			Started:  build.Started,
 			Finished: build.Finished,


### PR DESCRIPTION
@bradrydzewski Expose parent build number. 

Please, let me know what else to change, I didn't grasp entirely how data flows.

Related to: https://github.com/drone/drone/pull/1930

Also, it would be very nice to do an interpolation like `${DRONE_PARENT_BUILD_NUMBER:-DRONE_BUILD_NUMBER}`, using build number as fallback when it's not a deployment event.
Does go **envsubst** supports that? If it does, maybe I can change https://github.com/cncd/pipeline/blob/master/pipeline/frontend/metadata.go#L105 to only add env if `m.Curr.Parent != 0.` 