### PR TITLE
bitbucket needs to get ref via branch, cant via heads

### DIFF
--- a/service/commit/commit.go
+++ b/service/commit/commit.go
@@ -16,7 +16,6 @@ package commit
 
 import (
 	"context"
-
 	"github.com/drone/drone/core"
 	"github.com/drone/go-scm/scm"
 )
@@ -77,6 +76,17 @@ func (s *service) FindRef(ctx context.Context, user *core.User, repo, ref string
 		Token:   user.Token,
 		Refresh: user.Refresh,
 	})
+
+	switch s.client.Driver {
+	case scm.DriverBitbucket:
+		ref = scm.TrimRef(ref)
+		branch, _, err := s.client.Git.FindBranch(ctx, repo, ref) // wont work for a Tag
+		if err != nil {
+			return nil, err
+		}
+		ref = branch.Sha
+	}
+
 	commit, _, err := s.client.Git.FindCommit(ctx, repo, ref)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
@bradrydzewski as discussed in gitter.

Bitbucket does not return a ref the same way as Github so the new feature to trigger a build for a branch was not working for Bitbucket.

This pull request shows a simple fix for the issue so we can discuss different ways of changing the code to get this fixed. 