### PR TITLE
Add ability to restart build of any state

### DIFF
--- a/server/build.go
+++ b/server/build.go
@@ -496,11 +496,8 @@ func PostBuild(c *gin.Context) {
 	}
 
 	switch build.Status {
-	case model.StatusPending,
-		model.StatusRunning,
-		model.StatusDeclined,
-		model.StatusBlocked,
-		model.StatusError:
+	case model.StatusDeclined,
+		model.StatusBlocked:
 		c.String(500, "cannot restart a build with status %s", build.Status)
 		return
 	}


### PR DESCRIPTION
Build in any state can be restarted.
If it was an error - external environment (dependencies) can changes till now.
If build already running/pending - it is not a problem to schedule new build.