### PR TITLE
Agent build filtering by branch.

### DIFF
--- a/server/hook.go
+++ b/server/hook.go
@@ -322,6 +322,7 @@ func PostHook(c *gin.Context) {
 	message := pubsub.Message{
 		Labels: map[string]string{
 			"repo":    repo.FullName,
+			"branch":  repo.Branch,
 			"private": strconv.FormatBool(repo.IsPrivate),
 		},
 	}
@@ -347,6 +348,7 @@ func PostHook(c *gin.Context) {
 		}
 		task.Labels["platform"] = item.Platform
 		task.Labels["repo"] = b.Repo.FullName
+		task.Labels["branch"] = b.Repo.Branch
 
 		task.Data, _ = json.Marshal(rpc.Pipeline{
 			ID:      fmt.Sprint(item.Proc.ID),

--- a/server/hook.go
+++ b/server/hook.go
@@ -322,7 +322,7 @@ func PostHook(c *gin.Context) {
 	message := pubsub.Message{
 		Labels: map[string]string{
 			"repo":    repo.FullName,
-			"branch":  repo.Branch,
+			"branch":  build.Branch,
 			"private": strconv.FormatBool(repo.IsPrivate),
 		},
 	}
@@ -348,7 +348,7 @@ func PostHook(c *gin.Context) {
 		}
 		task.Labels["platform"] = item.Platform
 		task.Labels["repo"] = b.Repo.FullName
-		task.Labels["branch"] = b.Repo.Branch
+		task.Labels["branch"] = build.Branch
 
 		task.Data, _ = json.Marshal(rpc.Pipeline{
 			ID:      fmt.Sprint(item.Proc.ID),


### PR DESCRIPTION
This is a follow up to PR adding support for build filtering based on static labels:

* https://github.com/drone/drone/pull/2200
* https://github.com/drone/drone/issues/2171

The use case for filtering builds by branches is to allow certain agents to only build for commits pushed to certain branches; eg; merge commits to master would have dedicated agents with higher priority compared to regular commits.

Currently it is already possible to filter by repository name, platform type, and a variety of static labels defined in the .drone.yml pipeline, however, it is not yet possible to filter by branch.

@bradrydzewski Please let me know your thoughts on the topic and if any more work is required on the PR. I wasn't really sure where to add tests for this feature, if you could point me in the right direction that would be great. Thanks!