### PR TITLE
Urgent fix for changed auth behavior on Gitea

### DIFF
--- a/cmd/drone-server/server.go
+++ b/cmd/drone-server/server.go
@@ -1,11 +1,11 @@
 // Copyright 2018 Drone.IO Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //      http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -168,6 +168,12 @@ var flags = []cli.Flag{
 		Name:   "datasource",
 		Usage:  "database driver configuration string",
 		Value:  "drone.sqlite",
+	},
+	cli.StringFlag{
+		EnvVar: "DRONE_PROMETHEUS_TOKEN",
+		Name:   "prometheus-token",
+		Usage:  "token to secure prometheus metrics endpoint",
+		Value:  "",
 	},
 	//
 	// resource limit parameters
@@ -685,6 +691,9 @@ func setupEvilGlobals(c *cli.Context, v store.Store, r remote.Remote) {
 	// droneserver.Config.Server.Open = cli.Bool("open")
 	// droneserver.Config.Server.Orgs = sliceToMap(cli.StringSlice("orgs"))
 	// droneserver.Config.Server.Admins = sliceToMap(cli.StringSlice("admin"))
+
+	// prometheus
+	droneserver.Config.Prometheus.Token = c.String("prometheus-token")
 }
 
 type authorizer struct {

--- a/router/router.go
+++ b/router/router.go
@@ -1,11 +1,11 @@
 // Copyright 2018 Drone.IO Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //      http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -178,10 +178,7 @@ func Load(mux *httptreemux.ContextMux, middleware ...gin.HandlerFunc) http.Handl
 
 	monitor := e.Group("/metrics")
 	{
-		monitor.GET("",
-			session.MustAdmin(),
-			metrics.PromHandler(),
-		)
+		monitor.GET("", metrics.PromHandler())
 	}
 
 	e.GET("/version", server.Version)

--- a/server/metrics/prometheus.go
+++ b/server/metrics/prometheus.go
@@ -1,11 +1,11 @@
 // Copyright 2018 Drone.IO Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //      http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,14 +15,44 @@
 package metrics
 
 import (
-	"github.com/gin-gonic/gin"
+	"errors"
+  "fmt"
 
+	"github.com/drone/drone/server"
+	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+	// errInvalidToken is returned when the api request token is invalid.
+	errInvalidToken = errors.New("Invalid or missing token")
 )
 
 // PromHandler will pass the call from /api/metrics/prometheus to prometheus
 func PromHandler() gin.HandlerFunc {
+	handler := promhttp.Handler()
+
 	return func(c *gin.Context) {
-		promhttp.Handler().ServeHTTP(c.Writer, c.Request)
+		token := server.Config.Prometheus.Token
+		bearer := fmt.Sprintf("Bearer %s", token)
+
+		if token == "" {
+			handler.ServeHTTP(c.Writer, c.Request)
+			return
+		}
+
+		header := c.Request.Header.Get("Authorization")
+
+		if header == "" {
+			c.String(401, errInvalidToken.Error())
+			return
+		}
+
+		if header != bearer {
+			c.String(401, errInvalidToken.Error())
+			return
+		}
+
+		handler.ServeHTTP(c.Writer, c.Request)
 	}
 }

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -1,11 +1,11 @@
 // Copyright 2018 Drone.IO Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //      http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -79,6 +79,9 @@ var Config = struct {
 		// Open bool
 		// Orgs map[string]struct{}
 		// Admins map[string]struct{}
+	}
+	Prometheus struct {
+		Token string
 	}
 	Pipeline struct {
 		Limits     model.ResourceLimit


### PR DESCRIPTION
Within the PR https://github.com/go-gitea/gitea/pull/2184 on Gitea the
project dropped the standard behavior to use x-auth-basic personal
access token. So we should use a proper username and the token from now
on to support Gitea >= 1.2.0. Since this driver anyway only supports
Gitea >= 1.2.0 this won't be a breaking change on Drone side, the only
breaking change is on side of Gitea!