### PR TITLE
Return deploy envs when get build

### DIFF
--- a/model/build.go
+++ b/model/build.go
@@ -34,6 +34,7 @@ type Build struct {
 	Reviewed  int64   `json:"reviewed_at"   meddler:"build_reviewed"`
 	Procs     []*Proc `json:"procs,omitempty" meddler:"-"`
 	Files     []*File `json:"files,omitempty" meddler:"-"`
+	DeployEnvs []*DeployEnv `json:"deploy_envs,omitempty" meddler:"-"`
 }
 
 // Trim trims string values that would otherwise exceed

--- a/model/deploy_env.go
+++ b/model/deploy_env.go
@@ -1,0 +1,17 @@
+package model
+
+// DeployEnvStore persists process information to storage.
+type DeployEnvStore interface {
+	DeployEnvLoad(int64) (*DeployEnv, error)
+	DeployEnvFind(*Build, int) (*DeployEnv, error)
+	DeployEnvList(*Build) ([]*DeployEnv, error)
+	DeployEnvCreate([]*DeployEnv) error
+}
+
+// DeployEnv represents a process in the build pipeline.
+// swagger:model depoly_env
+type DeployEnv struct {
+	ID      int64  `json:"id"                   meddler:"deploy_env_id,pk"`
+	BuildID int64  `json:"build_id"             meddler:"deploy_env_build_id"`
+	Name    string `json:"name"                 meddler:"deploy_env_name"`
+}

--- a/server/build.go
+++ b/server/build.go
@@ -53,8 +53,11 @@ func GetBuild(c *gin.Context) {
 	}
 	files, _ := store.FromContext(c).FileList(build)
 	procs, _ := store.FromContext(c).ProcList(build)
+
+	deploy_envs, _ := store.FromContext(c).DeployEnvList(build)
 	build.Procs = model.Tree(procs)
 	build.Files = files
+	build.DeployEnvs = deploy_envs
 
 	c.JSON(http.StatusOK, build)
 }

--- a/store/datastore/ddl/migrate.go
+++ b/store/datastore/ddl/migrate.go
@@ -91,6 +91,8 @@ INSERT INTO migrations (name) VALUES
 ,('create-table-agents')
 ,('create-table-senders')
 ,('create-index-sender-repos')
+,('create-table-deploy_envs')
+,('create-index-deploy_envs-build')
 `
 
 var createMigrationsTable = `

--- a/store/datastore/ddl/mysql/ddl_gen.go
+++ b/store/datastore/ddl/mysql/ddl_gen.go
@@ -156,6 +156,14 @@ var migrations = []struct {
 		name: "alter-table-update-file-meta",
 		stmt: alterTableUpdateFileMeta,
 	},
+	{
+		name: "create-table-deploy_envs",
+		stmt: createTableDeployenvs,
+	},
+	{
+		name: "create-index-deploy_envs-build",
+		stmt: createIndexDeployenvsBuild,
+	},
 }
 
 // Migrate performs the database migration. If the migration fails
@@ -621,4 +629,20 @@ UPDATE files SET
  file_meta_passed=0
 ,file_meta_failed=0
 ,file_meta_skipped=0
+`
+
+//
+// 019_create_table_deploy_envs.sql
+//
+
+var createTableDeployenvs = `
+CREATE TABLE IF NOT EXISTS deploy_envs (
+ deploy_env_id         INTEGER PRIMARY KEY AUTO_INCREMENT
+,deploy_env_build_id   INTEGER
+,deploy_env_name       VARCHAR(250)
+);
+`
+
+var createIndexDeployenvsBuild = `
+CREATE INDEX deploy_env_build_ix ON deploy_envs (deploy_env_build_id);
 `

--- a/store/datastore/ddl/mysql/files/019_create_table_deploy_envs.sql
+++ b/store/datastore/ddl/mysql/files/019_create_table_deploy_envs.sql
@@ -1,0 +1,11 @@
+-- name: create-table-deploy_envs
+
+CREATE TABLE IF NOT EXISTS deploy_envs (
+ deploy_env_id         INTEGER PRIMARY KEY AUTO_INCREMENT
+,deploy_env_build_id   INTEGER
+,deploy_env_name       VARCHAR(250)
+);
+
+-- name: create-index-deploy_envs-build
+
+CREATE INDEX deploy_env_build_ix ON deploy_envs (deploy_env_build_id);

--- a/store/datastore/ddl/postgres/ddl_gen.go
+++ b/store/datastore/ddl/postgres/ddl_gen.go
@@ -156,6 +156,14 @@ var migrations = []struct {
 		name: "alter-table-update-file-meta",
 		stmt: alterTableUpdateFileMeta,
 	},
+	{
+		name: "create-table-deploy_envs",
+		stmt: createTableDeployenvs,
+	},
+	{
+		name: "create-index-deploy_envs-build",
+		stmt: createIndexDeployenvsBuild,
+	},
 }
 
 // Migrate performs the database migration. If the migration fails
@@ -621,4 +629,20 @@ UPDATE files SET
  file_meta_passed=0
 ,file_meta_failed=0
 ,file_meta_skipped=0
+`
+
+//
+// 019_create_table_deploy_envs.sql
+//
+
+var createTableDeployenvs = `
+CREATE TABLE IF NOT EXISTS deploy_envs (
+ deploy_env_id         SERIAL PRIMARY KEY
+,deploy_env_build_id   INTEGER
+,deploy_env_name       VARCHAR(250)
+);
+`
+
+var createIndexDeployenvsBuild = `
+CREATE INDEX IF NOT EXISTS deploy_env_build_ix ON deploy_envs (deploy_env_build_id);
 `

