### PR TITLE
Fix nolimit tag build

### DIFF
--- a/service/license/nolimit.go
+++ b/service/license/nolimit.go
@@ -16,8 +16,12 @@
 
 package license
 
-// DefaultLicense is an empty license with no restrictions.
-var DefaultLicense = &License{Kind: LicenseFoss}
+import (
+    "github.com/drone/drone/core"
+)
 
-func Trial(string) *License         { return nil }
-func Load(string) (*License, error) { return DefaultLicense, nil }
+// DefaultLicense is an empty license with no restrictions.
+var DefaultLicense = &core.License{Kind: core.LicenseFoss}
+
+func Trial(string) *core.License         { return nil }
+func Load(string) (*core.License, error) { return DefaultLicense, nil }


### PR DESCRIPTION
This should fix the `nolimit` build when specified. 

Don't forget to specify the env variable `DRONE_LICENSE` to something NOT empty e.g. `/etc/drone.key` even if it doesn't exist, otherwise you get a SIGSEGV when running the binary.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x14c97fd]

goroutine 1 [running]:
main.provideLicense(0xc0002ab2b0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, ...)
/usr/src/myapp/cmd/drone-server/inject_license.go:45 +0xbd
main.InitializeApplication(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x1a3185c5000, ...)
/usr/src/myapp/cmd/drone-server/wire_gen.go:62 +0xc10
main.main()
/usr/src/myapp/cmd/drone-server/main.go:63 +0x3ab
```