### PR TITLE
Add server env var to specify .drone.yml location

### DIFF
--- a/cmd/drone-server/server.go
+++ b/cmd/drone-server/server.go
@@ -93,6 +93,12 @@ var flags = []cli.Flag{
 		Name:   "open",
 		Usage:  "open user registration",
 	},
+	cli.StringFlag{
+		EnvVar: "DRONE_REPO_CONFIG",
+		Name:   "repo-config",
+		Usage:  "file path for the drone config",
+		Value:  ".drone.yml",
+	},
 	cli.DurationFlag{
 		EnvVar: "DRONE_SESSION_EXPIRES",
 		Name:   "session-expires",
@@ -639,6 +645,7 @@ func setupEvilGlobals(c *cli.Context, v store.Store, r remote.Remote) {
 	droneserver.Config.Server.Pass = c.String("agent-secret")
 	droneserver.Config.Server.Host = strings.TrimRight(c.String("server-host"), "/")
 	droneserver.Config.Server.Port = c.String("server-addr")
+	droneserver.Config.Server.RepoConfig = c.String("repo-config")
 	droneserver.Config.Server.SessionExpires = c.Duration("session-expires")
 	droneserver.Config.Pipeline.Networks = c.StringSlice("network")
 	droneserver.Config.Pipeline.Volumes = c.StringSlice("volume")

--- a/server/repo.go
+++ b/server/repo.go
@@ -45,7 +45,7 @@ func PostRepo(c *gin.Context) {
 		}
 	}
 	if repo.Config == "" {
-		repo.Config = ".drone.yml"
+		repo.Config = Config.Server.RepoConfig
 	}
 	if repo.Timeout == 0 {
 		repo.Timeout = 60 // 1 hour default build time

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -60,6 +60,7 @@ var Config = struct {
 		Host           string
 		Port           string
 		Pass           string
+		RepoConfig     string
 		SessionExpires time.Duration
 		// Open bool
 		// Orgs map[string]struct{}


### PR DESCRIPTION
We would like a global default for specifying a different path/name for `.drone.yml`. 

This PR allows setting `DRONE_REPO_CONFIG` for the server to change the default path to `.drone.yml`. One consideration discussed was that setting this default does not retroactively change the default path for repos previously created.

Implementation-wise, I couldn't really think of a better place to stick this global - let me know if you'd prefer this elsewhere.
 