### PR TITLE
Use 'base_ref' as branch name for github tag events.

### DIFF
--- a/remote/github/convert.go
+++ b/remote/github/convert.go
@@ -204,6 +204,11 @@ func convertPushHook(from *webhook) *model.Build {
 		// just kidding, this is actually a tag event. Why did this come as a push
 		// event we'll never know!
 		build.Event = model.EventTag
+		// For tags, if the base_ref (tag's base branch) is set, we're using it
+		// as build's branch so that we can filter events base on it
+		if strings.HasPrefix(from.BaseRef, "refs/heads/") {
+			build.Branch = strings.Replace(from.BaseRef, "refs/heads/", "", -1)
+		}
 	}
 	return build
 }

--- a/remote/github/convert_test.go
+++ b/remote/github/convert_test.go
@@ -247,5 +247,25 @@ func Test_helper(t *testing.T) {
 			g.Assert(build.Event).Equal(model.EventTag)
 			g.Assert(build.Ref).Equal("refs/tags/v1.0.0")
 		})
+
+		g.It("should convert tag's base branch from webhook to build's branch ", func() {
+			from := &webhook{}
+			from.Ref = "refs/tags/v1.0.0"
+			from.BaseRef = "refs/heads/master"
+
+			build := convertPushHook(from)
+			g.Assert(build.Event).Equal(model.EventTag)
+			g.Assert(build.Branch).Equal("master")
+		})
+
+		g.It("should not convert tag's base_ref from webhook if not prefixed with 'ref/heads/'", func() {
+			from := &webhook{}
+			from.Ref = "refs/tags/v1.0.0"
+			from.BaseRef = "refs/refs/master"
+
+			build := convertPushHook(from)
+			g.Assert(build.Event).Equal(model.EventTag)
+			g.Assert(build.Branch).Equal("refs/tags/v1.0.0")
+		})
 	})
 }

