### PR TITLE
Don't return extra columns in result set

### DIFF
--- a/store/datastore/sql/postgres/files/feed.sql
+++ b/store/datastore/sql/postgres/files/feed.sql
@@ -1,10 +1,28 @@
 -- name: feed-latest-build
 
-SELECT repo_owner, repo_name, repo_full_name, b.*
+SELECT
+ repo_owner
+,repo_name
+,repo_full_name
+,build_number
+,build_event
+,build_status
+,build_created
+,build_started
+,build_finished
+,build_commit
+,build_branch
+,build_ref
+,build_refspec
+,build_remote
+,build_title
+,build_message
+,build_author
+,build_email
+,build_avatar
 FROM repos LEFT OUTER JOIN (
-  SELECT DISTINCT ON (build_repo_id) build_repo_id, build_id, build_number, build_event, build_status, build_created, build_started, build_finished, build_commit, build_branch, build_ref, build_refspec, build_remote, build_title, build_message, build_author, build_email, build_avatar
-    FROM builds
-    ORDER BY build_repo_id, build_id DESC
+	SELECT DISTINCT ON (build_repo_id) * FROM builds
+	ORDER BY build_repo_id, build_id DESC
 ) b ON b.build_repo_id = repos.repo_id
 INNER JOIN perms ON perms.perm_repo_id = repos.repo_id
 WHERE perms.perm_user_id = $1

--- a/store/datastore/sql/postgres/sql_gen.go
+++ b/store/datastore/sql/postgres/sql_gen.go
@@ -98,11 +98,29 @@ SELECT currval('builds_build_id_seq');
 `
 
 var feedLatestBuild = `
-SELECT repo_owner, repo_name, repo_full_name, b.*
+SELECT
+ repo_owner
+,repo_name
+,repo_full_name
+,build_number
+,build_event
+,build_status
+,build_created
+,build_started
+,build_finished
+,build_commit
+,build_branch
+,build_ref
+,build_refspec
+,build_remote
+,build_title
+,build_message
+,build_author
+,build_email
+,build_avatar
 FROM repos LEFT OUTER JOIN (
-  SELECT DISTINCT ON (build_repo_id) build_repo_id, build_id, build_number, build_event, build_status, build_created, build_started, build_finished, build_commit, build_branch, build_ref, build_refspec, build_remote, build_title, build_message, build_author, build_email, build_avatar
-    FROM builds
-    ORDER BY build_repo_id, build_id DESC
+	SELECT DISTINCT ON (build_repo_id) * FROM builds
+	ORDER BY build_repo_id, build_id DESC
 ) b ON b.build_repo_id = repos.repo_id
 INNER JOIN perms ON perms.perm_repo_id = repos.repo_id
 WHERE perms.perm_user_id = $1


### PR DESCRIPTION
Since commit 360708e93de1ee1c7aff829c6b832b9e2b5a5f5f the feed-latest-build query has returned extra columns in the results, causing log messages like the following:

```
meddler.Targets: column [build_repo_id] not found in struct
meddler.Targets: column [build_id] not found in struct
meddler.WriteTargets: column [build_repo_id] not found in struct
meddler.WriteTargets: column [build_id] not found in struct
```

This is a result of the optimised Postgres query including the `build_repo_id` and `build_id` terms, where previously they were not inclued.
This PR rewrites the query slightly to produce the expected result set (i.e. without the `build_repo_id` and `build_id` columns). As a side-effect it also looks similar to the original query.

Signed-off-by: Niall Sheridan <nsheridan@squarespace.com>