### PR TITLE
(minor) typo: 'enviornment' -> 'environment'

### DIFF
--- a/.drone.sh
+++ b/.drone.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # only execute this script as part of the pipeline.
-[ -z "$CI" ] && echo "missing ci enviornment variable" && exit 2
+[ -z "$CI" ] && echo "missing ci environment variable" && exit 2
 
 # only execute the script when github token exists.
 [ -z "$SSH_KEY" ] && echo "missing ssh key" && exit 3


### PR DESCRIPTION
Hello, just poking around to see how you've set your build scripts up and noticed a minor typo when an environment variable isn't set.