### PR TITLE
Fix secrets/vault plugin test

### DIFF
--- a/plugins/secrets/vault/kubernetes_test.go
+++ b/plugins/secrets/vault/kubernetes_test.go
@@ -64,6 +64,6 @@ func TestGetKubernetesToken(t *testing.T) {
 		t.Errorf("Expected returned token to have value '%s', got: '%s'", fakeClientToken, token)
 	}
 	if ttl != fakeLeaseDuration {
-		t.Errorf("Expected TTL to have value '%s', got: '%s'", fakeLeaseDuration.Seconds(), ttl.Seconds())
+		t.Errorf("Expected TTL to have value '%f', got: '%f'", fakeLeaseDuration.Seconds(), ttl.Seconds())
 	}
 }


### PR DESCRIPTION
Just found this from running `go test ./...`:

```shell
# github.com/drone/drone/plugins/secrets/vault
plugins/secrets/vault/kubernetes_test.go:67: T.Errorf format %s has arg fakeLeaseDuration.Seconds() of wrong type float64
FAIL    github.com/drone/drone/plugins/secrets/vault [build failed]
```