### PR TITLE
Proposal: Add building doc and Makefile

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,39 @@
+# Building Drone CI
+
+## Install Go Dependencies
+
+    $ go get github.com/drone/drone-ui/dist
+    $ go get github.com/golang/protobuf/proto
+    $ go get golang.org/x/net/context
+
+## Server
+
+If you plan on running the server binary in a Docker container,
+run `export GOOS=linux GOARCH=amd64` first.
+
+```
+go build \
+  -o release/drone-server \
+  -ldflags "-extldflags -static -X github.com/drone/drone/version.VersionDev=build.$(date +'%s')" \
+    github.com/drone/drone/cmd/drone-server
+```
+
+## Agent
+
+```
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build \
+  -o release/drone-agent \
+    github.com/drone/drone/cmd/drone-agent
+```
+
+## Docker Images
+
+Ensure the binaries have been built first (see above).
+
+Build the server:
+
+    $ docker build -t drone-server .
+
+Build the agent:
+
+    $ docker build -t drone-agent -f Dockerfile.agent .

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -2,9 +2,7 @@
 
 ## Install Go Dependencies
 
-    $ go get github.com/drone/drone-ui/dist
-    $ go get github.com/golang/protobuf/proto
-    $ go get golang.org/x/net/context
+    $ go get ./...
 
 ## Server
 

--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,7 @@ agent: fmt depend | $(BASE) ; $(info $(M) building agent executable…) @ ## Bui
 
 .PHONY: depend
 depend: $(BASE) ; $(info $(M) installing dependencies…) @ ## Install dependencies
