### PR TITLE
allow in a patch update to change the build number if the user is an …

### DIFF
--- a/model/repo.go
+++ b/model/repo.go
@@ -57,13 +57,14 @@ func (r *Repo) Update(from *Repo) {
 
 // RepoPatch represents a repository patch object.
 type RepoPatch struct {
-	Config      *string `json:"config_file,omitempty"`
-	IsTrusted   *bool   `json:"trusted,omitempty"`
-	IsGated     *bool   `json:"gated,omitempty"`
-	Timeout     *int64  `json:"timeout,omitempty"`
-	Visibility  *string `json:"visibility,omitempty"`
-	AllowPull   *bool   `json:"allow_pr,omitempty"`
-	AllowPush   *bool   `json:"allow_push,omitempty"`
-	AllowDeploy *bool   `json:"allow_deploy,omitempty"`
-	AllowTag    *bool   `json:"allow_tag,omitempty"`
+	Config       *string `json:"config_file,omitempty"`
+	IsTrusted    *bool   `json:"trusted,omitempty"`
+	IsGated      *bool   `json:"gated,omitempty"`
+	Timeout      *int64  `json:"timeout,omitempty"`
+	Visibility   *string `json:"visibility,omitempty"`
+	AllowPull    *bool   `json:"allow_pr,omitempty"`
+	AllowPush    *bool   `json:"allow_push,omitempty"`
+	AllowDeploy  *bool   `json:"allow_deploy,omitempty"`
+	AllowTag     *bool   `json:"allow_tag,omitempty"`
+	BuildCounter *int    `json:"build_counter,omitempty"`
 }

--- a/server/repo.go
+++ b/server/repo.go
@@ -95,7 +95,7 @@ func PatchRepo(c *gin.Context) {
 		return
 	}
 
-	if (in.IsTrusted != nil || in.Timeout != nil) && !user.Admin {
+	if (in.IsTrusted != nil || in.Timeout != nil || in.BuildCounter != nil) && !user.Admin {
 		c.String(403, "Insufficient privileges")
 		return
 	}
@@ -132,6 +132,9 @@ func PatchRepo(c *gin.Context) {
 			c.String(400, "Invalid visibility type")
 			return
 		}
+	}
+	if in.BuildCounter != nil {
+		repo.Counter = *in.BuildCounter
 	}
 
 	err := store.UpdateRepo(c, repo)


### PR DESCRIPTION
…admin

Server side update for the cli https://github.com/drone/drone-cli/pull/60 to be able to change the build-counter for issue https://github.com/drone/drone/issues/2057 @bradrydzewski I'm not really able to build drone anymore with the enterprise changes and what not so I haven't been able to test this part of the code :( but from what I can tell it's the only updates that are needed to make the cli updates work.
