### PR TITLE
Use Proxy.Addr instead of Server.Addr for external links.

### DIFF
--- a/cmd/drone-server/inject_login.go
+++ b/cmd/drone-server/inject_login.go
@@ -66,7 +66,7 @@ func provideBitbucketLogin(config config.Config) login.Middleware {
 	return &bitbucket.Config{
 		ClientID:     config.Bitbucket.ClientID,
 		ClientSecret: config.Bitbucket.ClientSecret,
-		RedirectURL:  config.Server.Addr + "/login",
+		RedirectURL:  config.Proxy.Addr + "/login",
 	}
 }
 
@@ -99,7 +99,7 @@ func provideGiteaLogin(config config.Config) login.Middleware {
 			Server:       config.Gitea.Server,
 			Client:       defaultClient(config.Gitea.SkipVerify),
 			Logger:       logrus.StandardLogger(),
-			RedirectURL:  config.Server.Addr + "/login",
+			RedirectURL:  config.Proxy.Addr + "/login",
 			Scope:        config.Gitea.Scope,
 		}
 	}
@@ -120,7 +120,7 @@ func provideGitlabLogin(config config.Config) login.Middleware {
 	return &gitlab.Config{
 		ClientID:     config.GitLab.ClientID,
 		ClientSecret: config.GitLab.ClientSecret,
-		RedirectURL:  config.Server.Addr + "/login",
+		RedirectURL:  config.Proxy.Addr + "/login",
 		Server:       config.GitLab.Server,
 		Client:       defaultClient(config.GitLab.SkipVerify),
 	}
@@ -156,7 +156,7 @@ func provideStashLogin(config config.Config) login.Middleware {
 		ConsumerKey:    config.Stash.ConsumerKey,
 		ConsumerSecret: config.Stash.ConsumerSecret,
 		PrivateKey:     privateKey,
-		CallbackURL:    config.Server.Addr + "/login",
+		CallbackURL:    config.Proxy.Addr + "/login",
 		Client:         defaultClient(config.Stash.SkipVerify),
 	}
 }

--- a/cmd/drone-server/inject_service.go
+++ b/cmd/drone-server/inject_service.go
@@ -104,7 +104,7 @@ func provideSession(store core.UserStore, config config.Config) core.Session {
 // user service based on the environment configuration.
 func provideStatusService(client *scm.Client, renewer core.Renewer, config config.Config) core.StatusService {
 	return status.New(client, renewer, status.Config{
-		Base:     config.Server.Addr,
+		Base:     config.Proxy.Addr,
 		Name:     config.Status.Name,
 		Disabled: config.Status.Disabled,
 	})
@@ -133,7 +133,7 @@ func provideSystem(config config.Config) *core.System {
 	return &core.System{
 		Proto:   config.Server.Proto,
 		Host:    config.Server.Host,
-		Link:    config.Server.Addr,
+		Link:    config.Proxy.Addr,
 		Version: version.Version.String(),
 	}
 }


### PR DESCRIPTION
Fix that DRONE_SERVER_PROXY_HOST is not used for external links in gitea, github etc..
