### PR TITLE
server: fully qualify Status URI

### DIFF
--- a/server/rpc.go
+++ b/server/rpc.go
@@ -425,7 +425,7 @@ func (s *RPC) Done(c context.Context, id string, state rpc.State) error {
 					s.store.UpdateUser(user)
 				}
 			}
-			uri := fmt.Sprintf("%s/%s/%d", s.host, repo.FullName, build.Number)
+			uri := fmt.Sprintf("https://%s/%s/%d", s.host, repo.FullName, build.Number)
 			err = s.remote.Status(user, repo, build, uri)
 			if err != nil {
 				logrus.Errorf("error setting commit status for %s/%d", repo.FullName, build.Number)


### PR DESCRIPTION
Required by Bitbucket Server to properly post status updates.

FWIW, I don't really think this should be merged in this state, but hoped this would be a good starting point for a conversation.  It appears that all other points in the code where status updates occur, we steal the protocol based on the incoming request.  I'm not sure if we can use that same pattern here or if we need to do something else.  If this is an easy fix, please feel free to close this out.  If not, I'd be happy to work on it if you give me some direction on where I should go.