--- a/remote/github/types.go
+++ b/remote/github/types.go
@@ -4,6 +4,7 @@ type webhook struct {
 	Ref     string `json:"ref"`
 	Action  string `json:"action"`
 	Deleted bool   `json:"deleted"`
+	BaseRef string `json:"base_ref"`
 
 	Head struct {
 		ID        string `json:"id"`

--- a/vendor/github.com/cncd/pipeline/pipeline/frontend/yaml/constraint.go
+++ b/vendor/github.com/cncd/pipeline/pipeline/frontend/yaml/constraint.go
@@ -4,13 +4,14 @@ import (
 	"path/filepath"
 
 	"github.com/cncd/pipeline/pipeline/frontend"
-	libcompose "github.com/docker/libcompose/yaml"
 	"github.com/cncd/pipeline/pipeline/frontend/yaml/types"
+	libcompose "github.com/docker/libcompose/yaml"
 )
 
 type (
 	// Constraints defines a set of runtime constraints.
 	Constraints struct {
+		Ref         Constraint
 		Repo        Constraint
 		Instance    Constraint
 		Platform    Constraint
@@ -43,6 +44,7 @@ func (c *Constraints) Match(metadata frontend.Metadata) bool {
 		c.Event.Match(metadata.Curr.Event) &&
 		c.Branch.Match(metadata.Curr.Commit.Branch) &&
 		c.Repo.Match(metadata.Repo.Name) &&
+		c.Ref.Match(metadata.Curr.Commit.Ref) &&
 		c.Matrix.Match(metadata.Job.Matrix)
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -39,80 +39,80 @@
 		{
 			"checksumSHA1": "W3AuK8ocqHwlUajGmQLFvnRhTZE=",
 			"path": "github.com/cncd/pipeline/pipeline",
-			"revision": "0a10375aa44bfebeeaffd0b5010ff9cb01893e2d",
-			"revisionTime": "2017-09-12T15:56:23Z"
+			"revision": "b7427ae1fb86bb04e2997e5f3a1eec75c4b056ef",
+			"revisionTime": "2017-09-14T17:45:32Z"
 		},
 		{
 			"checksumSHA1": "gc+efbEPGdecp6I2ezd6J3+UL3o=",
 			"path": "github.com/cncd/pipeline/pipeline/backend",
-			"revision": "0a10375aa44bfebeeaffd0b5010ff9cb01893e2d",
-			"revisionTime": "2017-09-12T15:56:23Z"
+			"revision": "b7427ae1fb86bb04e2997e5f3a1eec75c4b056ef",
+			"revisionTime": "2017-09-14T17:45:32Z"
 		},
 		{
 			"checksumSHA1": "IIuOItGMhYP6kLtlZWYBO+liSx4=",
 			"path": "github.com/cncd/pipeline/pipeline/backend/docker",
-			"revision": "0a10375aa44bfebeeaffd0b5010ff9cb01893e2d",
-			"revisionTime": "2017-09-12T15:56:23Z"
+			"revision": "b7427ae1fb86bb04e2997e5f3a1eec75c4b056ef",
+			"revisionTime": "2017-09-14T17:45:32Z"
 		},
 		{
 			"checksumSHA1": "2A3+CnkMfvvO4oRkjQKqi44no0g=",
 			"path": "github.com/cncd/pipeline/pipeline/frontend",
-			"revision": "0a10375aa44bfebeeaffd0b5010ff9cb01893e2d",
-			"revisionTime": "2017-09-12T15:56:23Z"
+			"revision": "b7427ae1fb86bb04e2997e5f3a1eec75c4b056ef",
+			"revisionTime": "2017-09-14T17:45:32Z"
 		},
 		{
-			"checksumSHA1": "wvnLS1c0wKmcDLBsjQO4Dv6iCWA=",
+			"checksumSHA1": "VZEf4sUe0jVi3TPXE+gfjpKtXFA=",
 			"path": "github.com/cncd/pipeline/pipeline/frontend/yaml",
-			"revision": "0a10375aa44bfebeeaffd0b5010ff9cb01893e2d",
-			"revisionTime": "2017-09-12T15:56:23Z"
+			"revision": "b7427ae1fb86bb04e2997e5f3a1eec75c4b056ef",
+			"revisionTime": "2017-09-14T17:45:32Z"
 		},
 		{
-			"checksumSHA1": "hx0Ok9hti6N9qsJB1sJ05HsMHSM=",
+			"checksumSHA1": "Bso8L5AC/YA4k+YVfIg+m2bMLmU=",
 			"path": "github.com/cncd/pipeline/pipeline/frontend/yaml/compiler",
-			"revision": "0a10375aa44bfebeeaffd0b5010ff9cb01893e2d",
-			"revisionTime": "2017-09-12T15:56:23Z"
+			"revision": "b7427ae1fb86bb04e2997e5f3a1eec75c4b056ef",
+			"revisionTime": "2017-09-14T17:45:32Z"
 		},
 		{
-			"checksumSHA1": "cIbHWz3UTpPjiwfDVJgkQ3BYuD4=",
+			"checksumSHA1": "tExCYtVZoTnfEkEQL7r/megor8I=",
 			"path": "github.com/cncd/pipeline/pipeline/frontend/yaml/linter",
-			"revision": "0a10375aa44bfebeeaffd0b5010ff9cb01893e2d",
-			"revisionTime": "2017-09-12T15:56:23Z"
+			"revision": "b7427ae1fb86bb04e2997e5f3a1eec75c4b056ef",
+			"revisionTime": "2017-09-14T17:45:32Z"
 		},
 		{
 			"checksumSHA1": "kx2sPUIMozPC/g6E4w48h3FfH3k=",
 			"path": "github.com/cncd/pipeline/pipeline/frontend/yaml/matrix",
-			"revision": "0a10375aa44bfebeeaffd0b5010ff9cb01893e2d",
-			"revisionTime": "2017-09-12T15:56:23Z"
+			"revision": "b7427ae1fb86bb04e2997e5f3a1eec75c4b056ef",
+			"revisionTime": "2017-09-14T17:45:32Z"
 		},
 		{
 			"checksumSHA1": "L7Q5qJmPITNmvFEEaj5MPwCWFRk=",
 			"path": "github.com/cncd/pipeline/pipeline/frontend/yaml/types",
-			"revision": "0a10375aa44bfebeeaffd0b5010ff9cb01893e2d",
-			"revisionTime": "2017-09-12T15:56:23Z"
+			"revision": "b7427ae1fb86bb04e2997e5f3a1eec75c4b056ef",
+			"revisionTime": "2017-09-14T17:45:32Z"
 		},
 		{
 			"checksumSHA1": "2/3f3oNmxXy5kcrRLCFa24Oc9O4=",
 			"path": "github.com/cncd/pipeline/pipeline/interrupt",
-			"revision": "0a10375aa44bfebeeaffd0b5010ff9cb01893e2d",
-			"revisionTime": "2017-09-12T15:56:23Z"
+			"revision": "b7427ae1fb86bb04e2997e5f3a1eec75c4b056ef",
+			"revisionTime": "2017-09-14T17:45:32Z"
 		},
 		{
 			"checksumSHA1": "uOjTfke7Qxosrivgz/nVTHeIP5g=",
 			"path": "github.com/cncd/pipeline/pipeline/multipart",
-			"revision": "0a10375aa44bfebeeaffd0b5010ff9cb01893e2d",
-			"revisionTime": "2017-09-12T15:56:23Z"
+			"revision": "b7427ae1fb86bb04e2997e5f3a1eec75c4b056ef",
+			"revisionTime": "2017-09-14T17:45:32Z"
 		},
 		{
 			"checksumSHA1": "pyaqbQRdFkOGTE0mSNou27ikvfs=",
 			"path": "github.com/cncd/pipeline/pipeline/rpc",
-			"revision": "0a10375aa44bfebeeaffd0b5010ff9cb01893e2d",
-			"revisionTime": "2017-09-12T15:56:23Z"
+			"revision": "b7427ae1fb86bb04e2997e5f3a1eec75c4b056ef",
+			"revisionTime": "2017-09-14T17:45:32Z"
 		},
 		{
 			"checksumSHA1": "huYd+DhpBP/0kHMAC0mPZAZBmnw=",
 			"path": "github.com/cncd/pipeline/pipeline/rpc/proto",
-			"revision": "0a10375aa44bfebeeaffd0b5010ff9cb01893e2d",
-			"revisionTime": "2017-09-12T15:56:23Z"
+			"revision": "b7427ae1fb86bb04e2997e5f3a1eec75c4b056ef",
+			"revisionTime": "2017-09-14T17:45:32Z"
 		},
 		{
 			"checksumSHA1": "7Qj1DK0ceAXkYztW0l3+L6sn+V8=",


### PR DESCRIPTION
Implements https://github.com/drone/drone/issues/2217

This change adds ability to filter builds by the source branch name for tag
events from Github.

