### PR TITLE
Enable Vault auth through kubernetes auth method

### DIFF
--- a/cmd/drone-server/server.go
+++ b/cmd/drone-server/server.go
@@ -175,6 +175,24 @@ var flags = []cli.Flag{
 		Usage:  "token to secure prometheus metrics endpoint",
 		Value:  "",
 	},
+	cli.StringFlag{
+		EnvVar: "DRONE_VAULT_AUTH_TYPE",
+		Name:   "drone-vault-auth-type",
+		Usage:  "auth backend type used for connecting to vault",
+		Value:  "token",
+	},
+	cli.StringFlag{
+		EnvVar: "DRONE_VAULT_AUTH_MOUNT_POINT",
+		Name:   "drone-vault-auth-mount-point",
+		Usage:  "mount point for desired vault auth backend",
+		Value:  "",
+	},
+	cli.StringFlag{
+		EnvVar: "DRONE_VAULT_KUBERNETES_ROLE",
+		Name:   "drone-vault-kubernetes-role",
+		Usage:  "role to authenticate as for vault kubernetes auth",
+		Value:  "",
+	},
 	//
 	// resource limit parameters
 	//

--- a/cmd/drone-server/server.go
+++ b/cmd/drone-server/server.go
@@ -179,7 +179,7 @@ var flags = []cli.Flag{
 		EnvVar: "DRONE_VAULT_AUTH_TYPE",
 		Name:   "drone-vault-auth-type",
 		Usage:  "auth backend type used for connecting to vault",
-		Value:  "token",
+		Value:  "",
 	},
 	cli.StringFlag{
 		EnvVar: "DRONE_VAULT_AUTH_MOUNT_POINT",

--- a/plugins/secrets/vault/fixtures/fakeJwt
+++ b/plugins/secrets/vault/fixtures/fakeJwt
@@ -1,0 +1,1 @@
+fakeJwt

--- a/plugins/secrets/vault/kubernetes.go
+++ b/plugins/secrets/vault/kubernetes.go
@@ -16,22 +16,22 @@ Vault JSON Response
   }
 }
 */
