### PR TITLE
Fix out-of-bounds error when a push doesn't contain commits

### DIFF
--- a/remote/gitea/helper.go
+++ b/remote/gitea/helper.go
@@ -82,13 +82,18 @@ func buildFromPush(hook *pushHook) *model.Build {
 		sender = hook.Sender.Login
 	}
 
+	message := ""
+	if len(hook.Commits) > 0 {
+		message = hook.Commits[0].Message
+	}
+
 	return &model.Build{
 		Event:     model.EventPush,
 		Commit:    hook.After,
 		Ref:       hook.Ref,
 		Link:      hook.Compare,
 		Branch:    strings.TrimPrefix(hook.Ref, "refs/heads/"),
-		Message:   hook.Commits[0].Message,
+		Message:   message,
 		Avatar:    avatar,
 		Author:    author,
 		Email:     hook.Sender.Email,


### PR DESCRIPTION
This happens when I push a new tag with `git tag -af foo -m "bar" && git push --tags`. Both the 'create' and 'push' events are triggered.
The log of the drone server would show an internal panic like the following:

```
2018/06/11 08:34:56 [Recovery] panic recovered:
POST /hook?access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0ZXh0IjoibXVyYS9OVFREQVRBLXBsdWdpbiIsInR5cGUiOiJob29rIn0.IDq3cvR1LNHTvtrWWrmqW4GfyterT8B4tKS_MDUFBMQ HTTP/1.1
Host: 192.120.100.224
Accept-Encoding: gzip
Content-Length: 2902
Content-Type: application/json
User-Agent: GiteaServer
X-Gitea-Delivery: ad3bd9f2-571d-4dac-91d7-ec6b63baf5e7
X-Gitea-Event: push
X-Github-Delivery: ad3bd9f2-571d-4dac-91d7-ec6b63baf5e7
X-Github-Event: push
X-Gogs-Delivery: ad3bd9f2-571d-4dac-91d7-ec6b63baf5e7
X-Gogs-Event: push


runtime error: index out of range
/usr/local/go/src/runtime/panic.go:489 (0x430c7f)
/usr/local/go/src/runtime/panic.go:28 (0x42f8fe)
/go/src/github.com/drone/drone/remote/gitea/helper.go:91 (0xa1cf2f)
/go/src/github.com/drone/drone/remote/gitea/parse.go:72 (0xa1e61b)
/go/src/github.com/drone/drone/remote/gitea/parse.go:44 (0xa1e471)
/go/src/github.com/drone/drone/remote/gitea/gitea.go:338 (0xa1c4db)
/go/src/github.com/drone/drone/server/hook.go:72 (0x932cd4)
/go/src/github.com/drone/drone/vendor/github.com/gin-gonic/gin/context.go:97 (0x88800a)
/go/src/github.com/drone/drone/router/middleware/token/token.go:31 (0x8a1620)
/go/src/github.com/drone/drone/vendor/github.com/gin-gonic/gin/context.go:97 (0x88800a)
/go/src/github.com/drone/drone/router/middleware/session/user.go:82 (0x8a0ac2)
/go/src/github.com/drone/drone/vendor/github.com/gin-gonic/gin/context.go:97 (0x88800a)
/go/src/github.com/drone/drone/router/middleware/store.go:29 (0x9a0fa7)
/go/src/github.com/drone/drone/vendor/github.com/gin-gonic/gin/context.go:97 (0x88800a)
/go/src/github.com/drone/drone/vendor/github.com/gin-gonic/contrib/ginrus/ginrus.go:26 (0x9a13ff)
/go/src/github.com/drone/drone/vendor/github.com/gin-gonic/gin/context.go:97 (0x88800a)
/go/src/github.com/drone/drone/router/middleware/header/header.go:39 (0x898630)
/go/src/github.com/drone/drone/vendor/github.com/gin-gonic/gin/context.go:97 (0x88800a)
/go/src/github.com/drone/drone/router/middleware/header/header.go:31 (0x8985d9)
/go/src/github.com/drone/drone/vendor/github.com/gin-gonic/gin/context.go:97 (0x88800a)
/go/src/github.com/drone/drone/vendor/github.com/gin-gonic/gin/recovery.go:45 (0x89629a)
/go/src/github.com/drone/drone/vendor/github.com/gin-gonic/gin/context.go:97 (0x88800a)
/go/src/github.com/drone/drone/vendor/github.com/gin-gonic/gin/gin.go:284 (0x88de40)
/go/src/github.com/drone/drone/vendor/github.com/gin-gonic/gin/gin.go:265 (0x88d75b)
/usr/local/go/src/net/http/server.go:2568 (0x6cc862)
/usr/local/go/src/net/http/server.go:1825 (0x6c8a02)
/usr/local/go/src/runtime/asm_amd64.s:2197 (0x45f881)
```
