### PR TITLE
Add support for automatic cancellation of running/pending builds

### DIFF
--- a/cmd/drone-server/server.go
+++ b/cmd/drone-server/server.go
@@ -461,6 +461,19 @@ var flags = []cli.Flag{
 		Name:   "coding-skip-verify",
 		Usage:  "coding skip ssl verification",
 	},
+	//
+	// experimental parameters
+	//
+	cli.BoolFlag{
+		EnvVar: "DRONE_EXPERIMENTAL_AUTO_CANCEL_PENDING",
+		Name:   "experimental-auto-cancel-pending",
+		Usage:  "automatically cancel pending builds for same branch",
+	},
+	cli.BoolFlag{
+		EnvVar: "DRONE_EXPERIMENTAL_AUTO_CANCEL_RUNNING",
+		Name:   "experimental-auto-cancel-running",
+		Usage:  "automatically cancel running builds for same branch",
+	},
 }
 
 func server(c *cli.Context) error {

--- a/model/settings.go
+++ b/model/settings.go
@@ -2,10 +2,16 @@ package model
 
 // Settings defines system configuration parameters.
 type Settings struct {
-	Open   bool            // Enables open registration
-	Secret string          // Secret token used to authenticate agents
-	Admins map[string]bool // Administrative users
-	Orgs   map[string]bool // Organization whitelist
+	Open         bool            // Enables open registration
+	Secret       string          // Secret token used to authenticate agents
+	Admins       map[string]bool // Administrative users
+	Orgs         map[string]bool // Organization whitelist
+	Experimental Experimental    // Experimental settings
+}
+
+type Experimental struct {
+	AutoCancelPending bool // Automatically cancels pending builds for the same branch
+	AutoCancelRunning bool // Auto cancels running builds for the same branch
 }
 
 // IsAdmin returns true if the user is a member of the administrator list.

--- a/router/middleware/config.go
+++ b/router/middleware/config.go
@@ -25,6 +25,10 @@ func setupConfig(c *cli.Context) *model.Settings {
 		Secret: c.String("agent-secret"),
 		Admins: sliceToMap2(c.StringSlice("admin")),
 		Orgs:   sliceToMap2(c.StringSlice("orgs")),
+		Experimental: model.Experimental{
+			AutoCancelPending: c.Bool("experimental-auto-cancel-pending"),
+			AutoCancelRunning: c.Bool("experimental-auto-cancel-running"),
+		},
 	}
 }
 

--- a/server/hook.go
+++ b/server/hook.go
@@ -238,6 +238,28 @@ func PostHook(c *gin.Context) {
 	// on status change notifications
 	last, _ := store.GetBuildLastBefore(c, repo, build.Branch, build.ID)
 
+	config := ToConfig(c)
+
+	// If we have enabled killing pending jobs for the same branch, look at the state
+	// of the last build, force killing in the same method a zombie proc would be cleaned up
+	if config.Experimental.AutoCancelPending && build.Branch != "master" {
+		if last.Status == model.StatusPending {
+			procs, err := store.FromContext(c).ProcList(last)
+			if err == nil {
+				forceKillBuild(c, last, procs)
+			}
+		}
+	}
+
+	// If we have enabled killing running jobs for the same branch, look at the state
+	// of the last build, killing it in the same method that cancelling build uses
+	if config.Experimental.AutoCancelRunning && build.Branch != "master" {
+		proc, err := store.FromContext(c).ProcFind(last, 1)
+		if err == nil && proc.State == model.StatusRunning {
+			killRunningBuild(c, proc)
+		}
+	}
+
 	//
 	// BELOW: NEW
 	//
@@ -308,6 +330,7 @@ func PostHook(c *gin.Context) {
 		Labels: map[string]string{
 			"repo":    repo.FullName,
 			"private": strconv.FormatBool(repo.IsPrivate),
+			"branch":  build.Branch,
 		},
 	}
 	buildCopy := *build
@@ -332,6 +355,7 @@ func PostHook(c *gin.Context) {
 		}
 		task.Labels["platform"] = item.Platform
 		task.Labels["repo"] = b.Repo.FullName
+		task.Labels["branch"] = build.Branch
 
 		task.Data, _ = json.Marshal(rpc.Pipeline{
 			ID:      fmt.Sprint(item.Proc.ID),

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -328,6 +328,7 @@ func (s *RPC) Init(c context.Context, id string, state rpc.State) error {
 			Labels: map[string]string{
 				"repo":    repo.FullName,
 				"private": strconv.FormatBool(repo.IsPrivate),
+				"branch":  build.Branch,
 			},
 		}
 		message.Data, _ = json.Marshal(model.Event{
@@ -489,6 +490,7 @@ func createFilterFunc(filter rpc.Filter) (queue.Filter, error) {
 
 	return func(task *queue.Task) bool {
 		if st != nil {
+			fmt.Println("LABELS: ", task.Labels)
 			match, _ := st.Eval(expr.NewRow(task.Labels))
 			return match
 		}


### PR DESCRIPTION
By using two new variables (flagged as EXPERIMENTAL), new builds
for a branch will check to see whether it should cancel any preceding
builds.

Cancelling pending builds uses the same logic that killing zombie processes
does, and cancelling running builds uses the same logic that cancelling from
the UI does.

Deals, in part, with the ideas discussed in #1980 
