### PR TITLE
Fix gitlab(api v4) configuration file path contains '/'

### DIFF
--- a/remote/gitlab/client/project.go
+++ b/remote/gitlab/client/project.go
@@ -17,6 +17,7 @@ package client
 import (
 	"encoding/base64"
 	"encoding/json"
+	"net/url"
 	"strconv"
 	"strings"
 )
@@ -99,7 +100,7 @@ func (c *Client) RepoRawFileRef(id, ref, filepath string) ([]byte, error) {
 		repoUrlRawFileRef,
 		QMap{
 			":id":       id,
-			":filepath": filepath,
+			":filepath": url.QueryEscape(filepath),
 		},
 		QMap{
 			"ref": ref,


### PR DESCRIPTION
When using gitlab(api v4), modify the configuration file path to include '/' and get an error while building.

> Error #1: *Gitlab.buildAndExecRequest failed: <404>

The configuration file path needs to be encoded twice.A decoding is performed before the request is sent.