### PR TITLE
Fix agent panics by checking array size before indexing.

### DIFF
--- a/cmd/drone-agent/agent.go
+++ b/cmd/drone-agent/agent.go
@@ -492,7 +492,12 @@ func extractRepositoryName(config *backend.Config) (string, error) {
 	if len(config.Stages[0].Steps) < 1 {
 		return "", errors.New("agent: Unable to get repo name, no steps in stage.")
 	}
-	return config.Stages[0].Steps[0].Environment["DRONE_REPO"], nil
+
+	if val, ok := config.Stages[0].Steps[0].Environment["DRONE_REPO"]; ok {
+		return val, nil
+	} else {
+		return val, errors.New("agent: DRONE_REPO environment variable does not exist.")
+	}
 }
 
 // extract build number from the configuration
@@ -503,5 +508,10 @@ func extractBuildNumber(config *backend.Config) (string, error) {
 	if len(config.Stages[0].Steps) < 1 {
 		return "", errors.New("agent: Unable to get build number, no steps in stage.")
 	}
-	return config.Stages[0].Steps[0].Environment["DRONE_BUILD_NUMBER"], nil
+
+	if val, ok := config.Stages[0].Steps[0].Environment["DRONE_BUILD_NUMBER"]; ok {
+		return val, nil
+	} else {
+		return val, errors.New("agent: DRONE_BUILD_NUMBER environment variable does not exist.")
+	}
 }

--- a/cmd/drone-agent/agent_test.go
+++ b/cmd/drone-agent/agent_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestGetRepoName(t *testing.T) {
+func TestExtractRepoName(t *testing.T) {
 
 	backendConfig := new(backend.Config)
 	name, err := extractRepositoryName(backendConfig)
@@ -48,5 +48,51 @@ func TestGetRepoName(t *testing.T) {
 
 	if name != "TestRepo" {
 		t.Errorf("Repo name should match environment variable DRONE_REPO.")
+	}
+}
+
+func TestExtractBuildNumber(t *testing.T) {
+
+	backendConfig := new(backend.Config)
+	name, err := extractBuildNumber(backendConfig)
+
+	if err == nil {
+		t.Errorf("Should return error but instead returned %s", name)
+	}
+
+	if name != "" {
+		t.Errorf("Should have an empty string as the name.")
+	}
+
+	backendConfig.Stages = append(backendConfig.Stages, new(backend.Stage))
+
+	name, err = extractBuildNumber(backendConfig)
+
+	if err == nil {
+		t.Errorf("Should return error by instead returned %s", name)
+	}
+
+	if name != "" {
+		t.Errorf("Should have an empty string as the name.")
+	}
+
+	backendConfig.Stages = append(backendConfig.Stages, new(backend.Stage))
+	backendConfig.Stages[0].Steps = append(backendConfig.Stages[0].Steps, new(backend.Step))
+	backendConfig.Stages[0].Steps[0].Environment = make(map[string]string)
+
+	backendConfig.Stages[0].Steps[0].Environment["DRONE_BUILD_NUMBER"] = "101"
+
+	name, err = extractBuildNumber(backendConfig)
+
+	if err != nil {
+		t.Errorf("Should not return error.")
+	}
+
+	if name == "" {
+		t.Errorf("Should not have an empty string as the name.")
+	}
+
+	if name != "101" {
+		t.Errorf("Repo name should match environment variable DRONE_BUILD_NUMBER.")
 	}
 }

--- a/cmd/drone-agent/agent_test.go
+++ b/cmd/drone-agent/agent_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"github.com/cncd/pipeline/pipeline/backend"
+	"testing"
+)
+
+func TestGetRepoName(t *testing.T) {
+
+	backendConfig := new(backend.Config)
+	name, err := extractRepositoryName(backendConfig)
+
+	if err == nil {
+		t.Errorf("Should return error but instead returned %s", name)
+	}
+
+	if name != "" {
+		t.Errorf("Should have an empty string as the name.")
+	}
+
+	backendConfig.Stages = append(backendConfig.Stages, new(backend.Stage))
+
+	name, err = extractRepositoryName(backendConfig)
+
+	if err == nil {
+		t.Errorf("Should return error by instead returned %s", name)
+	}
+
+	if name != "" {
+		t.Errorf("Should have an empty string as the name.")
+	}
+
+	backendConfig.Stages = append(backendConfig.Stages, new(backend.Stage))
+	backendConfig.Stages[0].Steps = append(backendConfig.Stages[0].Steps, new(backend.Step))
+	backendConfig.Stages[0].Steps[0].Environment = make(map[string]string)
+
+	backendConfig.Stages[0].Steps[0].Environment["DRONE_REPO"] = "TestRepo"
+
+	name, err = extractRepositoryName(backendConfig)
+
+	if err != nil {
+		t.Errorf("Should not return error.")
+	}
+
+	if name == "" {
+		t.Errorf("Should not have an empty string as the name.")
+	}
+
+	if name != "TestRepo" {
+		t.Errorf("Repo name should match environment variable DRONE_REPO.")
+	}
+}


### PR DESCRIPTION
Ran into an issue where agents would panic when due to an `index out of range` runtime error. This would cause the container to die and jobs would hang. 

I've update the agent code to check that both `Stages` and `Steps` are not empty lists, and if they are empty we should fail and return early from the job executor.

```
{"time":"2018-06-06T14:41:33Z","level":"debug","message":"request next execution"}
panic: runtime error: index out of range
goroutine 12 [running]:
main.(*runner).run(0xc42031a240, 0xbc0da0, 0xc420205780, 0x0, 0x0)
        /go/src/github.com/drone/drone/cmd/drone-agent/agent.go:182 +0x170d
main.loop.func2(0xc4202af030, 0xc4202aef98, 0xbc3300, 0xc42027cf40, 0xc4201cf980, 0x0, 0x0, 0xc4202aef80, 0xc4202aeff0)
        /go/src/github.com/drone/drone/cmd/drone-agent/agent.go:132 +0x193
created by main.loop
        /go/src/github.com/drone/drone/cmd/drone-agent/agent.go:137 +0x910
{"time":"2018-06-06T14:41:34Z","level":"debug","message":"request next execution"}
```