### PR TITLE
Use branch form value as fallback for last build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - endpoint to trigger new build for branch, by [@bradrydzewski](https://github.com/bradrydzewski). [#2679](https://github.com/drone/drone/issues/2679).
 - endpoint to trigger new build for branch and sha, by [@bradrydzewski](https://github.com/bradrydzewski). [#2679](https://github.com/drone/drone/issues/2679).
 - DRONE_PROMETHEUS_ANONYMOUS_ACCESS configuration option, by [@janberktold](https://github.com/janberktold)
-- 
+
+### Fixed
+
+- allow to filter last builds by branch, by [@tboerger](https://github.com/tboerger).
+
 ## [1.1.0] - 2019-04-23
 ### Added
 
 - specify a user for the pipeline step, by [@bradrydzewski](https://github.com/bradrydzewski). [#2651](https://github.com/drone/drone/issues/2651).
 - support for Gitea oauth2, by [@techknowlogick](https://github.com/techknowlogick). [#2622](https://github.com/drone/drone/pull/2622).
 - ping the docker daemon before starting the agent, by [@bradrydzewski](https://github.com/bradrydzewski). [#2495](https://github.com/drone/drone/issues/2495).
-- support for Cron job name in Yaml trigger block, by [@bradrydzewski](https://github.com/bradrydzewski). [#2628](https://github.com/drone/drone/issues/2628). 
-- support for Cron job name in Yaml when block, by [@bradrydzewski](https://github.com/bradrydzewski). [#2628](https://github.com/drone/drone/issues/2628). 
+- support for Cron job name in Yaml trigger block, by [@bradrydzewski](https://github.com/bradrydzewski). [#2628](https://github.com/drone/drone/issues/2628).
+- support for Cron job name in Yaml when block, by [@bradrydzewski](https://github.com/bradrydzewski). [#2628](https://github.com/drone/drone/issues/2628).
 - sqlite username column changed to case-insensitive, by [@bradrydzewski](https://github.com/bradrydzewski).
 - endpoint to purge repository from database, by [@bradrydzewski](https://github.com/bradrydzewski).
 - support for per-organization secrets, by [@bradrydzewski](https://github.com/bradrydzewski).

--- a/handler/api/repos/builds/latest.go
+++ b/handler/api/repos/builds/latest.go
@@ -36,6 +36,7 @@ func HandleLast(
 			namespace = chi.URLParam(r, "owner")
 			name      = chi.URLParam(r, "name")
 			ref       = r.FormValue("ref")
+			branch    = r.FormValue("branch")
 		)
 		repo, err := repos.FindName(r.Context(), namespace, name)
 		if err != nil {
@@ -44,6 +45,9 @@ func HandleLast(
 		}
 		if ref == "" {
 			ref = fmt.Sprintf("refs/heads/%s", repo.Branch)
+		}
+		if branch != "" {
+			ref = fmt.Sprintf("refs/heads/%s", branch)
 		}
 		build, err := builds.FindRef(r.Context(), repo.ID, ref)
 		if err != nil {


### PR DESCRIPTION
The current version of the Drone CLI is still using the branch form
value to filter the latest build information while the server is
listening only for the ref form value. With this fix we are falling back
to branch form value if it gets defined, formats it as a ref and hands
it to the further functions.