### PR TITLE
Redirect HTTP to HTTPS when SSL is enabled.

### DIFF
--- a/cmd/drone-server/server.go
+++ b/cmd/drone-server/server.go
@@ -565,7 +565,7 @@ func server(c *cli.Context) error {
 	// start the server with lets encrypt enabled
 	// listen on ports 443 and 80
 	g.Go(func() error {
-		return http.ListenAndServe(":http", handler)
+		return http.ListenAndServe(":http", http.HandlerFunc(redirect))
 	})
 
 	g.Go(func() error {
@@ -681,6 +681,9 @@ func redirect(w http.ResponseWriter, req *http.Request) {
 	serverHost = strings.TrimPrefix(serverHost, "https://")
 	req.URL.Scheme = "https"
 	req.URL.Host = serverHost
+
+	w.Header().Set("Strict-Transport-Security", "max-age=31536000")
+
 	http.Redirect(w, req, req.URL.String(), http.StatusMovedPermanently)
 }
 

--- a/cmd/drone-server/server.go
+++ b/cmd/drone-server/server.go
@@ -536,7 +536,7 @@ func server(c *cli.Context) error {
 	// start the server with tls enabled
 	if c.String("server-cert") != "" {
 		g.Go(func() error {
-			return http.ListenAndServe(":http", handler)
+			return http.ListenAndServe(":http", http.HandlerFunc(redirect))
 		})
 		g.Go(func() error {
 			serve := &http.Server{
@@ -673,6 +673,15 @@ func (a *authorizer) authorize(ctx context.Context) error {
 		return errors.New("invalid agent token")
 	}
 	return errors.New("missing agent token")
+}
+
+func redirect(w http.ResponseWriter, req *http.Request) {
+	var serverHost string = droneserver.Config.Server.Host
+	serverHost = strings.TrimPrefix(serverHost, "http://")
+	serverHost = strings.TrimPrefix(serverHost, "https://")
+	req.URL.Scheme = "https"
+	req.URL.Host = serverHost
+	http.Redirect(w, req, req.URL.String(), http.StatusMovedPermanently)
 }
 
 func cacheDir() string {


### PR DESCRIPTION
In our current drone setup, we are not using a proxy, thus letting drone handle
SSL termination. In addition, we are not exposing port 80 (effectively disabling
insecure drone access). When new engineers join and attempt to access drone,
they are not sent a 301 and often complain that they either do not have access
or that drone is broken (when in reality they are just accessing drone via the
incorrect protocol/port).

This commit changes the default behavior when running drone with a server-cert
by only sending redirects on port 80 rather than allowing both secure and
insecure access.

