### PR TITLE
BUILDING: add export CGO_ENABLED=0

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -9,5 +9,6 @@
 
 3. Install binaries to $GOPATH/bin
 
+    export CGO_ENABLED=0
     go install github.com/drone/drone/cmd/drone-agent
     go install github.com/drone/drone/cmd/drone-server


### PR DESCRIPTION
While this will work fine without it, you'll hit an issue when you go to
run a docker container built with this because the resulting binary will
look for some dynamic library on start and fail to find it which yields
a "no such file or directory" error.

This at least hints someone down the right track.  If you're using
sqlite3 locally, then you'll need CGO enabled (AFAICT).