### PR TITLE
Pass agent hostname to server and persist

### DIFF
--- a/cmd/drone-agent/main.go
+++ b/cmd/drone-agent/main.go
@@ -40,6 +40,10 @@ func main() {
 			Usage:  "start the agent in debug mode",
 		},
 		cli.StringFlag{
+			EnvVar: "DRONE_HOSTNAME,HOSTNAME",
+			Name:   "hostname",
+		},
+		cli.StringFlag{
 			EnvVar: "DRONE_PLATFORM",
 			Name:   "platform",
 			Value:  "linux/amd64",

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -10,6 +10,8 @@ import (
 
 	oldcontext "golang.org/x/net/context"
 
+	"google.golang.org/grpc/metadata"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/cncd/logging"
 	"github.com/cncd/pipeline/pipeline/rpc"
@@ -207,6 +209,14 @@ func (s *RPC) Upload(c context.Context, id string, file *rpc.File) error {
 		return err
 	}
 
+	metadata, ok := metadata.FromContext(c)
+	if ok {
+		hostname, ok := metadata["hostname"]
+		if ok && len(hostname) != 0 {
+			proc.Machine = hostname[0]
+		}
+	}
+
 	if file.Mime == "application/json+logs" {
 		return s.store.LogSave(
 			proc,
@@ -237,6 +247,13 @@ func (s *RPC) Init(c context.Context, id string, state rpc.State) error {
 	if err != nil {
 		log.Printf("error: cannot find proc with id %d: %s", procID, err)
 		return err
+	}
+	metadata, ok := metadata.FromContext(c)
+	if ok {
+		hostname, ok := metadata["hostname"]
+		if ok && len(hostname) != 0 {
+			proc.Machine = hostname[0]
+		}
 	}
 
 	build, err := s.store.GetBuild(proc.BuildID)


### PR DESCRIPTION
This pull request passes the agent hostname to the server as described in https://github.com/drone/drone/issues/1496. The hostname is persisted in the database so that we can see where a build (and build step) were executed.