### PR TITLE
uses email from Sender field of push event

### DIFF
--- a/remote/gitea/fixtures/hooks.go
+++ b/remote/gitea/fixtures/hooks.go
@@ -46,6 +46,7 @@ const HookPush = `
     "login": "gordon",
     "id": 1,
     "username": "gordon",
+    "email": "gordon@golang.org",
     "avatar_url": "http://gitea.golang.org///1.gravatar.com/avatar/8c58a0be77ee441bb8f8595b7f1b4e87"
   }
 }

--- a/remote/gitea/helper.go
+++ b/remote/gitea/helper.go
@@ -77,7 +77,7 @@ func buildFromPush(hook *pushHook) *model.Build {
 		Message:   hook.Commits[0].Message,
 		Avatar:    avatar,
 		Author:    author,
-		Email:     hook.Pusher.Email,
+		Email:     hook.Sender.Email,
 		Timestamp: time.Now().UTC().Unix(),
 		Sender:    sender,
 	}

--- a/remote/gitea/types.go
+++ b/remote/gitea/types.go
@@ -38,6 +38,7 @@ type pushHook struct {
 		ID       int64  `json:"id"`
 		Login    string `json:"login"`
 		Username string `json:"username"`
+		Email    string `json:"email"`
 		Avatar   string `json:"avatar_url"`
 	} `json:"sender"`
 }

--- a/remote/gogs/fixtures/hooks.go
+++ b/remote/gogs/fixtures/hooks.go
@@ -44,6 +44,7 @@ var HookPush = `
   "sender": {
     "login": "gordon",
     "id": 1,
+    "email": "gordon@golang.org",
     "avatar_url": "http://gogs.golang.org///1.gravatar.com/avatar/8c58a0be77ee441bb8f8595b7f1b4e87"
   }
 }

--- a/remote/gogs/helper.go
+++ b/remote/gogs/helper.go
@@ -77,7 +77,7 @@ func buildFromPush(hook *pushHook) *model.Build {
 		Message:   hook.Commits[0].Message,
 		Avatar:    avatar,
 		Author:    author,
-		Email:     hook.Pusher.Email,
+		Email:     hook.Sender.Email,
 		Timestamp: time.Now().UTC().Unix(),
 		Sender:    sender,
 	}

--- a/remote/gogs/types.go
+++ b/remote/gogs/types.go
@@ -37,6 +37,7 @@ type pushHook struct {
 		ID       int64  `json:"id"`
 		Login    string `json:"login"`
 		Username string `json:"username"`
+		Email    string `json:"email"`
 		Avatar   string `json:"avatar_url"`
 	} `json:"sender"`
 }


### PR DESCRIPTION
Gitea/Gogs [set repository owner](https://github.com/go-gitea/gitea/blob/d644e8810710bc2e5035aa25f63c597c47312404/models/pull.go#L469) information as Pusher in webhook.

For example, if we have a repository: git.example.com/org1/repo1, owner
of repository will be `org1` and the email field will be empty. This PR
changes gitea/gogs helpers to use the email in Sender field, which is
the user that click the merge button.

