### PR TITLE
Add support for v1.PodSpec.ImagePullSecrets on Kubernetes native Drone server

### DIFF
--- a/cmd/drone-server/config/config.go
+++ b/cmd/drone-server/config/config.go
@@ -124,14 +124,15 @@ type (
 
 	// Kubernetes provides kubernetes configuration
 	Kubernetes struct {
-		Enabled            bool   `envconfig:"DRONE_KUBERNETES_ENABLED"`
-		Namespace          string `envconfig:"DRONE_KUBERNETES_NAMESPACE"`
-		Path               string `envconfig:"DRONE_KUBERNETES_CONFIG_PATH"`
-		URL                string `envconfig:"DRONE_KUBERNETES_CONFIG_URL"`
-		TTL                int    `envconfig:"DRONE_KUBERNETES_TTL_AFTER_FINISHED" default:"300"`
-		ServiceAccountName string `envconfig:"DRONE_KUBERNETES_SERVICE_ACCOUNT"`
-		PullPolicy         string `envconfig:"DRONE_KUBERNETES_IMAGE_PULL" default:"Always"`
-		Image              string `envconfig:"DRONE_KUBERNETES_IMAGE"`
+		Enabled            bool     `envconfig:"DRONE_KUBERNETES_ENABLED"`
+		Namespace          string   `envconfig:"DRONE_KUBERNETES_NAMESPACE"`
+		Path               string   `envconfig:"DRONE_KUBERNETES_CONFIG_PATH"`
+		URL                string   `envconfig:"DRONE_KUBERNETES_CONFIG_URL"`
+		TTL                int      `envconfig:"DRONE_KUBERNETES_TTL_AFTER_FINISHED" default:"300"`
+		ServiceAccountName string   `envconfig:"DRONE_KUBERNETES_SERVICE_ACCOUNT"`
+		PullPolicy         string   `envconfig:"DRONE_KUBERNETES_IMAGE_PULL" default:"Always"`
+		PullSecrets        []string `envconfig:"DRONE_KUBERNETES_IMAGE_PULL_SECRETS"`
+		Image              string   `envconfig:"DRONE_KUBERNETES_IMAGE"`
 	}
 
 	// Nomad configuration.

--- a/cmd/drone-server/inject_scheduler.go
+++ b/cmd/drone-server/inject_scheduler.go
@@ -50,14 +50,15 @@ func provideScheduler(store core.StageStore, config config.Config) core.Schedule
 func provideKubernetesScheduler(config config.Config) core.Scheduler {
 	logrus.Info("main: kubernetes scheduler enabled")
 	sched, err := kube.FromConfig(kube.Config{
-		Namespace:       config.Kube.Namespace,
-		ServiceAccount:  config.Kube.ServiceAccountName,
-		ConfigURL:       config.Kube.URL,
-		ConfigPath:      config.Kube.Path,
-		TTL:             config.Kube.TTL,
-		Image:           config.Kube.Image,
-		ImagePullPolicy: config.Kube.PullPolicy,
-		ImagePrivileged: config.Runner.Privileged,
+		Namespace:        config.Kube.Namespace,
+		ServiceAccount:   config.Kube.ServiceAccountName,
+		ConfigURL:        config.Kube.URL,
+		ConfigPath:       config.Kube.Path,
+		TTL:              config.Kube.TTL,
+		Image:            config.Kube.Image,
+		ImagePullPolicy:  config.Kube.PullPolicy,
+		ImagePullSecrets: config.Kube.PullSecrets,
+		ImagePrivileged:  config.Runner.Privileged,
 		// LimitMemory:      config.Nomad.Memory,
 		// LimitCompute:     config.Nomad.CPU,
 		// RequestMemory:    config.Nomad.Memory,

--- a/scheduler/kube/config.go
+++ b/scheduler/kube/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	TTL              int
 	Image            string
 	ImagePullPolicy  string
+	ImagePullSecrets []string
 	ImagePrivileged  []string
 	DockerHost       string
 	DockerHostWin    string

--- a/scheduler/kube/kube.go
+++ b/scheduler/kube/kube.go
@@ -124,6 +124,10 @@ func (s *kubeScheduler) Schedule(ctx context.Context, stage *core.Stage) error {
 		},
 	}
 	volumes = append(volumes, volume)
+	pullSecrets := make([]v1.LocalObjectReference, len(s.config.ImagePullSecrets))
+	for i, s := range s.config.ImagePullSecrets {
+		pullSecrets[i].Name = s
+	}
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -147,6 +151,7 @@ func (s *kubeScheduler) Schedule(ctx context.Context, stage *core.Stage) error {
 				Spec: v1.PodSpec{
 					ServiceAccountName: s.config.ServiceAccount,
 					RestartPolicy:      v1.RestartPolicyNever,
+					ImagePullSecrets:   pullSecrets,
 					Containers: []v1.Container{{
 						Name:            "drone-controller",
 						Image:           internal.DefaultImage(s.config.Image),


### PR DESCRIPTION
When using a private registry with authentication in Kubernetes, jobs get stuck in "ImagePullBackoff" state. This PR adds support for ImagePullSecrets when creating the Kubernetes Job, so the job can start.

To use the feature, set the env. var. DRONE_KUBERNETES_IMAGE_PULL_SECRETS to the name of the k8s secret for the private registry when deploying the Kubernetes native Drone server.