### PR TITLE
Fix gogs hookPullRequest actionSync typo

### DIFF
--- a/remote/gogs/parse.go
+++ b/remote/gogs/parse.go
@@ -14,7 +14,7 @@ const (
 	hookPullRequest = "pull_request"
 
 	actionOpen = "opened"
-	actionSync = "synchronize"
+	actionSync = "synchronized"
 
 	stateOpen = "open"
 


### PR DESCRIPTION
When pushing an update to a pull request in gogs, the webhook to drone is accepted with a "200 OK" but fails to trigger a build.
In gogs, the action for synchronizing a pull request is called "synchronize**d**", but remote/gogs/parse.go expects it to be called "synchronize", thus ignoring the build trigger in parsePullRequestHook.

Example webhook data from gogs that gets ignored by drone:
```
{
  "action": "synchronized",
  "number": 2,
  "pull_request": {
    "id": 6,
    "number": 2,
    [...]
```