### PR TITLE
Add saving email of Bitbucket account

### DIFF
--- a/remote/bitbucket/bitbucket.go
+++ b/remote/bitbucket/bitbucket.go
@@ -69,7 +69,17 @@ func (c *config) Login(w http.ResponseWriter, req *http.Request) (*model.User, e
 	if err != nil {
 		return nil, err
 	}
-	return convertUser(curr, token), nil
+
+	emails, err := client.ListEmail()
+	if err != nil {
+		return nil, err
+	}
+	email := matchingEmail(emails.Values)
+	if email == nil {
+		return nil, fmt.Errorf("No verified Email address for Bitbucket account")
+	}
+
+	return convertUser(curr, email, token), nil
 }
 
 // Auth uses the Bitbucket oauth2 access token and refresh token to authenticate

--- a/remote/bitbucket/bitbucket_test.go
+++ b/remote/bitbucket/bitbucket_test.go
@@ -58,6 +58,7 @@ func Test_bitbucket(t *testing.T) {
 				g.Assert(u.Login).Equal(fakeUser.Login)
 				g.Assert(u.Token).Equal("2YotnFZFEjr1zCsicMWpAA")
 				g.Assert(u.Secret).Equal("tGzv3JOkF0XG5Qx2TlKWIA")
+				g.Assert(u.Email).Equal(fakeUser.Email)
 			})
 			g.It("Should handle failure to exchange code", func() {
 				w := httptest.NewRecorder()
@@ -75,6 +76,7 @@ func Test_bitbucket(t *testing.T) {
 				_, err := c.Login(nil, r)
 				g.Assert(err != nil).IsTrue()
 			})
+			// TODO(langovoi): don't know how to cover case when user doesn't have verified email and client.ListEmail failed
 		})
 
 		g.Describe("Given an access token", func() {
@@ -280,6 +282,7 @@ var (
 	fakeUser = &model.User{
 		Login: "superman",
 		Token: "cfcd2084",
+		Email: "octocat@github.com",
 	}
 
 	fakeUserRefresh = &model.User{

--- a/remote/bitbucket/convert.go
+++ b/remote/bitbucket/convert.go
@@ -123,13 +123,14 @@ func convertRepoLite(from *internal.Repo) *model.RepoLite {
 
 // convertUser is a helper function used to convert a Bitbucket user account
 // structure to the Drone User structure.
-func convertUser(from *internal.Account, token *oauth2.Token) *model.User {
+func convertUser(from *internal.Account, email *internal.Email, token *oauth2.Token) *model.User {
 	return &model.User{
 		Login:  from.Login,
 		Token:  token.AccessToken,
 		Secret: token.RefreshToken,
 		Expiry: token.Expiry.UTC().Unix(),
 		Avatar: from.Links.Avatar.Href,
+		Email:  email.Email,
 	}
 }
 
@@ -211,4 +212,13 @@ func extractEmail(gitauthor string) (author string) {
 		author = matches[0][1]
 	}
 	return
+}
+
+func matchingEmail(emails []*internal.Email) *internal.Email {
+	for _, email := range emails {
+		if email.IsPrimary && email.IsConfirmed {
+			return email
+		}
+	}
+	return nil
 }

--- a/remote/bitbucket/convert_test.go
+++ b/remote/bitbucket/convert_test.go
@@ -106,13 +106,15 @@ func Test_helper(t *testing.T) {
 			}
 			user := &internal.Account{Login: "octocat"}
 			user.Links.Avatar.Href = "http://..."
+			email := &internal.Email{Email: "octocat@github.com"}
 
-			result := convertUser(user, token)
+			result := convertUser(user, email, token)
 			g.Assert(result.Avatar).Equal(user.Links.Avatar.Href)
 			g.Assert(result.Login).Equal(user.Login)
 			g.Assert(result.Token).Equal(token.AccessToken)
 			g.Assert(result.Secret).Equal(token.RefreshToken)
 			g.Assert(result.Expiry).Equal(token.Expiry.UTC().Unix())
+			g.Assert(result.Email).Equal(email.Email)
 		})
 
 		g.It("should use clone url", func() {

--- a/remote/bitbucket/fixtures/handler.go
+++ b/remote/bitbucket/fixtures/handler.go
@@ -22,6 +22,7 @@ func Handler() http.Handler {
 	e.GET("/2.0/repositories/:owner", getUserRepos)
 	e.GET("/2.0/teams/", getUserTeams)
 	e.GET("/2.0/user/", getUser)
+	e.GET("/2.0/user/emails", getUserEmails)
 
 	return e
 }
@@ -130,6 +131,13 @@ func getUserRepos(c *gin.Context) {
 	}
 }
 
+func getUserEmails(c *gin.Context) {
+	switch c.Request.Header.Get("Authorization") {
+	default:
+		c.String(200, userEmailsPayload)
+	}
+}
+
 const tokenPayload = `
 {
 	"access_token":"2YotnFZFEjr1zCsicMWpAA",
@@ -222,5 +230,20 @@ const userTeamPayload = `
       "type": "team"
     }
   ]
+}
+`
+
+const userEmailsPayload = `
+{
+   "pagelen": 10,
+   "values": [
+      {
+         "is_primary": true,
+         "is_confirmed": true,
+         "email": "octocat@github.com"
+      }
+   ],
+   "page": 1,
+   "size": 1
 }
 `


### PR DESCRIPTION
I found that email of Bitbucket user not saving, so I was implemented this functionality.

Also I have problem with tests - I don't know how to cover two cases:

1. error of [client.ListEmail()](https://github.com/langovoi/drone/blob/69b19336d80e34d1d212765cf292e08040b0b965/remote/bitbucket/bitbucket.go#L75)
1. user [without verified email](https://github.com/langovoi/drone/blob/69b19336d80e34d1d212765cf292e08040b0b965/remote/bitbucket/bitbucket.go#L79)

I think tests for this must be [here](https://github.com/langovoi/drone/blob/69b19336d80e34d1d212765cf292e08040b0b965/remote/bitbucket/bitbucket_test.go#L79).

It is my first time with Go, so if something looks wrong I will be glad to get feedback.