### PR TITLE
upgrade alpine base image to latest version

### DIFF
--- a/Dockerfile.agent.alpine
+++ b/Dockerfile.agent.alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.7
 
 RUN apk add -U --no-cache ca-certificates
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.7
 EXPOSE 8000 9000 80 443
 
 RUN apk add -U --no-cache ca-certificates


### PR DESCRIPTION
This pull request upgrades the alpine base image used for drone-server and drone-agent,
since 3.7 is the latest released version with updated ca-certificates.