### PR TITLE
Fix EventStreamSSE Memory Leak

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -78,7 +78,7 @@ func EventStreamSSE(c *gin.Context) {
 
 	go func() {
 		// TODO remove this from global config
-		Config.Services.Pubsub.Subscribe(c, "topic/events", func(m pubsub.Message) {
+		Config.Services.Pubsub.Subscribe(ctx, "topic/events", func(m pubsub.Message) {
 			name := m.Labels["repo"]
 			priv := m.Labels["private"]
 			if repo[name] || priv == "false" {


### PR DESCRIPTION
The `Config.Services.Pubsub.Subscribe` interface at EventStreamSSE is being initialized with the global Gin Context. This causes the publisher object to [hang at line 58](https://github.com/cncd/pubsub/blob/master/pub.go#L58) and the goroutine remains opened indefinetly, which can be a source of memory leak.

Setting it to the locally defined ctx object correctly causes the goroutine to close when the function exits due to the deferred close.

See https://discourse.drone.io/t/memory-leak-on-drone-server/1884/4 for further information.

