### PR TITLE
Fix check to avoid running agent on server

### DIFF
--- a/cmd/drone-server/inject_runner.go
+++ b/cmd/drone-server/inject_runner.go
@@ -40,7 +40,7 @@ func provideRunner(
 ) *runner.Runner {
 	// the local runner is only created when the nomad or
 	// kubernetes scheduler are disabled
-	if config.Nomad.Enabled || config.Kube.Enabled || config.Agent.Enabled {
+	if config.Nomad.Enabled || config.Kube.Enabled || !config.Agent.Enabled {
 		return nil
 	}
 	engine, err := docker.NewEnv()


### PR DESCRIPTION
- This was causing the agent to spin up on the server even though
  it was not enabled

