### PR TITLE
Fix autocert generation

### DIFF
--- a/cmd/drone-server/server.go
+++ b/cmd/drone-server/server.go
@@ -584,7 +584,7 @@ func server(c *cli.Context) error {
 	dir := cacheDir()
 	os.MkdirAll(dir, 0700)
 
-	manager := autocert.Manager{
+	manager := &autocert.Manager{
 		Prompt:     autocert.AcceptTOS,
 		HostPolicy: autocert.HostWhitelist(address.Host),
 		Cache:      autocert.DirCache(dir),


### PR DESCRIPTION
Fix  for https://discourse.drone.io/t/autocert-unable-to-authorize/1565

manager.HTTPHandler  activates the http-01 challenge by setting a property and needs to keep the reference. 