### PR TITLE
Gitlab hook

### DIFF
--- a/remote/gitlab/gitlab.go
+++ b/remote/gitlab/gitlab.go
@@ -601,6 +601,7 @@ func push(parsed *client.HookPayload, req *http.Request) (*model.Repo, *model.Bu
 
 	var head = parsed.Head()
 	build.Message = head.Message
+	build.Link = head.URL
 	// build.Timestamp = head.Timestamp
 
 	// extracts the commit author (ideally email)

--- a/remote/gitlab/gitlab.go
+++ b/remote/gitlab/gitlab.go
@@ -523,6 +523,7 @@ func mergeRequest(parsed *client.HookPayload, req *http.Request) (*model.Repo, *
 
 	build.Message = lastCommit.Message
 	build.Commit = lastCommit.Id
+	build.Link = lastCommit.URL
 	//build.Remote = parsed.ObjectAttributes.Source.HttpUrl
 
 	build.Ref = fmt.Sprintf("refs/merge-requests/%d/head", obj.IId)
@@ -542,7 +543,6 @@ func mergeRequest(parsed *client.HookPayload, req *http.Request) (*model.Repo, *
 	}
 
 	build.Title = obj.Title
-	build.Link = obj.Url
 
 	return repo, build, nil
 }


### PR DESCRIPTION
When a merge request is triggered, `DRONE_COMMIT_LINK` is set to the MR link, something like:

```
DRONE_COMMIT_LINK=http://example.com/diaspora/merge_requests/1
```

IMO, it should be set to the last commit URL:

```
DRONE_COMMIT_LINK=http://example.com/awesome_space/awesome_project/commits/da1560886d4f094c3e6c9ef40349f7d38b5d27d7
```

This PR also add `DRONE_COMMIT_LINK` in case of push event.