### PR TITLE
adds DRONE_RUNNER_ANNOTATIONS config bit

### DIFF
--- a/cmd/drone-controller/config/config.go
+++ b/cmd/drone-controller/config/config.go
@@ -82,20 +82,21 @@ type (
 
 	// Runner provides the runner configuration.
 	Runner struct {
-		Platform   string            `envconfig:"DRONE_RUNNER_PLATFORM" default:"linux/amd64"`
-		OS         string            `envconfig:"DRONE_RUNNER_OS"`
-		Arch       string            `envconfig:"DRONE_RUNNER_ARCH"`
-		Kernel     string            `envconfig:"DRONE_RUNNER_KERNEL"`
-		Variant    string            `envconfig:"DRONE_RUNNER_VARIANT"`
-		Machine    string            `envconfig:"DRONE_RUNNER_NAME"`
-		Capacity   int               `envconfig:"DRONE_RUNNER_CAPACITY" default:"2"`
-		Labels     map[string]string `envconfig:"DRONE_RUNNER_LABELS"`
-		Volumes    []string          `envconfig:"DRONE_RUNNER_VOLUMES"`
-		Networks   []string          `envconfig:"DRONE_RUNNER_NETWORKS"`
-		Devices    []string          `envconfig:"DRONE_RUNNER_DEVICES"`
-		Privileged []string          `envconfig:"DRONE_RUNNER_PRIVILEGED_IMAGES"`
-		Environ    map[string]string `envconfig:"DRONE_RUNNER_ENVIRON"`
-		Limits     struct {
+		Platform    string            `envconfig:"DRONE_RUNNER_PLATFORM" default:"linux/amd64"`
+		OS          string            `envconfig:"DRONE_RUNNER_OS"`
+		Annotations map[string]string `envconfig:"DRONE_RUNNER_ANNOTATIONS"`
+		Arch        string            `envconfig:"DRONE_RUNNER_ARCH"`
+		Kernel      string            `envconfig:"DRONE_RUNNER_KERNEL"`
+		Variant     string            `envconfig:"DRONE_RUNNER_VARIANT"`
+		Machine     string            `envconfig:"DRONE_RUNNER_NAME"`
+		Capacity    int               `envconfig:"DRONE_RUNNER_CAPACITY" default:"2"`
+		Labels      map[string]string `envconfig:"DRONE_RUNNER_LABELS"`
+		Volumes     []string          `envconfig:"DRONE_RUNNER_VOLUMES"`
+		Networks    []string          `envconfig:"DRONE_RUNNER_NETWORKS"`
+		Devices     []string          `envconfig:"DRONE_RUNNER_DEVICES"`
+		Privileged  []string          `envconfig:"DRONE_RUNNER_PRIVILEGED_IMAGES"`
+		Environ     map[string]string `envconfig:"DRONE_RUNNER_ENVIRON"`
+		Limits      struct {
 			MemSwapLimit Bytes  `envconfig:"DRONE_LIMIT_MEM_SWAP"`
 			MemLimit     Bytes  `envconfig:"DRONE_LIMIT_MEM"`
 			ShmSize      Bytes  `envconfig:"DRONE_LIMIT_SHM_SIZE"`

--- a/cmd/drone-controller/main.go
+++ b/cmd/drone-controller/main.go
@@ -73,7 +73,7 @@ func main() {
 	var engine engine.Engine
 
 	if isKubernetes() {
-		engine, err = kube.NewFile("", "", config.Runner.Machine)
+		engine, err = kube.NewFile("", "", config.Runner.Machine, config.Runner.Annotations)
 		if err != nil {
 			logrus.WithError(err).
 				Fatalln("cannot create the kubernetes client")

--- a/cmd/drone-server/config/config.go
+++ b/cmd/drone-server/config/config.go
@@ -197,22 +197,25 @@ type (
 
 	// Runner provides the runner configuration.
 	Runner struct {
-		Local      bool              `envconfig:"DRONE_RUNNER_LOCAL"`
-		Image      string            `envconfig:"DRONE_RUNNER_IMAGE"    default:"drone/controller:1.0.0"`
-		Platform   string            `envconfig:"DRONE_RUNNER_PLATFORM" default:"linux/amd64"`
-		OS         string            `envconfig:"DRONE_RUNNER_OS"`
-		Arch       string            `envconfig:"DRONE_RUNNER_ARCH"`
-		Kernel     string            `envconfig:"DRONE_RUNNER_KERNEL"`
-		Variant    string            `envconfig:"DRONE_RUNNER_VARIANT"`
-		Machine    string            `envconfig:"DRONE_RUNNER_NAME"`
-		Capacity   int               `envconfig:"DRONE_RUNNER_CAPACITY" default:"2"`
-		Labels     map[string]string `envconfig:"DRONE_RUNNER_LABELS"`
-		Volumes    []string          `envconfig:"DRONE_RUNNER_VOLUMES"`
-		Networks   []string          `envconfig:"DRONE_RUNNER_NETWORKS"`
-		Devices    []string          `envconfig:"DRONE_RUNNER_DEVICES"`
-		Privileged []string          `envconfig:"DRONE_RUNNER_PRIVILEGED_IMAGES"`
-		Environ    map[string]string `envconfig:"DRONE_RUNNER_ENVIRON"`
-		Limits     struct {
+		Local    bool   `envconfig:"DRONE_RUNNER_LOCAL"`
+		Image    string `envconfig:"DRONE_RUNNER_IMAGE"    default:"drone/controller:1.0.0"`
+		Platform string `envconfig:"DRONE_RUNNER_PLATFORM" default:"linux/amd64"`
+		OS       string `envconfig:"DRONE_RUNNER_OS"`
+		// Annotations is map[string]string, but will run through envconfig one more time
+		// before being converted. Keeping String here.
+		Annotations string            `envconfig:"DRONE_RUNNER_ANNOTATIONS"`
+		Arch        string            `envconfig:"DRONE_RUNNER_ARCH"`
+		Kernel      string            `envconfig:"DRONE_RUNNER_KERNEL"`
+		Variant     string            `envconfig:"DRONE_RUNNER_VARIANT"`
+		Machine     string            `envconfig:"DRONE_RUNNER_NAME"`
+		Capacity    int               `envconfig:"DRONE_RUNNER_CAPACITY" default:"2"`
+		Labels      map[string]string `envconfig:"DRONE_RUNNER_LABELS"`
+		Volumes     []string          `envconfig:"DRONE_RUNNER_VOLUMES"`
+		Networks    []string          `envconfig:"DRONE_RUNNER_NETWORKS"`
+		Devices     []string          `envconfig:"DRONE_RUNNER_DEVICES"`
+		Privileged  []string          `envconfig:"DRONE_RUNNER_PRIVILEGED_IMAGES"`
+		Environ     map[string]string `envconfig:"DRONE_RUNNER_ENVIRON"`
+		Limits      struct {
 			MemSwapLimit Bytes  `envconfig:"DRONE_LIMIT_MEM_SWAP"`
 			MemLimit     Bytes  `envconfig:"DRONE_LIMIT_MEM"`
 			ShmSize      Bytes  `envconfig:"DRONE_LIMIT_SHM_SIZE"`

--- a/cmd/drone-server/inject_scheduler.go
+++ b/cmd/drone-server/inject_scheduler.go
@@ -57,6 +57,7 @@ func provideKubernetesScheduler(config config.Config) core.Scheduler {
 		TTL:             config.Kube.TTL,
 		Image:           config.Kube.Image,
 		ImagePullPolicy: config.Kube.PullPolicy,
+		Annotations:     config.Runner.Annotations,
 		ImagePrivileged: config.Runner.Privileged,
 		// LimitMemory:      config.Nomad.Memory,
 		// LimitCompute:     config.Nomad.CPU,

--- a/scheduler/kube/config.go
+++ b/scheduler/kube/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	Namespace        string
 	ServiceAccount   string
 	ConfigURL        string
+	Annotations      string
 	ConfigPath       string
 	TTL              int
 	Image            string

--- a/scheduler/kube/kube.go
+++ b/scheduler/kube/kube.go
@@ -21,7 +21,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	batchv1 "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -52,6 +52,7 @@ func (s *kubeScheduler) Schedule(ctx context.Context, stage *core.Stage) error {
 	env := toEnvironment(
 		map[string]string{
 			"DRONE_RUNNER_PRIVILEGED_IMAGES": strings.Join(s.config.ImagePrivileged, ","),
+			"DRONE_RUNNER_ANNOTATIONS":       s.config.Annotations,
 			"DRONE_LIMIT_MEM":                fmt.Sprint(s.config.LimitMemory),
 			"DRONE_LIMIT_CPU":                fmt.Sprint(s.config.LimitCompute),
 			"DRONE_STAGE_ID":                 fmt.Sprint(stage.ID),
@@ -180,7 +181,7 @@ func (s *kubeScheduler) Cancel(ctx context.Context, id int64) error {
 			continue
 		}
 		err = s.client.BatchV1().Jobs(job.Namespace).Delete(job.Name, &metav1.DeleteOptions{
-		// GracePeriodSeconds
+			// GracePeriodSeconds
 		})
 		if err != nil {
 			result = multierror.Append(result, err)


### PR DESCRIPTION
This PR adds the DRONE_RUNNER_ANNOTATIONS config bit to be used by the kubernetes Runner. 

This is my first attempt at go, and I apologize in advance for any conventions that may be improper. I figured starting the conversation would be better than not trying at all

This work is to help close out https://github.com/drone/drone-runtime/issues/38