### PR TITLE
Extend validation on secret names

### DIFF
--- a/model/secret.go
+++ b/model/secret.go
@@ -17,6 +17,7 @@ package model
 import (
 	"errors"
 	"path/filepath"
+	"strings"
 )
 
 var (
@@ -72,7 +73,7 @@ func (s *Secret) Match(event string) bool {
 // Validate validates the required fields and formats.
 func (s *Secret) Validate() error {
 	switch {
-	case len(s.Name) == 0:
+	case len(s.Name) == 0 || strings.ContainsAny(s.Name, "/"):
 		return errSecretNameInvalid
 	case len(s.Value) == 0:
 		return errSecretValueInvalid

--- a/model/secret_test.go
+++ b/model/secret_test.go
@@ -53,6 +53,13 @@ func TestSecret(t *testing.T) {
 				err := secret.Validate()
 				g.Assert(err != nil).IsTrue()
 			})
+			g.It("when name contains a forward slash", func() {
+				secret := Secret{}
+				secret.Name = "secret/name"
+				secret.Value = "secretvalue"
+				err := secret.Validate()
+				g.Assert(err != nil).IsTrue()
+			})
 			g.It("when no value", func() {
 				secret := Secret{}
 				secret.Name = "secretname"


### PR DESCRIPTION
From Discourse:

> [This is because you secret names include a slash character, which should not be allowed. I need to add some validation on the server-side to the name field. The slash interferes with the REST API calls.](https://discourse.drone.io/t/drone-cloud-secret-deletion-fails-with-json-parse-error/3355/2)

I've only disallowed the forward slash for now, since I know that's broken in my secret names.