### PR TITLE
Fix Gitea remote pull-request webhook parsing

### DIFF
--- a/remote/gitea/fixtures/hooks.go
+++ b/remote/gitea/fixtures/hooks.go
@@ -103,13 +103,11 @@ const HookPullRequest = `{
       "email": "gordon@golang.org",
       "avatar_url": "http://gitea.golang.org///1.gravatar.com/avatar/8c58a0be77ee441bb8f8595b7f1b4e87"
     },
-    "base_branch": "master",
     "base": {
       "label": "master",
       "ref": "master",
       "sha": "9353195a19e45482665306e466c832c46560532d"
     },
-    "head_branch": "feature/changes",
     "head": {
       "label": "feature/changes",
       "ref": "feature/changes",

--- a/remote/gitea/helper.go
+++ b/remote/gitea/helper.go
@@ -127,15 +127,15 @@ func buildFromPullRequest(hook *pullRequestHook) *model.Build {
 		Commit:  hook.PullRequest.Head.Sha,
 		Link:    hook.PullRequest.URL,
 		Ref:     fmt.Sprintf("refs/pull/%d/head", hook.Number),
-		Branch:  hook.PullRequest.BaseBranch,
+		Branch:  hook.PullRequest.Base.Ref,
 		Message: hook.PullRequest.Title,
 		Author:  hook.PullRequest.User.Username,
 		Avatar:  avatar,
 		Sender:  sender,
 		Title:   hook.PullRequest.Title,
 		Refspec: fmt.Sprintf("%s:%s",
-			hook.PullRequest.HeadBranch,
-			hook.PullRequest.BaseBranch,
+			hook.PullRequest.Head.Ref,
+			hook.PullRequest.Base.Ref,
 		),
 	}
 	return build

--- a/remote/gitea/helper_test.go
+++ b/remote/gitea/helper_test.go
@@ -127,6 +127,7 @@ func Test_parse(t *testing.T) {
 			g.Assert(build.Ref).Equal("refs/pull/1/head")
 			g.Assert(build.Link).Equal(hook.PullRequest.URL)
 			g.Assert(build.Branch).Equal("master")
+			g.Assert(build.Refspec).Equal("feature/changes:master")
 			g.Assert(build.Message).Equal(hook.PullRequest.Title)
 			g.Assert(build.Avatar).Equal("http://1.gravatar.com/avatar/8c58a0be77ee441bb8f8595b7f1b4e87")
 			g.Assert(build.Author).Equal(hook.PullRequest.User.Username)

--- a/remote/gitea/types.go
+++ b/remote/gitea/types.go
@@ -54,16 +54,15 @@ type pullRequestHook struct {
 			Email    string `json:"email"`
 			Avatar   string `json:"avatar_url"`
 		} `json:"user"`
-		Title      string   `json:"title"`
-		Body       string   `json:"body"`
-		Labels     []string `json:"labels"`
-		State      string   `json:"state"`
-		URL        string   `json:"html_url"`
-		Mergeable  bool     `json:"mergeable"`
-		Merged     bool     `json:"merged"`
-		MergeBase  string   `json:"merge_base"`
-		BaseBranch string   `json:"base_branch"`
-		Base       struct {
+		Title     string   `json:"title"`
+		Body      string   `json:"body"`
+		Labels    []string `json:"labels"`
+		State     string   `json:"state"`
+		URL       string   `json:"html_url"`
+		Mergeable bool     `json:"mergeable"`
+		Merged    bool     `json:"merged"`
+		MergeBase string   `json:"merge_base"`
+		Base      struct {
 			Label string `json:"label"`
 			Ref   string `json:"ref"`
 			Sha   string `json:"sha"`
@@ -82,8 +81,7 @@ type pullRequestHook struct {
 				} `json:"owner"`
 			} `json:"repo"`
 		} `json:"base"`
-		HeadBranch string `json:"head_branch"`
-		Head       struct {
+		Head struct {
 			Label string `json:"label"`
 			Ref   string `json:"ref"`
 			Sha   string `json:"sha"`


### PR DESCRIPTION
The Gitea remote references non-existent properties of the pull request webhook payload to determine the base branch (and refspec). Using Gitea v1.3.2 (latest stable) the pull request webhook payload does not include the `pull_request.base_branch` or `pull_request.head_branch` properties. It does however, include `pull_request.base.ref` and `pull_request.head.ref` properties that contain the desired information. 

This pull request changes the parsing of pull request webhooks to use the existent properties.
An assertion has been added to test the parsing of the pull request refspec.