### PR TITLE
Add EphemeralDisk to nomad env configuration

### DIFF
--- a/cmd/drone-server/config/config.go
+++ b/cmd/drone-server/config/config.go
@@ -145,6 +145,7 @@ type (
 		ImagePull   bool     `envconfig:"DRONE_NOMAD_IMAGE_PULL"`
 		Memory      int      `envconfig:"DRONE_NOMAD_DEFAULT_RAM" default:"1024"`
 		CPU         int      `envconfig:"DRONE_NOMAD_DEFAULT_CPU" default:"500"`
+		Disk        int      `envconfig:"DRONE_NOMAD_DEFAULT_DISK" default:"300"`
 	}
 
 	// License provides license configuration

--- a/cmd/drone-server/inject_scheduler.go
+++ b/cmd/drone-server/inject_scheduler.go
@@ -100,6 +100,7 @@ func provideNomadScheduler(config config.Config) core.Scheduler {
 		// LimitCompute:     config.Nomad.CPU,
 		RequestMemory:    config.Nomad.Memory,
 		RequestCompute:   config.Nomad.CPU,
+		EphemeralDisk:    config.Nomad.Disk,
 		CallbackHost:     config.RPC.Host,
 		CallbackProto:    config.RPC.Proto,
 		CallbackSecret:   config.RPC.Secret,

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,8 @@ github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uP
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-retryablehttp v0.0.0-20180718195005-e651d75abec6 h1:qCv4319q2q7XKn0MQbi8p37hsJ+9Xo8e6yojA73JVxk=
 github.com/hashicorp/go-retryablehttp v0.0.0-20180718195005-e651d75abec6/go.mod h1:fXcdFsQoipQa7mwORhKad5jmDCeSy/RCGzWA08PO0lM=
+github.com/hashicorp/go-rootcerts v1.0.0 h1:Rqb66Oo1X/eSV1x66xbDccZjhJigjg0+e82kpwzSwCI=
+github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/nomad v0.0.0-20190125003214-134391155854 h1:L7WhLZt2ory/kQWxqkMwOiBpIoa4BWoadN7yx8LHEtk=

--- a/scheduler/nomad/config.go
+++ b/scheduler/nomad/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	LimitCompute     int
 	RequestMemory    int
 	RequestCompute   int
+	EphemeralDisk    int
 	CallbackHost     string
 	CallbackProto    string
 	CallbackSecret   string

--- a/scheduler/nomad/nomad.go
+++ b/scheduler/nomad/nomad.go
@@ -108,6 +108,9 @@ func (s *nomadScheduler) Schedule(ctx context.Context, stage *core.Stage) error 
 				RestartPolicy: &api.RestartPolicy{
 					Mode: stringToPtr("fail"),
 				},
+				EphemeralDisk: &api.EphemeralDisk{
+					SizeMB: intToPtr(s.config.EphemeralDisk),
+				},
 			},
 		},
 		Meta: map[string]string{


### PR DESCRIPTION
When using nomad as a scheduler, the ephemeral disk allocated to each step is fixed at 300mb.  In most cases this is enough, but there are many in which a large disk is necessary (building docker images, compiling with webpack, etc) 