### PR TITLE
add working docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '2'
+
+services:
+  drone-server:
+    image: drone/drone:8.2
+    ports:
+      - 80:8000
+    volumes:
+      - /var/lib/drone:/var/lib/drone/
+    restart: always
+    environment:
+      - DRONE_OPEN=true
+      - DRONE_HOST=${DRONE_HOST}
+      - DRONE_GITHUB=true
+      - DRONE_GITHUB_CLIENT=${DRONE_GITHUB_CLIENT}
+      - DRONE_GITHUB_SECRET=${DRONE_GITHUB_SECRET}
+      - DRONE_SECRET=${DRONE_SECRET}
+
+  drone-agent:
+    image: drone/agent:8.2
+    command: agent
+    restart: always
+    depends_on:
+      - drone-server
+    links:
+      - drone-server
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - DRONE_SERVER=drone-server:9000
+      - DRONE_SECRET=${DRONE_SECRET}


### PR DESCRIPTION
Using drone is easy, when providing a simple docker-compose setup.
However, the documentation is outdated and the information on the
net like stackoverflow are wrong in terms of producing errors in the
most recent versions, where the agent cannot talk to the server
using GRPC.

This removes the port 9000 to be not exposed to the public (being
just open for internal connections) and the link from the agent ot
server is added.

I hope this solves all the confusion of how to use drone, as it is
now a simple "docker-compose up".