--- a/store/datastore/ddl/postgres/files/019_create_table_deploy_envs.sql
+++ b/store/datastore/ddl/postgres/files/019_create_table_deploy_envs.sql
@@ -1,0 +1,11 @@
+-- name: create-table-deploy_envs
+
+CREATE TABLE IF NOT EXISTS deploy_envs (
+ deploy_env_id         SERIAL PRIMARY KEY
+,deploy_env_build_id   INTEGER
+,deploy_env_name       VARCHAR(250)
+);
+
+-- name: create-index-deploy_envs-build
+
+CREATE INDEX IF NOT EXISTS deploy_env_build_ix ON deploy_envs (deploy_env_build_id);

--- a/store/datastore/ddl/sqlite/ddl_gen.go
+++ b/store/datastore/ddl/sqlite/ddl_gen.go
@@ -160,6 +160,14 @@ var migrations = []struct {
 		name: "alter-table-update-file-meta",
 		stmt: alterTableUpdateFileMeta,
 	},
+	{
+		name: "create-table-deploy_envs",
+		stmt: createTableDeployenvs,
+	},
+	{
+		name: "create-index-deploy_envs-build",
+		stmt: createIndexDeployenvsBuild,
+	},
 }
 
 // Migrate performs the database migration. If the migration fails
@@ -622,4 +630,20 @@ UPDATE files SET
  file_meta_passed=0
 ,file_meta_failed=0
 ,file_meta_skipped=0
+`
+
+//
+// 019_create_table_deploy_envs.sql
+//
+
+var createTableDeployenvs = `
+CREATE TABLE IF NOT EXISTS deploy_envs (
+ deploy_env_id         INTEGER PRIMARY KEY AUTOINCREMENT
+,deploy_env_build_id   INTEGER
+,deploy_env_name       TEXT
+);
+`
+
+var createIndexDeployenvsBuild = `
+CREATE INDEX IF NOT EXISTS deploy_env_build_ix ON deploy_envs (deploy_env_build_id);
 `

--- a/store/datastore/ddl/sqlite/files/019_create_table_deploy_envs.sql
+++ b/store/datastore/ddl/sqlite/files/019_create_table_deploy_envs.sql
@@ -1,0 +1,11 @@
+-- name: create-table-deploy_envs
+
+CREATE TABLE IF NOT EXISTS deploy_envs (
+ deploy_env_id         INTEGER PRIMARY KEY AUTOINCREMENT
+,deploy_env_build_id   INTEGER
+,deploy_env_name       TEXT
+);
+
+-- name: create-index-deploy_envs-build
+
+CREATE INDEX IF NOT EXISTS deploy_env_build_ix ON deploy_envs (deploy_env_build_id);

--- a/store/datastore/deploy_env.go
+++ b/store/datastore/deploy_env.go
@@ -1,0 +1,23 @@
+package datastore
+
+import (
+	"github.com/drone/drone/model"
+	"github.com/drone/drone/store/datastore/sql"
+	"github.com/russross/meddler"
+)
+
+func (db *datastore) DeployEnvList(build *model.Build) ([]*model.DeployEnv, error) {
+	stmt := sql.Lookup(db.driver, "deploy_envs-find-build")
+	list := []*model.DeployEnv{}
+	err := meddler.QueryAll(db, &list, stmt, build.ID)
+	return list, err
+}
+
+func (db *datastore) DeployEnvCreate(deploy_envs []*model.DeployEnv) error {
+	for _, deploy_env := range deploy_envs {
+		if err := meddler.Insert(db, "deploy_envs", deploy_env); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/store/datastore/deploy_env_test.go
+++ b/store/datastore/deploy_env_test.go
@@ -1,0 +1,42 @@
+package datastore
+
+import (
+	"testing"
+
+	"github.com/drone/drone/model"
+)
+
+func TestDeployEnvList(t *testing.T) {
+	s := newTest()
+	defer func() {
+		s.Exec("delete from deploy_envs")
+		s.Close()
+	}()
+
+	err := s.DeployEnvCreate([]*model.DeployEnv{
+		{
+			BuildID: 1,
+			Name:    "test",
+		},
+		{
+			BuildID: 1,
+			Name:    "dev",
+		},
+		{
+			BuildID: 1,
+			Name:    "prod",
+		},
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: insert deploy_envs: %s", err)
+		return
+	}
+	deploy_envs, err := s.DeployEnvList(&model.Build{ID: 1})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if got, want := len(deploy_envs), 3; got != want {
+		t.Errorf("Want %d deploy_envs, got %d", want, got)
+	}
+}

--- a/store/datastore/sql/mysql/files/deploy_envs.sql
+++ b/store/datastore/sql/mysql/files/deploy_envs.sql
@@ -1,0 +1,10 @@
+-- name: deploy_envs-find-build
+
+SELECT
+ deploy_env_id
+,deploy_env_build_id
+,deploy_env_name
+FROM deploy_envs
+WHERE deploy_env_build_id = ?
+ORDER BY deploy_env_id ASC
+

--- a/store/datastore/sql/mysql/sql_gen.go
+++ b/store/datastore/sql/mysql/sql_gen.go
@@ -12,6 +12,7 @@ var index = map[string]string{
 	"count-users":                 countUsers,
 	"count-repos":                 countRepos,
 	"count-builds":                countBuilds,
+	"deploy_envs-find-build":      deployenvsFindBuild,
 	"feed-latest-build":           feedLatestBuild,
 	"feed":                        feed,
 	"files-find-build":            filesFindBuild,
@@ -96,6 +97,16 @@ WHERE repo_active = true
 var countBuilds = `
 SELECT count(1)
 FROM builds
