### PR TITLE
feat(s3): allow user to specify s3 endpoint for non aws usage

### DIFF
--- a/cmd/drone-server/config/config.go
+++ b/cmd/drone-server/config/config.go
@@ -330,8 +330,9 @@ type (
 
 	// S3 provides the storage configuration.
 	S3 struct {
-		Bucket string `envconfig:"DRONE_S3_BUCKET"`
-		Prefix string `envconfig:"DRONE_S3_PREFIX"`
+		Bucket   string `envconfig:"DRONE_S3_BUCKET"`
+		Prefix   string `envconfig:"DRONE_S3_PREFIX"`
+		Endpoint string `envconfig:"DRONE_S3_ENDPOINT"`
 	}
 
 	// HTTP provides http configuration.

--- a/cmd/drone-server/inject_store.go
+++ b/cmd/drone-server/inject_store.go
@@ -85,6 +85,7 @@ func provideLogStore(db *db.DB, config config.Config) core.LogStore {
 	return logs.NewS3Env(
 		config.S3.Bucket,
 		config.S3.Prefix,
+		config.S3.Endpoint,
 	)
 }
 

--- a/docker/Dockerfile.agent.linux.amd64
+++ b/docker/Dockerfile.agent.linux.amd64
@@ -1,7 +1,7 @@
-FROM alpine:3.6 as alpine
+FROM alpine:3.9 as alpine
 RUN apk add -U --no-cache ca-certificates
 
-FROM alpine:3.6
+FROM alpine:3.9
 ENV GODEBUG netdns=go
 ENV DRONE_RUNNER_OS=linux
 ENV DRONE_RUNNER_ARCH=amd64

--- a/docker/Dockerfile.controller.linux.amd64
+++ b/docker/Dockerfile.controller.linux.amd64
@@ -1,7 +1,7 @@
-FROM alpine:3.6 as alpine
+FROM alpine:3.9 as alpine
 RUN apk add -U --no-cache ca-certificates
 
-FROM alpine:3.6
+FROM alpine:3.9
 ENV GODEBUG netdns=go
 ENV DRONE_RUNNER_OS=linux
 ENV DRONE_RUNNER_ARCH=amd64

--- a/docker/Dockerfile.controller.linux.arm
+++ b/docker/Dockerfile.controller.linux.arm
@@ -1,7 +1,7 @@
-FROM alpine:3.6 as alpine
+FROM alpine:3.9 as alpine
 RUN apk add -U --no-cache ca-certificates
 
-FROM alpine:3.6
+FROM alpine:3.9
 ENV GODEBUG=netdns=go
 ENV DRONE_RUNNER_OS=linux
 ENV DRONE_RUNNER_ARCH=arm

--- a/docker/Dockerfile.controller.linux.arm64
+++ b/docker/Dockerfile.controller.linux.arm64
@@ -1,7 +1,7 @@
-FROM alpine:3.6 as alpine
+FROM alpine:3.9 as alpine
 RUN apk add -U --no-cache ca-certificates
 
-FROM alpine:3.6
+FROM alpine:3.9
 ENV GODEBUG=netdns=go
 ENV DRONE_RUNNER_OS=linux
 ENV DRONE_RUNNER_ARCH=arm64

--- a/docker/Dockerfile.server.linux.amd64
+++ b/docker/Dockerfile.server.linux.amd64
@@ -1,9 +1,9 @@
 # docker build --rm -f docker/Dockerfile -t drone/drone .
 
-FROM alpine:3.6 as alpine
+FROM alpine:3.9 as alpine
 RUN apk add -U --no-cache ca-certificates
 
-FROM alpine:3.6
+FROM alpine:3.9
 EXPOSE 80 443
 VOLUME /data
 

--- a/docker/Dockerfile.server.linux.arm
+++ b/docker/Dockerfile.server.linux.arm
@@ -1,9 +1,9 @@
 # docker build --rm -f docker/Dockerfile -t drone/drone .
 
-FROM alpine:3.6 as alpine
+FROM alpine:3.9 as alpine
 RUN apk add -U --no-cache ca-certificates
 
-FROM alpine:3.6
+FROM alpine:3.9
 EXPOSE 80 443
 VOLUME /data
 

--- a/docker/Dockerfile.server.linux.arm64
+++ b/docker/Dockerfile.server.linux.arm64
@@ -1,9 +1,9 @@
 # docker build --rm -f docker/Dockerfile -t drone/drone .
 
-FROM alpine:3.6 as alpine
+FROM alpine:3.9 as alpine
 RUN apk add -U --no-cache ca-certificates
 
-FROM alpine:3.6
+FROM alpine:3.9
 EXPOSE 80 443
 VOLUME /data
 

--- a/store/logs/s3.go
+++ b/store/logs/s3.go
@@ -22,12 +22,14 @@ import (
 // s3gof3r as an alternate. github.com/rlmcpherson/s3gof3r
 
 // NewS3Env returns a new S3 log store.
-func NewS3Env(bucket, prefix string) core.LogStore {
+func NewS3Env(bucket, prefix, endpoint string) core.LogStore {
 	return &s3store{
 		bucket: bucket,
 		prefix: prefix,
 		session: session.Must(
-			session.NewSession(),
+			session.NewSession(&aws.Config{
+				Endpoint: aws.String(endpoint),
+			}),
 		),
 	}
 }


### PR DESCRIPTION
This PR does the following:

- Updates the Dockerfiles to be based on a newer version of alpine
- Adds the `DRONE_S3_ENDPOINT` environment variable to allow users to specify the s3 endpoint to connect to
  - This is needed for services like [DigitalOcean spaces](https://www.digitalocean.com/products/spaces/) and other s3 compatible services
  - You could argue that the AWS library should support something like `AWS_ENDPOINT`, however, historically they haven't been willing to do this for any language or even the [cli](https://aws.amazon.com/cli). For example, https://github.com/aws/aws-sdk-php/issues/1239 has been open for almost two years.

**Note:** I've tested this update on AWS and DigitalOcean spaces.