### PR TITLE
Escape newlines in env var substitution

### DIFF
--- a/server/hook.go
+++ b/server/hook.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -461,7 +462,11 @@ func (b *builder) Build() ([]*buildItem, error) {
 
 		y := b.Yaml
 		s, err := envsubst.Eval(y, func(name string) string {
-			return environ[name]
+			env := environ[name]
+			if strings.Contains(env, "\n") {
+				env = fmt.Sprintf("%q", env)
+			}
+			return env
 		})
 		if err != nil {
 			return nil, err

--- a/server/hook_test.go
+++ b/server/hook_test.go
@@ -1,0 +1,31 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/drone/drone/model"
+)
+
+func TestMultilineEnvsubst(t *testing.T) {
+	b := builder{
+		Repo: &model.Repo{},
+		Curr: &model.Build{
+			Message: `aaa
+bbb`,
+		},
+		Last: &model.Build{},
+		Netrc: &model.Netrc{},
+		Secs: []*model.Secret{},
+		Regs: []*model.Registry{},
+		Link: "",
+		Yaml: `pipeline:
+  xxx:
+    image: scratch
+    yyy: ${DRONE_COMMIT_MESSAGE}
+`,
+	}
+
+	if _, err := b.Build(); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Multiline values for env var substitution were not being escaped and could therefore cause YAML parsing to fail with something like `yaml: line 5: could not find expected ':'`.

For example, `${DRONE_COMMIT_MESSAGE}` could have more than two lines (e.g., `aaa\nbbb`).

Prior to substitution, `.drone.yml` might look like this.

```yaml
pipeline:
  xxx:
    image: scratch
    yyy: ${DRONE_COMMIT_MESSAGE}
```

After substitution, it might then look like this, and the YAML parser will fail.

```yaml
pipeline:
  xxx:
    image: scratch
    yyy: aaa
bbb
```

In order to prevent this, use `fmt.Sprintf("%q")` to escape the newlines, as well as any control characters.