### PR TITLE
Use canonical logrus import

### DIFF
--- a/cmd/drone-server/server.go
+++ b/cmd/drone-server/server.go
@@ -43,8 +43,8 @@ import (
 	droneserver "github.com/drone/drone/server"
 	"github.com/drone/drone/store"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/contrib/ginrus"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	oldcontext "golang.org/x/net/context"
 )

--- a/model/queue.go
+++ b/model/queue.go
@@ -17,8 +17,8 @@ package model
 import (
 	"context"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/cncd/queue"
+	"github.com/sirupsen/logrus"
 )
 
 // Task defines scheduled pipeline Task.

--- a/plugins/secrets/vault/vault.go
+++ b/plugins/secrets/vault/vault.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/drone/drone/model"
 	"github.com/drone/drone/plugins/secrets"
+	"github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/vault/api"
 	"gopkg.in/yaml.v2"

--- a/remote/bitbucketserver/internal/client.go
+++ b/remote/bitbucketserver/internal/client.go
@@ -23,9 +23,9 @@ import (
 	"net/http"
 	"strconv"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/drone/drone/model"
 	"github.com/mrjones/oauth"
+	log "github.com/sirupsen/logrus"
 	"strings"
 )
 

--- a/router/middleware/session/repo.go
+++ b/router/middleware/session/repo.go
@@ -22,8 +22,8 @@ import (
 	"github.com/drone/drone/remote"
 	"github.com/drone/drone/store"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
 )
 
 func Repo(c *gin.Context) *model.Repo {

--- a/router/middleware/token/token.go
+++ b/router/middleware/token/token.go
@@ -21,8 +21,8 @@ import (
 	"github.com/drone/drone/router/middleware/session"
 	"github.com/drone/drone/store"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
 )
 
 func Refresh(c *gin.Context) {

--- a/server/badge.go
+++ b/server/badge.go
@@ -17,8 +17,8 @@ package server
 import (
 	"fmt"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/drone/drone/model"
 	"github.com/drone/drone/shared/httputil"

--- a/server/build.go
+++ b/server/build.go
@@ -24,7 +24,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/cncd/pipeline/pipeline/rpc"
 	"github.com/cncd/pubsub"
 	"github.com/cncd/queue"
@@ -32,6 +31,7 @@ import (
 	"github.com/drone/drone/shared/httputil"
 	"github.com/drone/drone/store"
 	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
 
 	"github.com/drone/drone/model"
 	"github.com/drone/drone/router/middleware/session"

--- a/server/hook.go
+++ b/server/hook.go
@@ -28,13 +28,13 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/drone/drone/model"
 	"github.com/drone/drone/remote"
 	"github.com/drone/drone/shared/httputil"
 	"github.com/drone/drone/shared/token"
 	"github.com/drone/drone/store"
 	"github.com/drone/envsubst"
+	"github.com/sirupsen/logrus"
 
 	"github.com/cncd/pipeline/pipeline/backend"
 	"github.com/cncd/pipeline/pipeline/frontend"

--- a/server/login.go
+++ b/server/login.go
@@ -26,8 +26,8 @@ import (
 	"github.com/drone/drone/store"
 	"github.com/gorilla/securecookie"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
 )
 
 func HandleLogin(c *gin.Context) {

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -27,12 +27,12 @@ import (
 
 	"google.golang.org/grpc/metadata"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/cncd/logging"
 	"github.com/cncd/pipeline/pipeline/rpc"
 	"github.com/cncd/pipeline/pipeline/rpc/proto"
 	"github.com/cncd/pubsub"
 	"github.com/cncd/queue"
+	"github.com/sirupsen/logrus"
 
 	"github.com/drone/drone/model"
 	"github.com/drone/drone/remote"

--- a/server/stream.go
+++ b/server/stream.go
@@ -28,8 +28,8 @@ import (
 	"github.com/drone/drone/router/middleware/session"
 	"github.com/drone/drone/store"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
 )
 
 //

--- a/server/user.go
+++ b/server/user.go
@@ -20,9 +20,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/securecookie"
+	"github.com/sirupsen/logrus"
 
 	"github.com/drone/drone/model"
 	"github.com/drone/drone/remote"

--- a/store/datastore/store.go
+++ b/store/datastore/store.go
@@ -23,7 +23,7 @@ import (
 	"github.com/drone/drone/store/datastore/ddl"
 	"github.com/russross/meddler"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // datastore is an implementation of a model.Store built on top

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -20,7 +20,7 @@
 			"revisionTime": "2017-01-24T17:08:27Z"
 		},
 		{
-			"path": "github.com/Sirupsen/logrus",
+			"path": "github.com/sirupsen/logrus",
 			"revision": "4b6ea7319e214d98c938f12692336f7ca9348d6b",
 			"revisionTime": "2016-03-17T14:11:10Z"
 		},


### PR DESCRIPTION
Right now if you try to import Drone as a dependency in a system using [Go modules] you will see an error like this:

```
go: github.com/Sirupsen/logrus@v1.1.0: parsing go.mod: unexpected module path "github.com/sirupsen/logrus"                                                                                   
go: error loading module requirements
```

The canonical name is lowercase (see their `Go.mod` file):

https://github.com/sirupsen/logrus/blob/1ed61965b9e594bf37539680d7f63eccd060314f/go.mod#L1

The version in the vendor dir probably also needs to be updated to fix this, but I was less comfortable making potentially breaking changes to a repo that I'm not familiar with and didn't want to download and learn the vendor tool. For now this makes it possible (I think) for users who have vendoring disabled to use Drone as a dependency.

[Go modules]: https://golang.org/doc/go1.11#modules