### PR TITLE
Add ability to configure and use tls with grpc traffic

### DIFF
--- a/cmd/drone-agent/agent.go
+++ b/cmd/drone-agent/agent.go
@@ -1,11 +1,11 @@
 // Copyright 2018 Drone.IO Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //      http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,8 +25,6 @@ import (
 	"sync"
 	"time"
 
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/cncd/pipeline/pipeline"
@@ -82,19 +80,7 @@ func loop(c *cli.Context) error {
 	// TODO authenticate to grpc server
 
 	// grpc.Dial(target, ))
-
-	conn, err := grpc.Dial(
-		c.String("server"),
-		grpc.WithInsecure(),
-		grpc.WithPerRPCCredentials(&credentials{
-			username: c.String("username"),
-			password: c.String("password"),
-		}),
-		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time: c.Duration("keepalive-time"),
-			Timeout: c.Duration("keepalive-timeout"),
-		}),
-	)
+	conn, err := dialGrpc(c)
 
 	if err != nil {
 		return err

--- a/cmd/drone-agent/grpc.go
+++ b/cmd/drone-agent/grpc.go
@@ -1,0 +1,102 @@
+// Copyright 2018 Drone.IO Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/rs/zerolog/log"
+	"github.com/urfave/cli"
+
+	"google.golang.org/grpc"
+	grpcCredentials "google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
+)
+
+func dialGrpc(c *cli.Context) (*grpc.ClientConn, error) {
+	dialOpts := []grpc.DialOption{
+		grpc.WithPerRPCCredentials(&credentials{
+			username: c.String("username"),
+			password: c.String("password"),
+		}),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time: c.Duration("keepalive-time"),
+			Timeout: c.Duration("keepalive-timeout"),
+		}),
+	}
+
+	if c.Bool("grpc-tls-enable") {
+		log.Debug().Msg("grpc: Configuring TLS")
+
+		// Create the client TLS credentials
+		creds, err := grpcTLS(c)
+		if err != nil {
+			return nil, err
+		}
+
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(creds))
+	} else {
+		dialOpts = append(dialOpts, grpc.WithInsecure())
+	}
+
+	return grpc.Dial(c.String("server"), dialOpts...)
+}
+
+func grpcTLS(c *cli.Context) (grpcCredentials.TransportCredentials, error) {
+	var err error
+	certPool := x509.NewCertPool()
+	if c.String("grpc-ca-cert-file") != "" {
+		// Read in custom CA file
+		ca, err := ioutil.ReadFile(c.String("grpc-ca-file"))
+		if err != nil {
+			return nil, fmt.Errorf("could not read ca certificate: %s", err)
+		}
+
+		// Append the CA certificate to CertPool
+		if ok := certPool.AppendCertsFromPEM(ca); !ok {
+			return nil, fmt.Errorf("failed to append ca certs")
+		}
+	} else {
+		// Load System CA certs
+		certPool, err = x509.SystemCertPool()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	creds := grpcCredentials.NewTLS(&tls.Config{
+		ServerName: c.String("grpc-servername"),
+		RootCAs:    certPool,
+	})
+
+	// Pass client cert to server for client verification
+	if c.String("grpc-cert-file") != "" && c.String("grpc-key-file") != "" {
+		certificate, err := tls.LoadX509KeyPair(c.String("grpc-cert-file"), c.String("grpc-key-file"))
+		if err != nil {
+			return nil, fmt.Errorf("could not load client key pair: %s", err)
+		}
+
+		creds = grpcCredentials.NewTLS(&tls.Config{
+			ServerName:   c.String("grpc-servername"),
+			Certificates: []tls.Certificate{certificate},
+			RootCAs:      certPool,
+		})
+	}
+
+	return creds, nil
+}

--- a/cmd/drone-agent/main.go
+++ b/cmd/drone-agent/main.go
@@ -1,11 +1,11 @@
 // Copyright 2018 Drone.IO Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //      http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -108,6 +108,31 @@ func main() {
 			Name:   "keepalive-timeout",
 			Usage:  "after pinging for a keepalive check, the agent waits for a duration of this time before closing the connection if no activity",
 			Value:  time.Second * 20,
+		},
+		cli.BoolFlag{
+			EnvVar: "DRONE_GRPC_TLS_ENABLE",
+			Name:   "grpc-tls-enable",
+			Usage:  "enable grpc tls for server<>agent communication",
+		},
+		cli.StringFlag{
+			EnvVar: "DRONE_GRPC_CERT_FILE",
+			Name:   "grpc-cert-file",
+			Usage:  "cert file for grpc tls client verification",
+		},
+		cli.StringFlag{
+			EnvVar: "DRONE_GRPC_KEY_FILE",
+			Name:   "grpc-key-file",
+			Usage:  "key file for grpc tls client verification",
+		},
+		cli.StringFlag{
+			EnvVar: "DRONE_GRPC_CA_FILE",
+			Name:   "grpc-ca-file",
+			Usage:  "ca cert for grpc tls",
+		},
+		cli.StringFlag{
+			EnvVar: "DRONE_GRPC_SERVERNAME",
+			Name:   "grpc-servername",
+			Usage:  "force server name to something other then actual hostname (for testing)",
 		},
 	}
 

