### PR TITLE
Add keepalive to agents

### DIFF
--- a/cmd/drone-agent/agent.go
+++ b/cmd/drone-agent/agent.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/cncd/pipeline/pipeline"
@@ -68,6 +69,26 @@ func loop(c *cli.Context) error {
 
 	// grpc.Dial(target, ))
 
+	agentKeepalive := keepalive.ClientParameters{}
+	if c.String("keepalive-time") != "" {
+		d, err := time.ParseDuration(c.String("keepalive-time"))
+
+		if err != nil {
+			return err
+		}
+
+		agentKeepalive.Time = d
+	}
+	if c.String("keepalive-timeout") != "" {
+		d, err := time.ParseDuration(c.String("keepalive-timeout"))
+
+		if err != nil {
+			return err
+		}
+
+		agentKeepalive.Timeout = d
+	}
+
 	conn, err := grpc.Dial(
 		c.String("server"),
 		grpc.WithInsecure(),
@@ -75,6 +96,7 @@ func loop(c *cli.Context) error {
 			username: c.String("username"),
 			password: c.String("password"),
 		}),
+		grpc.WithKeepaliveParams(agentKeepalive),
 	)
 
 	if err != nil {

--- a/cmd/drone-agent/agent.go
+++ b/cmd/drone-agent/agent.go
@@ -69,26 +69,6 @@ func loop(c *cli.Context) error {
 
 	// grpc.Dial(target, ))
 
-	agentKeepalive := keepalive.ClientParameters{}
-	if c.String("keepalive-time") != "" {
-		d, err := time.ParseDuration(c.String("keepalive-time"))
-
-		if err != nil {
-			return err
-		}
-
-		agentKeepalive.Time = d
-	}
-	if c.String("keepalive-timeout") != "" {
-		d, err := time.ParseDuration(c.String("keepalive-timeout"))
-
-		if err != nil {
-			return err
-		}
-
-		agentKeepalive.Timeout = d
-	}
-
 	conn, err := grpc.Dial(
 		c.String("server"),
 		grpc.WithInsecure(),
@@ -96,7 +76,10 @@ func loop(c *cli.Context) error {
 			username: c.String("username"),
 			password: c.String("password"),
 		}),
-		grpc.WithKeepaliveParams(agentKeepalive),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time: c.Duration("keepalive-time"),
+			Timeout: c.Duration("keepalive-timeout"),
+		}),
 	)
 
 	if err != nil {

--- a/cmd/drone-agent/main.go
+++ b/cmd/drone-agent/main.go
@@ -80,12 +80,12 @@ func main() {
 			Name:   "healthcheck",
 			Usage:  "enables the healthcheck endpoint",
 		},
-		cli.StringFlag{
+		cli.DurationFlag{
 			EnvVar: "DRONE_KEEPALIVE_TIME",
 			Name:   "keepalive-time",
 			Usage:  "after a duration of this time if the agent doesn't see any activity it pings the server to see if the transport is still alive",
 		},
-		cli.StringFlag{
+		cli.DurationFlag{
 			EnvVar: "DRONE_KEEPALIVE_TIMEOUT",
 			Name:   "keepalive-timeout",
 			Usage:  "after having pinged for keepalive check, the client waits for a duration of Timeout and if no activity is seen even after that the connection is closed.",

--- a/cmd/drone-agent/main.go
+++ b/cmd/drone-agent/main.go
@@ -80,6 +80,16 @@ func main() {
 			Name:   "healthcheck",
 			Usage:  "enables the healthcheck endpoint",
 		},
+		cli.StringFlag{
+			EnvVar: "DRONE_KEEPALIVE_TIME",
+			Name:   "keepalive-time",
+			Usage:  "after a duration of this time if the agent doesn't see any activity it pings the server to see if the transport is still alive",
+		},
+		cli.StringFlag{
+			EnvVar: "DRONE_KEEPALIVE_TIMEOUT",
+			Name:   "keepalive-timeout",
+			Usage:  "after having pinged for keepalive check, the client waits for a duration of Timeout and if no activity is seen even after that the connection is closed.",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {


### PR DESCRIPTION
This adds keep alive to agents to send pings back to server during build inactivity.

This has helped me address issues between server<>agent when there are no builds for a period of time and firewalls kill the inactive connection.  May be helpful for other server<>agent comm issues as well.

I'm in progress of testing this specific iteration.  I had tested with hardcoded values and it worked beautifully.  Wanted to get this out there for review at least.  :)