### PR TITLE
Support for customizing web hook host

### DIFF
--- a/cmd/drone-server/server.go
+++ b/cmd/drone-server/server.go
@@ -54,7 +54,7 @@ var flags = []cli.Flag{
 	cli.StringFlag{
 		EnvVar: "DRONE_HOOK_HOST",
 		Name:   "hook-host",
-		Usage:  "for generating webhook links",
+		Usage:  "override hook host",
 		Value:  "",
 	},
 	cli.StringFlag{

--- a/cmd/drone-server/server.go
+++ b/cmd/drone-server/server.go
@@ -477,6 +477,18 @@ func server(c *cli.Context) error {
 		logrus.Fatalln("DRONE_HOST is not properly configured")
 	}
 
+	if !strings.Contains(c.String("server-host"), "://") {
+		logrus.Fatalln(
+			"DRONE_HOST must be <scheme>://<hostname> format",
+		)
+	}
+
+	if !strings.HasSuffix(c.String("server-host"), "/") {
+		logrus.Fatalln(
+			"DRONE_HOST must not have trailing slash",
+		)
+	}
+
 	remote_, err := SetupRemote(c)
 	if err != nil {
 		logrus.Fatal(err)

--- a/cmd/drone-server/server.go
+++ b/cmd/drone-server/server.go
@@ -52,6 +52,12 @@ var flags = []cli.Flag{
 		Value:  ":8000",
 	},
 	cli.StringFlag{
+		EnvVar: "DRONE_HOOK_HOST",
+		Name:   "hook-host",
+		Usage:  "for generating webhook links",
+		Value:  "",
+	},
+	cli.StringFlag{
 		EnvVar: "DRONE_SERVER_CERT",
 		Name:   "server-cert",
 		Usage:  "server ssl cert",
@@ -489,6 +495,12 @@ func server(c *cli.Context) error {
 		)
 	}
 
+	if c.String("hook-host") != "" && !strings.Contains(c.String("hook-host"), "://") {
+		logrus.Fatalln(
+			"HOOK_HOST must be <scheme>://<hostname> format",
+		)
+	}
+
 	remote_, err := SetupRemote(c)
 	if err != nil {
 		logrus.Fatal(err)
@@ -648,6 +660,7 @@ func setupEvilGlobals(c *cli.Context, v store.Store, r remote.Remote) {
 	droneserver.Config.Server.Pass = c.String("agent-secret")
 	droneserver.Config.Server.Host = strings.TrimRight(c.String("server-host"), "/")
 	droneserver.Config.Server.Port = c.String("server-addr")
+	droneserver.Config.Server.HookHost = strings.TrimRight(c.String("hook-host"), "/")
 	droneserver.Config.Server.RepoConfig = c.String("repo-config")
 	droneserver.Config.Server.SessionExpires = c.Duration("session-expires")
 	droneserver.Config.Pipeline.Networks = c.StringSlice("network")

--- a/server/badge.go
+++ b/server/badge.go
@@ -7,7 +7,6 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/drone/drone/model"
-	"github.com/drone/drone/shared/httputil"
 	"github.com/drone/drone/store"
 )
 
@@ -78,7 +77,7 @@ func GetCC(c *gin.Context) {
 		return
 	}
 
-	url := fmt.Sprintf("%s/%s/%d", httputil.GetURL(c.Request), repo.FullName, builds[0].Number)
+	url := fmt.Sprintf("%s/%s/%d", Config.Server.Host, repo.FullName, builds[0].Number)
 	cc := model.NewCC(repo, builds[0], url)
 	c.XML(200, cc)
 }

--- a/server/build.go
+++ b/server/build.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cncd/pubsub"
 	"github.com/cncd/queue"
 	"github.com/drone/drone/remote"
-	"github.com/drone/drone/shared/httputil"
 	"github.com/drone/drone/store"
 	"github.com/gin-gonic/gin"
 
@@ -312,7 +311,7 @@ func PostApproval(c *gin.Context) {
 		Netrc: netrc,
 		Secs:  secs,
 		Regs:  regs,
-		Link:  httputil.GetURL(c.Request),
+		Link:  Config.Server.Host,
 		Yaml:  conf.Data,
 		Envs:  envs,
 	}
@@ -570,7 +569,7 @@ func PostBuild(c *gin.Context) {
 		Netrc: netrc,
 		Secs:  secs,
 		Regs:  regs,
-		Link:  httputil.GetURL(c.Request),
+		Link:  Config.Server.Host,
 		Yaml:  conf.Data,
 		Envs:  buildParams,
 	}

--- a/server/build.go
+++ b/server/build.go
@@ -298,7 +298,7 @@ func PostApproval(c *gin.Context) {
 	}
 
 	defer func() {
-		uri := fmt.Sprintf("%s/%s/%d", httputil.GetURL(c.Request), repo.FullName, build.Number)
+		uri := fmt.Sprintf("%s/%s/%d", Config.Server.Host, repo.FullName, build.Number)
 		err = remote_.Status(user, repo, build, uri)
 		if err != nil {
 			logrus.Errorf("error setting commit status for %s/%d", repo.FullName, build.Number)
@@ -424,7 +424,7 @@ func PostDecline(c *gin.Context) {
 		return
 	}
 
-	uri := fmt.Sprintf("%s/%s/%d", httputil.GetURL(c.Request), repo.FullName, build.Number)
+	uri := fmt.Sprintf("%s/%s/%d", Config.Server.Host, repo.FullName, build.Number)
 	err = remote_.Status(user, repo, build, uri)
 	if err != nil {
 		logrus.Errorf("error setting commit status for %s/%d", repo.FullName, build.Number)

--- a/server/hook.go
+++ b/server/hook.go
@@ -17,7 +17,6 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/drone/drone/model"
 	"github.com/drone/drone/remote"
-	"github.com/drone/drone/shared/httputil"
 	"github.com/drone/drone/shared/token"
 	"github.com/drone/drone/store"
 	"github.com/drone/envsubst"
@@ -259,7 +258,7 @@ func PostHook(c *gin.Context) {
 		Secs:  secs,
 		Regs:  regs,
 		Envs:  envs,
-		Link:  httputil.GetURL(c.Request),
+		Link:  Config.Server.Host,
 		Yaml:  conf.Data,
 	}
 	items, err := b.Build()

--- a/server/hook.go
+++ b/server/hook.go
@@ -244,7 +244,7 @@ func PostHook(c *gin.Context) {
 	//
 
 	defer func() {
-		uri := fmt.Sprintf("%s/%s/%d", httputil.GetURL(c.Request), repo.FullName, build.Number)
+		uri := fmt.Sprintf("%s/%s/%d", Config.Server.Host, repo.FullName, build.Number)
 		err = remote_.Status(user, repo, build, uri)
 		if err != nil {
 			logrus.Errorf("error setting commit status for %s/%d", repo.FullName, build.Number)

--- a/server/repo.go
+++ b/server/repo.go
@@ -199,7 +199,7 @@ func DeleteRepo(c *gin.Context) {
 		}
 	}
 
-	remote.Deactivate(user, repo, httputil.GetURL(c.Request))
+	remote.Deactivate(user, repo, getHookHost(c.Request))
 	c.JSON(200, repo)
 }
 

--- a/server/repo.go
+++ b/server/repo.go
@@ -17,6 +17,14 @@ import (
 	"github.com/drone/drone/store"
 )
 
+func getHookHost(r *http.Request) string {
+	if Config.Server.HookHost != "" {
+		return Config.Server.HookHost
+	}
+
+	return httputil.GetURL(r)
+}
+
 func PostRepo(c *gin.Context) {
 	remote := remote.FromContext(c)
 	user := session.User(c)
@@ -66,7 +74,7 @@ func PostRepo(c *gin.Context) {
 
 	link := fmt.Sprintf(
 		"%s/hook?access_token=%s",
-		httputil.GetURL(c.Request),
+		getHookHost(c.Request),
 		sig,
 	)
 
@@ -209,7 +217,7 @@ func RepairRepo(c *gin.Context) {
 	}
 
 	// reconstruct the link
-	host := httputil.GetURL(c.Request)
+	host := getHookHost(c.Request)
 	link := fmt.Sprintf(
 		"%s/hook?access_token=%s",
 		host,
@@ -295,7 +303,7 @@ func MoveRepo(c *gin.Context) {
 	}
 
 	// reconstruct the link
-	host := httputil.GetURL(c.Request)
+	host := getHookHost(c.Request)
 	link := fmt.Sprintf(
 		"%s/hook?access_token=%s",
 		host,

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -62,6 +62,7 @@ var Config = struct {
 		Pass           string
 		RepoConfig     string
 		SessionExpires time.Duration
+		HookHost       string
 		// Open bool
 		// Orgs map[string]struct{}
 		// Admins map[string]struct{}


### PR DESCRIPTION
This PR allows the customization of the web hook URL. This allows us to host Drone on an internal VPN and allow only the webhook URL to be exposed to the outside world.

We're running this fork successfully on our network - would love to get this merged upstream.