### PR TITLE
Add id column in migrations table for MySQL Group Replication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@
 .env.*
 release/
 scripts/
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .env.*
 release/
 scripts/
+.idea/

--- a/go.sum
+++ b/go.sum
@@ -176,6 +176,7 @@ github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uP
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-retryablehttp v0.0.0-20180718195005-e651d75abec6 h1:qCv4319q2q7XKn0MQbi8p37hsJ+9Xo8e6yojA73JVxk=
 github.com/hashicorp/go-retryablehttp v0.0.0-20180718195005-e651d75abec6/go.mod h1:fXcdFsQoipQa7mwORhKad5jmDCeSy/RCGzWA08PO0lM=
+github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/nomad v0.0.0-20190125003214-134391155854 h1:L7WhLZt2ory/kQWxqkMwOiBpIoa4BWoadN7yx8LHEtk=

--- a/store/shared/migrate/mysql/ddl_gen.go
+++ b/store/shared/migrate/mysql/ddl_gen.go
@@ -186,6 +186,7 @@ func selectCompleted(db *sql.DB) (map[string]struct{}, error) {
 
 var migrationTableCreate = `
 CREATE TABLE IF NOT EXISTS migrations (
+ id INTEGER PRIMARY KEY AUTO_INCREMENT,
  name VARCHAR(255)
 ,UNIQUE(name)
 )


### PR DESCRIPTION
Need PK each table on MySQL Group Replication.
```
2019-08-03T19:22:34.446530Z 80836 [ERROR] [MY-011542] [Repl] Plugin group_replication reported: 'Table migrations does not have any PRIMARY KEY. This is not compatible with Group Replication.'
```

Run drone and add id primary key, It’s worked.