-type VaultAuth struct {
+type vaultAuth struct {
 	Token string `json:"client_token"`
 	Lease string `json:"lease_duration"`
 }
-type VaultResp struct {
-	Auth VaultAuth
+type vaultResp struct {
+	Auth vaultAuth
 }
 
-func getKubernetesToken(addr, role, mountPoint, tokenFile string) (string, time.Duration, error) {
+func getKubernetesToken(addr, role, mount, tokenFile string) (string, time.Duration, error) {
 	b, err := ioutil.ReadFile(tokenFile)
 	if err != nil {
 		return "", 0, err
 	}
 
-	var resp VaultResp
-	path := fmt.Sprintf("%s/v1/auth/%s/login", addr, mountPoint)
+	var resp vaultResp
+	path := fmt.Sprintf("%s/v1/auth/%s/login", addr, mount)
 	data := map[string]string{
 		"jwt":  string(b),
 		"role": role,

--- a/plugins/secrets/vault/kubernetes.go
+++ b/plugins/secrets/vault/kubernetes.go
@@ -1,0 +1,47 @@
+package vault
+
+import (
+	"fmt"
+	"github.com/drone/drone/plugins/internal"
+	"io/ioutil"
+	"time"
+)
+
+/*
+Vault JSON Response
+{
+  "auth": {
+    "client_token" = "token",
+    "lease_duration" = "1234s"
+  }
+}
+*/
+type VaultAuth struct {
+	Token string `json:"client_token"`
+	Lease string `json:"lease_duration"`
+}
+type VaultResp struct {
+	Auth VaultAuth
+}
+
+func getKubernetesToken(addr, role, mountPoint, tokenFile string) (string, time.Duration, error) {
+	b, err := ioutil.ReadFile(tokenFile)
+	if err != nil {
+		return "", 0, err
+	}
+
+	var resp VaultResp
+	path := fmt.Sprintf("%s/v1/auth/%s/login", addr, mountPoint)
+	data := map[string]string{
+		"jwt":  string(b),
+		"role": role,
+	}
+
+	err = internal.Send("POST", path, data, &resp)
+	if err != nil {
+		return "", 0, err
+	}
+
+	ttl, err := time.ParseDuration(resp.Auth.Lease)
+	return resp.Auth.Token, ttl, nil
+}

--- a/plugins/secrets/vault/kubernetes.go
+++ b/plugins/secrets/vault/kubernetes.go
@@ -43,5 +43,9 @@ func getKubernetesToken(addr, role, mountPoint, tokenFile string) (string, time.
 	}
 
 	ttl, err := time.ParseDuration(resp.Auth.Lease)
+	if err != nil {
+		return "", 0, err
+	}
+
 	return resp.Auth.Token, ttl, nil
 }

--- a/plugins/secrets/vault/kubernetes_test.go
+++ b/plugins/secrets/vault/kubernetes_test.go
@@ -1,0 +1,69 @@
+package vault
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestGetKubernetesToken(t *testing.T) {
+	fakeRole := "fakeRole"
+	fakeMountPoint := "kubernetes"
+	fakeJwtFile := "fixtures/fakeJwt"
+	b, _ := ioutil.ReadFile(fakeJwtFile)
+	fakeJwt := string(b)
+	fakeClientToken := "fakeClientToken"
+	fakeLeaseMinutes := "10m"
+	fakeLeaseDuration, _ := time.ParseDuration(fakeLeaseMinutes)
+	fakeResp := fmt.Sprintf("{\"auth\": {\"client_token\": \"%s\", \"lease_duration\": \"%s\"}}", fakeClientToken, fakeLeaseMinutes)
+	expectedPath := "/v1/auth/kubernetes/login"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if r.Method != "POST" {
+			t.Errorf("Expected 'POST' request, got '%s'", r.Method)
+		}
+		if r.URL.EscapedPath() != expectedPath {
+			t.Errorf("Expected request to '%s', got '%s'", expectedPath, r.URL.EscapedPath())
+		}
+
+		var postdata struct {
+			Jwt  string
+			Role string
+		}
+		err := json.NewDecoder(r.Body).Decode(&postdata)
+		if err != nil {
+			t.Errorf("Encountered error parsing request JSON:  %s", err)
+		}
+
+		jwt := postdata.Jwt
+
+		if jwt != fakeJwt {
+			t.Errorf("Expected request to have jwt with value '%s', got: '%s'", fakeJwt, jwt)
+		}
+		role := postdata.Role
+		if role != fakeRole {
+			t.Errorf("Expected request to have role with value '%s', got: '%s'", fakeRole, role)
+		}
+
+		fmt.Fprintf(w, fakeResp)
+	}))
+	defer ts.Close()
+
+	url := ts.URL
+	token, ttl, err := getKubernetesToken(url, fakeRole, fakeMountPoint, fakeJwtFile)
+	if err != nil {
+		t.Errorf("getKubernetesToken returned an error: %s", err)
+	}
+
+	if token != fakeClientToken {
+		t.Errorf("Expected returned token to have value '%s', got: '%s'", fakeClientToken, token)
+	}
+	if ttl != fakeLeaseDuration {
+		t.Errorf("Expected TTL to have value '%s', got: '%s'", fakeLeaseDuration.Seconds(), ttl.Seconds())
+	}
+}

--- a/plugins/secrets/vault/opts.go
+++ b/plugins/secrets/vault/opts.go
@@ -4,11 +4,7 @@
 
 package vault
 
-import (
-	"github.com/Sirupsen/logrus"
-	"os"
-	"time"
-)
+import "time"
 
 // Opts sets custom options for the vault client.
 type Opts func(v *vault)
@@ -29,20 +25,13 @@ func WithRenewal(d time.Duration) Opts {
 	}
 }
 
