### PR TITLE
use of ProxyFromEnvironment for bitbucketserver

### DIFF
--- a/remote/bitbucketserver/bitbucketserver.go
+++ b/remote/bitbucketserver/bitbucketserver.go
@@ -233,6 +233,7 @@ func CreateConsumer(URL string, ConsumerKey string, PrivateKey *rsa.PrivateKey) 
 	consumer.HttpClient = &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			Proxy: http.ProxyFromEnvironment,
 		},
 	}
 	return consumer


### PR DESCRIPTION
Similar to https://github.com/drone/drone/pull/1724. Currently it looks like drone only supports this with github and gitlab. This PR will add the proxy support for bitbucketserver.

