### PR TITLE
Send both build and config in SenderAllowed

### DIFF
--- a/plugins/sender/plugin.go
+++ b/plugins/sender/plugin.go
@@ -18,7 +18,11 @@ func NewRemote(endpoint string) model.SenderService {
 
 func (p *plugin) SenderAllowed(user *model.User, repo *model.Repo, build *model.Build, conf *model.Config) (bool, error) {
 	path := fmt.Sprintf("%s/senders/%s/%s/%s/verify", p.endpoint, repo.Owner, repo.Name, build.Sender)
-	err := internal.Send("POST", path, build, nil)
+	data := map[string]interface{}{
+		"build": build,
+		"config": conf,
+	}
+	err := internal.Send("POST", path, &data, nil)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Following up on Gitter: Make SenderAllowed send both the build data and the config data to make it easy to verify the drone.yml file.