### PR TITLE
set default accept to application/json

### DIFF
--- a/shared/oauth2/oauth2.go
+++ b/shared/oauth2/oauth2.go
@@ -412,6 +412,7 @@ func (t *Transport) updateToken(tok *Token, v url.Values) error {
 	if err != nil {
 		return err
 	}
+	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.SetBasicAuth(t.ClientId, t.ClientSecret)
 	r, err := client.Do(req)


### PR DESCRIPTION
some oauth2 server only response json data, but response content-type is text/plain.