### PR TITLE
Execute database migrations and their logging in a transaction

### DIFF
--- a/store/datastore/ddl/mysql/ddl_gen.go
+++ b/store/datastore/ddl/mysql/ddl_gen.go
@@ -200,7 +200,9 @@ func Migrate(db *sql.DB) error {
 				return err
 			}
 		}
-		return tx.Commit()
+		if err := tx.Commit(); err != nil {
+			return err
+		}
 
 	}
 	return nil

--- a/store/datastore/ddl/postgres/ddl_gen.go
+++ b/store/datastore/ddl/postgres/ddl_gen.go
@@ -200,7 +200,9 @@ func Migrate(db *sql.DB) error {
 				return err
 			}
 		}
-		return tx.Commit()
+		if err := tx.Commit(); err != nil {
+			return err
+		}
 
 	}
 	return nil

--- a/store/datastore/ddl/sqlite/ddl_gen.go
+++ b/store/datastore/ddl/sqlite/ddl_gen.go
@@ -204,8 +204,9 @@ func Migrate(db *sql.DB) error {
 				return err
 			}
 		}
-		return tx.Commit()
-
+		if err := tx.Commit(); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/store/datastore/ddl/sqlite/ddl_gen.go
+++ b/store/datastore/ddl/sqlite/ddl_gen.go
@@ -1,11 +1,11 @@
 // Copyright 2018 Drone.IO Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //      http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -192,12 +192,19 @@ func Migrate(db *sql.DB) error {
 			continue
 		}
 
-		if _, err := db.Exec(migration.stmt); err != nil {
+		tx, err := db.Begin()
+		if err != nil {
 			return err
 		}
-		if err := insertMigration(db, migration.name); err != nil {
-			return err
+		{
+			if _, err := tx.Exec(migration.stmt); err != nil {
+				return err
+			}
+			if err := insertMigration(tx, migration.name); err != nil {
+				return err
+			}
 		}
+		return tx.Commit()
 
 	}
 	return nil
@@ -208,7 +215,7 @@ func createTable(db *sql.DB) error {
 	return err
 }
 
-func insertMigration(db *sql.DB, name string) error {
+func insertMigration(db *sql.Tx, name string) error {
 	_, err := db.Exec(migrationInsert, name)
 	return err
 }


### PR DESCRIPTION
Otherwise some inconsistencies may occur, and those can leave the migrations in a non-resumable state.