### PR TITLE
change build_author_name charset to utf8mb4

### DIFF
--- a/store/shared/migrate/mysql/files/004_create_table_builds.sql
+++ b/store/shared/migrate/mysql/files/004_create_table_builds.sql
@@ -22,7 +22,7 @@ CREATE TABLE IF NOT EXISTS builds (
 ,build_source        VARCHAR(500)
 ,build_target        VARCHAR(500)
 ,build_author        VARCHAR(500)
-,build_author_name   VARCHAR(500)
+,build_author_name   VARCHAR(500) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci
 ,build_author_email  VARCHAR(500)
 ,build_author_avatar VARCHAR(1000)
 ,build_sender        VARCHAR(500)


### PR DESCRIPTION
Fix the issue when build_author_name is UTF8 string (Github fullname). (Only MySQL)

This is error log from github webhook:

```
{"message":"Error 1366: Incorrect string value: '\\xE1\\xBB\\x85n H...' for column 'build_author_name' at row 1"}
```

Thanks!