### PR TITLE
Let agent pass filter expression string for builds

### DIFF
--- a/cmd/drone-agent/agent.go
+++ b/cmd/drone-agent/agent.go
@@ -32,6 +32,7 @@ func loop(c *cli.Context) error {
 		Labels: map[string]string{
 			"platform": c.String("platform"),
 		},
+		Expr: c.String("drone-filter"),
 	}
 
 	hostname := c.String("hostname")

--- a/cmd/drone-agent/main.go
+++ b/cmd/drone-agent/main.go
@@ -48,6 +48,11 @@ func main() {
 			Name:   "platform",
 			Value:  "linux/amd64",
 		},
+		cli.StringFlag{
+			EnvVar: "DRONE_FILTER",
+			Name:   "drone-filter",
+			Usage:  "A filter expression used to restrict builds by label",
+		},
 		cli.IntFlag{
 			EnvVar: "DRONE_MAX_PROCS",
 			Name:   "max-procs",


### PR DESCRIPTION
Add `DRONE_FILTER` env var for the agent to selectively build tasks.

First of a few PRs to implement build filtering as described in https://github.com/drone/drone/issues/2171#issuecomment-327589521



