### PR TITLE
Add users' permissions detection and get of users' email for Bitbucket integration

### DIFF
--- a/remote/bitbucket/bitbucket.go
+++ b/remote/bitbucket/bitbucket.go
@@ -69,7 +69,17 @@ func (c *config) Login(w http.ResponseWriter, req *http.Request) (*model.User, e
 	if err != nil {
 		return nil, err
 	}
-	return convertUser(curr, token), nil
+
+	emails, err := client.ListEmail()
+	if err != nil {
+		return nil, err
+	}
+	email := matchingEmail(emails.Values)
+	if email == nil {
+		return nil, fmt.Errorf("No confirmed email address for Bitbucket account")
+	}
+
+	return convertUser(curr, email, token), nil
 }
 
 // Auth uses the Bitbucket oauth2 access token and refresh token to authenticate

--- a/remote/bitbucket/bitbucket.go
+++ b/remote/bitbucket/bitbucket.go
@@ -179,7 +179,7 @@ func (c *config) Perm(u *model.User, owner, name string) (*model.Perm, error) {
 	resp := new(internal.RepoResp)
 
 	resp, err = client.ListRepos(owner, &internal.ListReposOpts{
-		Role: "contribute",
+		Role: "contributor",
 		Query: fmt.Sprintf("full_name = \"%s\"", repo.FullName),
 	})
 

--- a/remote/bitbucket/bitbucket_test.go
+++ b/remote/bitbucket/bitbucket_test.go
@@ -58,6 +58,7 @@ func Test_bitbucket(t *testing.T) {
 				g.Assert(u.Login).Equal(fakeUser.Login)
 				g.Assert(u.Token).Equal("2YotnFZFEjr1zCsicMWpAA")
 				g.Assert(u.Secret).Equal("tGzv3JOkF0XG5Qx2TlKWIA")
+				g.Assert(u.Email).Equal(fakeUser.Email)
 			})
 			g.It("Should handle failure to exchange code", func() {
 				w := httptest.NewRecorder()
@@ -72,6 +73,16 @@ func Test_bitbucket(t *testing.T) {
 			})
 			g.It("Should handle authentication errors", func() {
 				r, _ := http.NewRequest("GET", "?error=invalid_scope", nil)
+				_, err := c.Login(nil, r)
+				g.Assert(err != nil).IsTrue()
+			})
+			g.It("Should handle failure if user don't have confirmed email", func() {
+				r, _ := http.NewRequest("GET", "?error=without_confirmed_email", nil)
+				_, err := c.Login(nil, r)
+				g.Assert(err != nil).IsTrue()
+			})
+			g.It("Should handle failure to request emails list", func() {
+				r, _ := http.NewRequest("GET", "?error=user_emails_failed", nil)
 				_, err := c.Login(nil, r)
 				g.Assert(err != nil).IsTrue()
 			})
@@ -291,6 +302,7 @@ var (
 	fakeUser = &model.User{
 		Login: "superman",
 		Token: "cfcd2084",
+		Email: "octocat@github.com",
 	}
 
 	fakeUserRefresh = &model.User{

--- a/remote/bitbucket/bitbucket_test.go
+++ b/remote/bitbucket/bitbucket_test.go
@@ -146,18 +146,29 @@ func Test_bitbucket(t *testing.T) {
 			})
 			g.It("Should authorize read access", func() {
 				perm, err := c.Perm(
-					fakeUser,
-					fakeRepoNoHooks.Owner,
-					fakeRepoNoHooks.Name,
+					fakeUserReadOnly,
+					fakeRepo.Owner,
+					fakeRepo.Name,
 				)
 				g.Assert(err == nil).IsTrue()
 				g.Assert(perm.Pull).IsTrue()
 				g.Assert(perm.Push).IsFalse()
 				g.Assert(perm.Admin).IsFalse()
 			})
+			g.It("Should authorize read & write access", func() {
+				perm, err := c.Perm(
+					fakeUserReadWrite,
+					fakeRepo.Owner,
+					fakeRepo.Name,
+				)
+				g.Assert(err == nil).IsTrue()
+				g.Assert(perm.Pull).IsTrue()
+				g.Assert(perm.Push).IsTrue()
+				g.Assert(perm.Admin).IsFalse()
+			})
 			g.It("Should authorize admin access", func() {
 				perm, err := c.Perm(
-					fakeUser,
+					fakeUserAdmin,
 					fakeRepo.Owner,
 					fakeRepo.Name,
 				)
@@ -310,6 +321,21 @@ var (
 	fakeUserNoRepos = &model.User{
 		Login: "superman",
 		Token: "repos_not_found",
+	}
+
+	fakeUserReadOnly = &model.User{
+		Login: "superman",
+		Token: "read_only_repo",
+	}
+
+	fakeUserReadWrite = &model.User{
+		Login: "superman",
+		Token: "read_write_repo",
+	}
+
+	fakeUserAdmin = &model.User{
+		Login: "superman",
+		Token: "admin_repo",
 	}
 
 	fakeRepo = &model.Repo{

--- a/remote/bitbucket/convert.go
+++ b/remote/bitbucket/convert.go
@@ -112,13 +112,14 @@ func cloneLink(repo *internal.Repo) string {
 
 // convertUser is a helper function used to convert a Bitbucket user account
 // structure to the Drone User structure.
-func convertUser(from *internal.Account, token *oauth2.Token) *model.User {
+func convertUser(from *internal.Account, email *internal.Email, token *oauth2.Token) *model.User {
 	return &model.User{
 		Login:  from.Login,
 		Token:  token.AccessToken,
 		Secret: token.RefreshToken,
 		Expiry: token.Expiry.UTC().Unix(),
 		Avatar: from.Links.Avatar.Href,
+		Email:  email.Email,
 	}
 }
 
@@ -200,4 +201,13 @@ func extractEmail(gitauthor string) (author string) {
 		author = matches[0][1]
 	}
 	return
+}
+
+func matchingEmail(emails []*internal.Email) *internal.Email {
+	for _, email := range emails {
+		if email.IsPrimary && email.IsConfirmed {
+			return email
+		}
+	}
+	return nil
 }

--- a/remote/bitbucket/convert_test.go
+++ b/remote/bitbucket/convert_test.go
@@ -94,13 +94,15 @@ func Test_helper(t *testing.T) {
 			}
 			user := &internal.Account{Login: "octocat"}
 			user.Links.Avatar.Href = "http://..."
+			email := &internal.Email{Email: "octocat@github.com"}
 
-			result := convertUser(user, token)
+			result := convertUser(user, email, token)
 			g.Assert(result.Avatar).Equal(user.Links.Avatar.Href)
 			g.Assert(result.Login).Equal(user.Login)
 			g.Assert(result.Token).Equal(token.AccessToken)
 			g.Assert(result.Secret).Equal(token.RefreshToken)
 			g.Assert(result.Expiry).Equal(token.Expiry.UTC().Unix())
+			g.Assert(result.Email).Equal(email.Email)
 		})
 
 		g.It("should use clone url", func() {

--- a/remote/bitbucket/fixtures/handler.go
+++ b/remote/bitbucket/fixtures/handler.go
@@ -125,6 +125,27 @@ func getUserRepos(c *gin.Context) {
 	switch c.Request.Header.Get("Authorization") {
 	case "Bearer repos_not_found", "Bearer 70efdf2e":
 		c.String(404, "")
+	case "Bearer read_only_repo":
+		switch c.Query("role") {
+		case "member":
+			c.String(200, userRepoPayload)
+		default:
+			c.String(200, userEmptyRepoPayload)
+		}
+	case "Bearer admin_repo":
+		switch c.Query("role") {
+		case "contribute", "admin":
+			c.String(200, userRepoPayload)
+		default:
+			c.String(200, userEmptyRepoPayload)
+		}
+	case "Bearer read_write_repo":
+		switch c.Query("role") {
+		case "contribute":
+			c.String(200, userRepoPayload)
+		default:
+			c.String(200, userEmptyRepoPayload)
+		}
 	default:
 		c.String(200, userRepoPayload)
 	}
@@ -205,6 +226,15 @@ const userRepoPayload = `
       "is_private": true
     }
   ]
+}
+`
+
+const userEmptyRepoPayload = `
+{
+  "page": 1,
+  "pagelen": 10,
+  "size": 0,
+  "values": []
 }
 `
 

--- a/remote/bitbucket/fixtures/handler.go
+++ b/remote/bitbucket/fixtures/handler.go
@@ -22,6 +22,7 @@ func Handler() http.Handler {
 	e.GET("/2.0/repositories/:owner", getUserRepos)
 	e.GET("/2.0/teams/", getUserTeams)
 	e.GET("/2.0/user/", getUser)
+	e.GET("/2.0/user/emails", getUserEmails)
 
 	return e
 }
@@ -151,6 +152,17 @@ func getUserRepos(c *gin.Context) {
 	}
 }
 
+func getUserEmails(c *gin.Context) {
+	switch c.PostForm("error") {
+	case "user_emails_failed":
+		c.String(500, "")
+	case "without_confirmed_email":
+		c.String(200, userWithoutConfirmedEmailPayload)
+	default:
+		c.String(200, userEmailsPayload)
+	}
+}
+
 const tokenPayload = `
 {
 	"access_token":"2YotnFZFEjr1zCsicMWpAA",
@@ -252,5 +264,35 @@ const userTeamPayload = `
       "type": "team"
     }
   ]
+}
+`
+
+const userEmailsPayload = `
+{
+   "pagelen": 10,
+   "values": [
+      {
+         "is_primary": true,
+         "is_confirmed": true,
+         "email": "octocat@github.com"
+      }
+   ],
+   "page": 1,
+   "size": 1
+}
+`
+
+const userWithoutConfirmedEmailPayload = `
+{
+   "pagelen": 10,
+   "values": [
+      {
+         "is_primary": true,
+         "is_confirmed": false,
+         "email": "octocat@github.com"
+      }
+   ],
+   "page": 1,
+   "size": 1
 }
 `

--- a/remote/bitbucket/fixtures/handler.go
+++ b/remote/bitbucket/fixtures/handler.go
@@ -135,14 +135,14 @@ func getUserRepos(c *gin.Context) {
 		}
 	case "Bearer admin_repo":
 		switch c.Query("role") {
-		case "contribute", "admin":
+		case "contributor", "admin":
 			c.String(200, userRepoPayload)
 		default:
 			c.String(200, userEmptyRepoPayload)
 		}
 	case "Bearer read_write_repo":
 		switch c.Query("role") {
-		case "contribute":
+		case "contributor":
 			c.String(200, userRepoPayload)
 		default:
 			c.String(200, userEmptyRepoPayload)

--- a/remote/bitbucket/internal/client.go
+++ b/remote/bitbucket/internal/client.go
@@ -77,7 +77,7 @@ func (c *Client) FindRepo(owner, name string) (*Repo, error) {
 	return out, err
 }
 
-func (c *Client) ListRepos(account string, opts *ListOpts) (*RepoResp, error) {
+func (c *Client) ListRepos(account string, opts *ListReposOpts) (*RepoResp, error) {
 	out := new(RepoResp)
 	uri := fmt.Sprintf(pathRepos, c.base, account, opts.Encode())
 	err := c.do(uri, get, nil, out)
@@ -89,7 +89,7 @@ func (c *Client) ListReposAll(account string) ([]*Repo, error) {
 	var repos []*Repo
 
 	for {
-		resp, err := c.ListRepos(account, &ListOpts{Page: page, PageLen: 100})
+		resp, err := c.ListRepos(account, &ListReposOpts{Page: page, PageLen: 100})
 		if err != nil {
 			return repos, err
 		}

--- a/remote/bitbucket/internal/types.go
+++ b/remote/bitbucket/internal/types.go
@@ -200,6 +200,30 @@ func (o *ListTeamOpts) Encode() string {
 	return params.Encode()
 }
 
+type ListReposOpts struct {
+	Page    int
+	PageLen int
+	Role    string
+	Query	string
+}
+
+func (o *ListReposOpts) Encode() string {
+	params := url.Values{}
+	if o.Page != 0 {
+		params.Set("page", strconv.Itoa(o.Page))
+	}
+	if o.PageLen != 0 {
+		params.Set("pagelen", strconv.Itoa(o.PageLen))
+	}
+	if len(o.Role) != 0 {
+		params.Set("role", o.Role)
+	}
+	if len(o.Query) != 0 {
+		params.Set("q", o.Query)
+	}
+	return params.Encode()
+}
+
 type Error struct {
 	Status int
 	Body   struct {


### PR DESCRIPTION
Bitbucket integration improvements:
1) used undocumented API parameter for filtering repos by `role`, which help to get user permissions for repository (this feature [documented for teams API](https://developer.atlassian.com/bitbucket/api/2/reference/resource/teams), but [not for repositories API](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories));
2) added request for getting email of user.