-	@go get github.com/drone/drone-ui/dist
-	@go get github.com/golang/protobuf/proto
-	@go get golang.org/x/net/context
+	@go get ./...
 
 # Tools
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,140 @@
+PACKAGE  = github.com/drone/drone
+DATE    ?= $(shell date +%FT%T%z)
+VERSION ?= $(shell git describe --tags --always --dirty --match=v* 2> /dev/null || \
+			cat $(CURDIR)/.version 2> /dev/null || echo v0)
+GOPATH   = $(CURDIR)/.gopath~
+BIN      = $(GOPATH)/bin
+BASE     = $(GOPATH)/src/$(PACKAGE)
+PKGS     = $(or $(PKG),$(shell cd $(BASE) && env GOPATH=$(GOPATH) $(GO) list ./... | grep -v "^$(PACKAGE)/vendor/"))
+TESTPKGS = $(shell env GOPATH=$(GOPATH) $(GO) list -f '{{ if or .TestGoFiles .XTestGoFiles }}{{ .ImportPath }}{{ end }}' $(PKGS))
+
+GO      = go
+GODOC   = godoc
+GOFMT   = gofmt
+GLIDE   = glide
+TIMEOUT = 15
+V = 0
+Q = $(if $(filter 1,$V),,@)
+M = $(shell printf "\033[34;1m▶\033[0m")
+
+.PHONY: all
+all: server agent | $(BASE) ; @ ## Build server and agent binaries
+
+$(BASE): ; $(info $(M) setting GOPATH…)
+	@mkdir -p $(dir $@)
+	@ln -sf $(CURDIR) $@
+
+# Drone server
+
+.PHONY: server
+server: fmt depend | $(BASE) ; $(info $(M) building server executable…) @ ## Build server binary
+	$Q cd $(BASE) && $(GO) build \
+		-tags release \
+		-ldflags '-X $(PACKAGE)/cmd.Version=$(VERSION) -X $(PACKAGE)/cmd.BuildDate=$(DATE)' \
+		-o release/drone-server github.com/drone/drone/cmd/drone-server
+
+# Drone Agent
+
+.PHONY: agent
+agent: fmt depend | $(BASE) ; $(info $(M) building agent executable…) @ ## Build agent binary
+	$Q cd $(BASE) && CGO_ENABLED=0 $(GO) build \
+		-tags release \
+		-ldflags '-X $(PACKAGE)/cmd.Version=$(VERSION) -X $(PACKAGE)/cmd.BuildDate=$(DATE)' \
+		-o release/drone-agent github.com/drone/drone/cmd/drone-agent
+
+# Basic dependency management
+
+.PHONY: depend
+depend: $(BASE) ; $(info $(M) installing dependencies…) @ ## Install dependencies
+	@go get github.com/drone/drone-ui/dist
+	@go get github.com/golang/protobuf/proto
+	@go get golang.org/x/net/context
+
+# Tools
+
+GOLINT = $(BIN)/golint
+$(BIN)/golint: | $(BASE) ; $(info $(M) building golint…)
+	$Q go get github.com/golang/lint/golint
+
+GOCOVMERGE = $(BIN)/gocovmerge
+$(BIN)/gocovmerge: | $(BASE) ; $(info $(M) building gocovmerge…)
+	$Q go get github.com/wadey/gocovmerge
+
+GOCOV = $(BIN)/gocov
+$(BIN)/gocov: | $(BASE) ; $(info $(M) building gocov…)
+	$Q go get github.com/axw/gocov/...
+
+GOCOVXML = $(BIN)/gocov-xml
+$(BIN)/gocov-xml: | $(BASE) ; $(info $(M) building gocov-xml…)
+	$Q go get github.com/AlekSi/gocov-xml
+
+GO2XUNIT = $(BIN)/go2xunit
+$(BIN)/go2xunit: | $(BASE) ; $(info $(M) building go2xunit…)
+	$Q go get github.com/tebeka/go2xunit
+
+# Tests
+
+TEST_TARGETS := test-default test-bench test-short test-verbose test-race
+.PHONY: $(TEST_TARGETS) test-xml check test tests
+test-bench:   ARGS=-run=__absolutelynothing__ -bench=. ## Run benchmarks
+test-short:   ARGS=-short        ## Run only short tests
+test-verbose: ARGS=-v            ## Run tests in verbose mode with coverage reporting
+test-race:    ARGS=-race         ## Run tests with race detector
+$(TEST_TARGETS): NAME=$(MAKECMDGOALS:test-%=%)
+$(TEST_TARGETS): test
+check test tests: fmt lint | $(BASE) ; $(info $(M) running $(NAME:%=% )tests…) @ ## Run tests
+	$Q cd $(BASE) && $(GO) test -timeout $(TIMEOUT)s $(ARGS) $(TESTPKGS)
+
+test-xml: fmt lint | $(BASE) $(GO2XUNIT) ; $(info $(M) running $(NAME:%=% )tests…) @ ## Run tests with xUnit output
+	$Q cd $(BASE) && 2>&1 $(GO) test -timeout 20s -v $(TESTPKGS) | tee test/tests.output
+	$(GO2XUNIT) -fail -input test/tests.output -output test/tests.xml
+
+COVERAGE_MODE = atomic
+COVERAGE_PROFILE = $(COVERAGE_DIR)/profile.out
+COVERAGE_XML = $(COVERAGE_DIR)/coverage.xml
+COVERAGE_HTML = $(COVERAGE_DIR)/index.html
+.PHONY: test-coverage test-coverage-tools
+test-coverage-tools: | $(GOCOVMERGE) $(GOCOV) $(GOCOVXML)
+test-coverage: COVERAGE_DIR := $(CURDIR)/test/coverage.$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+test-coverage: fmt lint test-coverage-tools | $(BASE) ; $(info $(M) running coverage tests…) @ ## Run coverage tests
+	$Q mkdir -p $(COVERAGE_DIR)/coverage
+	$Q cd $(BASE) && for pkg in $(TESTPKGS); do \
+		$(GO) test \
+			-coverpkg=$$($(GO) list -f '{{ join .Deps "\n" }}' $$pkg | \
+					grep '^$(PACKAGE)/' | grep -v '^$(PACKAGE)/vendor/' | \
+					tr '\n' ',')$$pkg \
+			-covermode=$(COVERAGE_MODE) \
+			-coverprofile="$(COVERAGE_DIR)/coverage/`echo $$pkg | tr "/" "-"`.cover" $$pkg ;\
+	 done
+	$Q $(GOCOVMERGE) $(COVERAGE_DIR)/coverage/*.cover > $(COVERAGE_PROFILE)
+	$Q $(GO) tool cover -html=$(COVERAGE_PROFILE) -o $(COVERAGE_HTML)
+	$Q $(GOCOV) convert $(COVERAGE_PROFILE) | $(GOCOVXML) > $(COVERAGE_XML)
+
+.PHONY: lint
+lint: $(BASE) $(GOLINT) ; $(info $(M) running golint…) @ ## Run golint
+	$Q cd $(BASE) && ret=0 && for pkg in $(PKGS); do \
+		test -z "$$($(GOLINT) $$pkg | tee /dev/stderr)" || ret=1 ; \
+	 done ; exit $$ret
+
+.PHONY: fmt
+fmt: ; $(info $(M) running gofmt…) @ ## Run gofmt on all source files
+	@ret=0 && for d in $$($(GO) list -f '{{.Dir}}' ./... | grep -v /vendor/); do \
+		$(GOFMT) -l -w $$d/*.go || ret=$$? ; \
+	 done ; exit $$ret
+
+# Misc
+
+.PHONY: clean
+clean: ; $(info $(M) cleaning…)	@ ## Cleanup everything
+	@rm -rf $(GOPATH)
+	@rm -rf bin
+	@rm -rf test/tests.* test/coverage.*
+
+.PHONY: help
+help:
+	@grep -E '^[ a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: version
+version:
+	@echo $(VERSION)


### PR DESCRIPTION
The `.drone.sh` requires the closed source enterprise repo and is intended for CI.

Basic documentation on building Drone CI is missing. Can we add in some doc and also make it easier to build by supplying a `Makefile`?

From here, it would be good to also look at dependency management. Currently I've kept it simple by installing the deps manually.