--- a/cmd/drone-server/grpc.go
+++ b/cmd/drone-server/grpc.go
@@ -1,0 +1,147 @@
+// Copyright 2018 Drone.IO Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net"
+
+	"github.com/urfave/cli"
+	"github.com/Sirupsen/logrus"
+
+	"google.golang.org/grpc"
+	grpcCredentials "google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
+
+	"github.com/cncd/pipeline/pipeline/rpc/proto"
+	"github.com/drone/drone/remote"
+	droneserver "github.com/drone/drone/server"
+	"github.com/drone/drone/store"
+)
+
+func serveGrpc(c *cli.Context, r remote.Remote, v store.Store) error {
+	lis, err := net.Listen("tcp", ":9000")
+	if err != nil {
+		logrus.Error(err)
+		return err
+	}
+	auther := &authorizer{
+		password: c.String("agent-secret"),
+	}
+
+	grpcServerOpts := []grpc.ServerOption{
+		grpc.StreamInterceptor(auther.streamInterceptor),
+		grpc.UnaryInterceptor(auther.unaryIntercaptor),
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime: c.Duration("keepalive-min-time"),
+		}),
+	}
+
+	// Secure gRpc Server communication
+	if c.String("grpc-cert-file") != "" && c.String("grpc-key-file") != "" {
+		logrus.Debugln("grpc: Configuring TLS")
+
+		creds, err := grpcTLSCreds(c)
+		if err != nil {
+			return err
+		}
+
+		grpcServerOpts = append(grpcServerOpts, grpc.Creds(creds))
+	}
+
+	s := grpc.NewServer(grpcServerOpts...)
+
+	ss := new(droneserver.DroneServer)
+	ss.Queue = droneserver.Config.Services.Queue
+	ss.Logger = droneserver.Config.Services.Logs
+	ss.Pubsub = droneserver.Config.Services.Pubsub
+	ss.Remote = r
+	ss.Store = v
+	ss.Host = droneserver.Config.Server.Host
+	proto.RegisterDroneServer(s, ss)
+
+	err = s.Serve(lis)
+	if err != nil {
+		logrus.Error("grpc serve error: %s", err)
+		return err
+	}
+	return nil
+}
+
+func grpcTLSCreds(c *cli.Context) (grpcCredentials.TransportCredentials, error) {
+	// Load the certificates from disk
+	certificate, err := tls.LoadX509KeyPair(c.String("grpc-cert-file"), c.String("grpc-key-file"))
+	if err != nil {
+		return nil, fmt.Errorf("could not load server key pair: %s", err)
+	}
+
+	certPool := x509.NewCertPool()
+	if c.String("grpc-ca-cert-file") != "" {
+		// Read in custom CA file
+		ca, err := ioutil.ReadFile(c.String("grpc-ca-file"))
+		if err != nil {
+			return nil, fmt.Errorf("could not read ca certificate: %s", err)
+		}
+
+		// Append the CA certificate to certPool
+		if ok := certPool.AppendCertsFromPEM(ca); !ok {
+			return nil, fmt.Errorf("failed to append ca certs")
+		}
+	} else {
+		// Load System CA certs
+		certPool, err = x509.SystemCertPool()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	mode, err := tlsVerifyMode(c.String("grpc-client-auth"))
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the TLS configuration to pass to the GRPC server
+	creds := grpcCredentials.NewTLS(&tls.Config{
+		ClientAuth:   *mode,
+		Certificates: []tls.Certificate{certificate},
+		ClientCAs:    certPool,
+	})
+
+	return creds, nil
+}
+
+func tlsVerifyMode(mode string) (*tls.ClientAuthType, error) {
+	var clientAuthType tls.ClientAuthType
+
+	switch mode {
+	case "NoClientCert":
+		clientAuthType = tls.NoClientCert
+	case "RequestClientCert":
+		clientAuthType = tls.RequestClientCert
+	case "RequireAnyClientCert":
+		clientAuthType = tls.RequireAnyClientCert
+	case "VerifyClientCertIfGiven":
+		clientAuthType = tls.VerifyClientCertIfGiven
+	case "RequireAndVerifyClientCert":
+		clientAuthType = tls.RequireAndVerifyClientCert
+	default:
+		return nil, fmt.Errorf("verifyMode: %s is not a valid mode of: NoClientCert, RequestClientCert, RequireAnyClientCert, VerifyClientCertIfGiven, RequireAndVerifyClientCert", mode)
+	}
+
+	return &clientAuthType, nil
+}


### PR DESCRIPTION
This PR is to add ability to encrypt GRPC traffic.  I also split the grpc setup code to a `grpc.go` file for each the server and agent.  If you prefer not to have that done I can work to undo it.

At a minimum the following is required to be configured:

### Server
* `DRONE_GRPC_CERT_FILE`
* `DRONE_GRPC_KEY_FILE`

### Agent

* `DRONE_GRPC_TLS_ENABLE`

This code can also be used to configure another layer of authentication using server/client cert/key verification.  The following additional options are also provided to help facilitate that.

### Server

* `DRONE_GRPC_CA_FILE`
* `DRONE_GRPC_VERIFY_MODE`

### Agent

* `DRONE_GRPC_CERT_FILE`
* `DRONE_GRPC_KEY_FILE`
* `DRONE_GRPC_CA_FILE`

Finally, on the agent you can also specify `DRONE_GRPC_SERVERNAME` to override the hostname to use to match the certificate on the server.  This is primarily for testing purposes.

I have done some manual testing of this with a private drone instance built from source.