+`
+
+var deployenvsFindBuild = `
+SELECT
+ deploy_env_id
+,deploy_env_build_id
+,deploy_env_name
+FROM deploy_envs
+WHERE deploy_env_build_id = ?
+ORDER BY deploy_env_id ASC
 `
 
 var feedLatestBuild = `

--- a/store/datastore/sql/postgres/files/deploy_envs.sql
+++ b/store/datastore/sql/postgres/files/deploy_envs.sql
@@ -1,0 +1,10 @@
+-- name: deploy_envs-find-build
+
+SELECT
+ deploy_env_id
+,deploy_env_build_id
+,deploy_env_name
+FROM deploy_envs
+WHERE deploy_env_build_id = $1
+ORDER BY deploy_env_id ASC
+

--- a/store/datastore/sql/postgres/sql_gen.go
+++ b/store/datastore/sql/postgres/sql_gen.go
@@ -12,6 +12,7 @@ var index = map[string]string{
 	"count-users":                 countUsers,
 	"count-repos":                 countRepos,
 	"count-builds":                countBuilds,
+	"deploy_envs-find-build":      deployenvsFindBuild,
 	"feed-latest-build":           feedLatestBuild,
 	"feed":                        feed,
 	"files-find-build":            filesFindBuild,
@@ -96,6 +97,16 @@ WHERE repo_active = true
 var countBuilds = `
 SELECT reltuples
 FROM pg_class WHERE relname = 'builds'
+`
+
+var deployenvsFindBuild = `
+SELECT
+ deploy_env_id
+,deploy_env_build_id
+,deploy_env_name
+FROM deploy_envs
+WHERE deploy_env_build_id = $1
+ORDER BY deploy_env_id ASC
 `
 
 var feedLatestBuild = `

--- a/store/datastore/sql/sqlite/files/deploy_envs.sql
+++ b/store/datastore/sql/sqlite/files/deploy_envs.sql
@@ -1,0 +1,10 @@
+-- name: deploy_envs-find-build
+
+SELECT
+ deploy_env_id
+,deploy_env_build_id
+,deploy_env_name
+FROM deploy_envs
+WHERE deploy_env_build_id = ?
+ORDER BY deploy_env_id ASC
+

--- a/store/datastore/sql/sqlite/sql_gen.go
+++ b/store/datastore/sql/sqlite/sql_gen.go
@@ -12,6 +12,7 @@ var index = map[string]string{
 	"count-users":                 countUsers,
 	"count-repos":                 countRepos,
 	"count-builds":                countBuilds,
+	"deploy_envs-find-build":      deployenvsFindBuild,
 	"feed-latest-build":           feedLatestBuild,
 	"feed":                        feed,
 	"files-find-build":            filesFindBuild,
@@ -96,6 +97,16 @@ WHERE repo_active = 1
 var countBuilds = `
 SELECT count(1)
 FROM builds
+`
+
+var deployenvsFindBuild = `
+SELECT
+ deploy_env_id
+,deploy_env_build_id
+,deploy_env_name
+FROM deploy_envs
+WHERE deploy_env_build_id = ?
+ORDER BY deploy_env_id ASC
 `
 
 var feedLatestBuild = `

--- a/store/store.go
+++ b/store/store.go
@@ -136,6 +136,9 @@ type Store interface {
 	FileRead(*model.Proc, string) (io.ReadCloser, error)
 	FileCreate(*model.File, io.Reader) error
 
+	DeployEnvList(*model.Build) ([]*model.DeployEnv, error)
+	DeployEnvCreate([]*model.DeployEnv) error
+
 	TaskList() ([]*model.Task, error)
 	TaskInsert(*model.Task) error
 	TaskDelete(string) error


### PR DESCRIPTION
Parse user defined deploy environment from yaml, and then save it to build object. This patch works together with [add promote build to build menu](https://github.com/drone/drone-ui/pull/191), to show deploy environments when user click promote build menu