### PR TITLE
Urgent fix for changed auth behavior on Gitea

### DIFF
--- a/remote/gitea/gitea.go
+++ b/remote/gitea/gitea.go
@@ -271,8 +271,8 @@ func (c *client) Netrc(u *model.User, r *model.Repo) (*model.Netrc, error) {
 		}, nil
 	}
 	return &model.Netrc{
-		Login:    u.Token,
-		Password: "x-oauth-basic",
+		Login:    u.Login,
+		Password: u.Token,
 		Machine:  c.Machine,
 	}, nil
 }

--- a/remote/gitea/gitea_test.go
+++ b/remote/gitea/gitea_test.go
@@ -55,8 +55,8 @@ func Test_gitea(t *testing.T) {
 				})
 				netrc, _ := remote.Netrc(fakeUser, nil)
 				g.Assert(netrc.Machine).Equal("gitea.com")
-				g.Assert(netrc.Login).Equal(fakeUser.Token)
-				g.Assert(netrc.Password).Equal("x-oauth-basic")
+				g.Assert(netrc.Login).Equal(fakeUser.Login)
+				g.Assert(netrc.Password).Equal(fakeUser.Token)
 			})
 			g.It("Should return a netrc with the machine account", func() {
 				remote, _ := New(Opts{


### PR DESCRIPTION
Within the PR https://github.com/go-gitea/gitea/pull/2184 on Gitea the
project dropped the standard behavior to use x-auth-basic personal
access token. So we should use a proper username and the token from now
on to support Gitea >= 1.2.0. Since this driver anyway only supports
Gitea >= 1.2.0 this won't be a breaking change on Drone side, the only
breaking change is on side of Gitea!

