### PR TITLE
Fix vault-k8s expected response type

### DIFF
--- a/plugins/secrets/vault/kubernetes.go
+++ b/plugins/secrets/vault/kubernetes.go
@@ -12,13 +12,13 @@ Vault JSON Response
 {
   "auth": {
     "client_token" = "token",
-    "lease_duration" = "1234s"
+    "lease_duration" = 1234
   }
 }
 */
 type vaultAuth struct {
 	Token string `json:"client_token"`
-	Lease string `json:"lease_duration"`
+	Lease int    `json:"lease_duration"`
 }
 type vaultResp struct {
 	Auth vaultAuth
@@ -42,10 +42,7 @@ func getKubernetesToken(addr, role, mount, tokenFile string) (string, time.Durat
 		return "", 0, err
 	}
 
-	ttl, err := time.ParseDuration(resp.Auth.Lease)
-	if err != nil {
-		return "", 0, err
-	}
+	ttl := time.Duration(resp.Auth.Lease) * time.Second
 
 	return resp.Auth.Token, ttl, nil
 }

--- a/plugins/secrets/vault/kubernetes_test.go
+++ b/plugins/secrets/vault/kubernetes_test.go
@@ -17,9 +17,9 @@ func TestGetKubernetesToken(t *testing.T) {
 	b, _ := ioutil.ReadFile(fakeJwtFile)
 	fakeJwt := string(b)
 	fakeClientToken := "fakeClientToken"
-	fakeLeaseMinutes := "10m"
-	fakeLeaseDuration, _ := time.ParseDuration(fakeLeaseMinutes)
-	fakeResp := fmt.Sprintf("{\"auth\": {\"client_token\": \"%s\", \"lease_duration\": \"%s\"}}", fakeClientToken, fakeLeaseMinutes)
+	fakeLeaseSeconds := 86400
+	fakeLeaseDuration := time.Duration(fakeLeaseSeconds) * time.Second
+	fakeResp := fmt.Sprintf("{\"auth\": {\"client_token\": \"%s\", \"lease_duration\": %d}}", fakeClientToken, fakeLeaseSeconds)
 	expectedPath := "/v1/auth/kubernetes/login"
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Vault server response for lease_duration is an integer, rather than a string