### PR TITLE
Validate DRONE_HOST to ensure it contains a scheme and not a trailing slash

### DIFF
--- a/cmd/drone-server/server.go
+++ b/cmd/drone-server/server.go
@@ -477,6 +477,18 @@ func server(c *cli.Context) error {
 		logrus.Fatalln("DRONE_HOST is not properly configured")
 	}
 
+	if !strings.Contains(c.String("server-host"), "://") {
+		logrus.Fatalln(
+			"DRONE_HOST must be <scheme>://<hostname> format",
+		)
+	}
+
+	if !strings.HasSuffix(c.String("server-host"), "/") {
+		logrus.Fatalln(
+			"DRONE_HOST must not have trailing slash",
+		)
+	}
+
 	remote_, err := SetupRemote(c)
 	if err != nil {
 		logrus.Fatal(err)


### PR DESCRIPTION
Based on discussions here: https://discourse.drone.io/t/incorrect-linkback-from-bitbucket-cloud/1438/5

And instructions here: http://docs.drone.io/installation/

Code often is more effective than documentation.