-func WithKubernetesAuth() Opts {
+// WithKubernetes returns an options that sets
+// kubernetes-auth parameters required to retrieve
+// an initial Vault token
+func WithKubernetesAuth(addr, role, mount string) Opts {
 	return func(v *vault) {
-		addr := os.Getenv("VAULT_ADDR")
-		role := os.Getenv("DRONE_VAULT_KUBERNETES_ROLE")
-		mount := os.Getenv("DRONE_VAULT_AUTH_MOUNT_POINT")
-		jwtFile := "/var/run/secrets/kubernetes.io/serviceaccount/token"
-		token, ttl, err := getKubernetesToken(addr, role, mount, jwtFile)
-		if err != nil {
-			logrus.Debugf("vault: failed to obtain token via kubernetes-auth backend: %s", err)
-			return
-		}
-
-		v.client.SetToken(token)
-		v.ttl = ttl
-		v.renew = ttl / 2
+		v.kubeAuth.addr = addr
+		v.kubeAuth.role = role
+		v.kubeAuth.mount = mount
 	}
 }

--- a/plugins/secrets/vault/opts.go
+++ b/plugins/secrets/vault/opts.go
@@ -4,7 +4,11 @@
 
 package vault
 
-import "time"
+import (
+	"github.com/Sirupsen/logrus"
+	"os"
+	"time"
+)
 
 // Opts sets custom options for the vault client.
 type Opts func(v *vault)
@@ -22,5 +26,23 @@ func WithTTL(d time.Duration) Opts {
 func WithRenewal(d time.Duration) Opts {
 	return func(v *vault) {
 		v.renew = d
+	}
+}
+
+func WithKubernetesAuth() Opts {
+	return func(v *vault) {
+		addr := os.Getenv("VAULT_ADDR")
+		role := os.Getenv("DRONE_VAULT_KUBERNETES_ROLE")
+		mount := os.Getenv("DRONE_VAULT_AUTH_MOUNT_POINT")
+		jwtFile := "/var/run/secrets/kubernetes.io/serviceaccount/token"
+		token, ttl, err := getKubernetesToken(addr, role, mount, jwtFile)
+		if err != nil {
+			logrus.Debugf("vault: failed to obtain token via kubernetes-auth backend: %s", err)
+			return
+		}
+
+		v.client.SetToken(token)
+		v.ttl = ttl
+		v.renew = ttl / 2
 	}
 }

--- a/plugins/secrets/vault/opts.go
+++ b/plugins/secrets/vault/opts.go
@@ -25,9 +25,17 @@ func WithRenewal(d time.Duration) Opts {
 	}
 }
 
+// WithAuth returns an options that sets the vault
+// method to use for authentication
+func WithAuth(method string) Opts {
+	return func(v *vault) {
+		v.auth = method
+	}
+}
+
 // WithKubernetes returns an options that sets
 // kubernetes-auth parameters required to retrieve
-// an initial Vault token
+// an initial vault token
 func WithKubernetesAuth(addr, role, mount string) Opts {
 	return func(v *vault) {
 		v.kubeAuth.addr = addr

--- a/plugins/secrets/vault/opts_test.go
+++ b/plugins/secrets/vault/opts_test.go
@@ -26,3 +26,21 @@ func TestWithRenewal(t *testing.T) {
 		t.Errorf("Want renewal %v, got %v", want, got)
 	}
 }
+
+func TestWithKubernetesAuth(t *testing.T) {
+	v := new(vault)
+	addr := "https://address.fake"
+	role := "fakeRole"
+	mount := "kubernetes"
+	opt := WithKubernetesAuth(addr, role, mount)
+	opt(v)
+	if got, want := v.kubeAuth.addr, addr; got != want {
+		t.Errorf("Want addr %v, got %v", want, got)
+	}
+	if got, want := v.kubeAuth.role, role; got != want {
+		t.Errorf("Want role %v, got %v", want, got)
+	}
+	if got, want := v.kubeAuth.mount, mount; got != want {
+		t.Errorf("Want mount %v, got %v", want, got)
+	}
+}

--- a/plugins/secrets/vault/opts_test.go
+++ b/plugins/secrets/vault/opts_test.go
@@ -27,6 +27,16 @@ func TestWithRenewal(t *testing.T) {
 	}
 }
 
+func TestWithAuth(t *testing.T) {
+	v := new(vault)
+	method := "kubernetes"
+	opt := WithAuth(method)
+	opt(v)
+	if got, want := v.auth, method; got != want {
+		t.Errorf("Want auth %v, got %v", want, got)
+	}
+}
+
 func TestWithKubernetesAuth(t *testing.T) {
 	v := new(vault)
 	addr := "https://address.fake"


### PR DESCRIPTION
Added a feature to obtain the initial Vault token from the Kubernetes auth method.

This works by making a request to the vault server at the specified auth method mount point's login path and presenting the JWT located in a file on a running pod, along with the Kubernetes role to authenticate as.

Vault will then respond with a token and its TTL, if the request is valid.


My Go is pretty rusty, so I expect this code will require a bit of massaging before getting integrated.