### PR TITLE
Fix gRPC DeadlineExceeded  error

### DIFF
--- a/cmd/drone-agent/agent.go
+++ b/cmd/drone-agent/agent.go
@@ -211,6 +211,7 @@ func (r *runner) run(ctx context.Context) error {
 		logger.Debug().
 			Msg("listen for cancel signal")
 
+		ctx, cancel := context.WithTimeout(ctxmeta, timeout+1*time.Minute)
 		if werr := r.client.Wait(ctx, work.ID); werr != nil {
 			cancelled.SetTo(true)
 			logger.Warn().


### PR DESCRIPTION
Mainly solves a large number of error logs that may appear in the drone-agent

`grpc error: wait(): code: DeadlineExceeded: rpc error: code = DeadlineExceeded desc = context deadline exceeded`

and the drone-server:

`grpc: Server.processUnaryRPC failed to write status stream error: code = DeadlineExceeded desc = “context deadline exceeded”`

Please see https://discourse.drone.io/t/fix-grpc-deadlineexceeded-error/2884 for futher information.

