### PR TITLE
Fix/pluggable registry secrets

### DIFF
--- a/plugins/registry/plugin.go
+++ b/plugins/registry/plugin.go
@@ -32,7 +32,7 @@ func (p *plugin) RegistryList(repo *model.Repo) ([]*model.Registry, error) {
 
 func (p *plugin) RegistryCreate(repo *model.Repo, in *model.Registry) error {
 	path := fmt.Sprintf("%s/registry/%s/%s", p.endpoint, repo.Owner, repo.Name)
-	return internal.Send("PATCH", path, in, nil)
+	return internal.Send("POST", path, in, nil)
 }
 
 func (p *plugin) RegistryUpdate(repo *model.Repo, in *model.Registry) error {

--- a/plugins/registry/plugin.go
+++ b/plugins/registry/plugin.go
@@ -26,7 +26,7 @@ func (p *plugin) RegistryFind(repo *model.Repo, name string) (*model.Registry, e
 func (p *plugin) RegistryList(repo *model.Repo) ([]*model.Registry, error) {
 	path := fmt.Sprintf("%s/registry/%s/%s", p.endpoint, repo.Owner, repo.Name)
 	out := []*model.Registry{}
-	err := internal.Send("GET", path, nil, out)
+	err := internal.Send("GET", path, nil, &out)
 	return out, err
 }
 

--- a/plugins/secrets/plugin.go
+++ b/plugins/secrets/plugin.go
@@ -26,7 +26,7 @@ func (p *plugin) SecretFind(repo *model.Repo, name string) (*model.Secret, error
 func (p *plugin) SecretList(repo *model.Repo) ([]*model.Secret, error) {
 	path := fmt.Sprintf("%s/secrets/%s/%s", p.endpoint, repo.Owner, repo.Name)
 	out := []*model.Secret{}
-	err := internal.Send("GET", path, nil, out)
+	err := internal.Send("GET", path, nil, &out)
 	return out, err
 }
 


### PR DESCRIPTION
I was experiencing unmarshalling errors when using the plugable registry store

```
Error getting registry list. json: Unmarshal(non-pointer []*model.Registry)
```

This PR will fixes the issue

Also this PR will use `POST` as HTTP Verb for creating resources (see #1998 )

@bradrydzewski 
Even though the feature is not officially supported yet - it would be great to have it working, until the RPC implementation is available. (Maybe we can push a minor release in the coming weeks that will include this fix?)