### PR TITLE
DRONE_TRUSTED_ENVIRONMENT Env variable added:

### DIFF
--- a/cmd/drone-server/config/config.go
+++ b/cmd/drone-server/config/config.go
@@ -231,13 +231,14 @@ type (
 
 	// Server provides the server configuration.
 	Server struct {
-		Addr  string `envconfig:"-"`
-		Host  string `envconfig:"DRONE_SERVER_HOST" default:"localhost:8080"`
-		Port  string `envconfig:"DRONE_SERVER_PORT" default:":8080"`
-		Proto string `envconfig:"DRONE_SERVER_PROTO" default:"http"`
-		Acme  bool   `envconfig:"DRONE_TLS_AUTOCERT"`
-		Cert  string `envconfig:"DRONE_TLS_CERT"`
-		Key   string `envconfig:"DRONE_TLS_KEY"`
+		Addr    string `envconfig:"-"`
+		Host    string `envconfig:"DRONE_SERVER_HOST" default:"localhost:8080"`
+		Port    string `envconfig:"DRONE_SERVER_PORT" default:":8080"`
+		Proto   string `envconfig:"DRONE_SERVER_PROTO" default:"http"`
+		Acme    bool   `envconfig:"DRONE_TLS_AUTOCERT"`
+		Cert    string `envconfig:"DRONE_TLS_CERT"`
+		Key     string `envconfig:"DRONE_TLS_KEY"`
+		Trusted bool   `envconfig:"DRONE_TRUSTED_ENVIRONMENT"`
 	}
 
 	// Proxy provides proxy server configuration.

--- a/cmd/drone-server/inject_service.go
+++ b/cmd/drone-server/inject_service.go
@@ -49,7 +49,6 @@ var serviceSet = wire.NewSet(
 	orgs.New,
 	parser.New,
 	pubsub.New,
-	repo.New,
 	token.Renewer,
 	trigger.New,
 	user.New,
@@ -57,6 +56,7 @@ var serviceSet = wire.NewSet(
 	provideContentService,
 	provideDatadog,
 	provideHookService,
+	provideRepositoryService,
 	provideNetrcService,
 	provideSession,
 	provideStatusService,
@@ -76,6 +76,12 @@ func provideContentService(client *scm.Client, renewer core.Renewer) core.FileSe
 // hook service based on the environment configuration.
 func provideHookService(client *scm.Client, renewer core.Renewer, config config.Config) core.HookService {
 	return hook.New(client, config.Proxy.Addr, renewer)
+}
+
+// provideRepositoryService is a Wire provider function that returns a
+// repository service based on the environment configuration.
+func provideRepositoryService(client *scm.Client, renewer core.Renewer, config config.Config) core.RepositoryService {
+	return repo.New(client, renewer, config.Server.Trusted)
 }
 
 // provideNetrcService is a Wire provider function that returns

--- a/cmd/drone-server/wire_gen.go
+++ b/cmd/drone-server/wire_gen.go
@@ -16,7 +16,6 @@ import (
 	"github.com/drone/drone/service/hook/parser"
 	"github.com/drone/drone/service/license"
 	"github.com/drone/drone/service/org"
-	"github.com/drone/drone/service/repo"
 	"github.com/drone/drone/service/token"
 	"github.com/drone/drone/service/user"
 	"github.com/drone/drone/store/batch"
@@ -79,7 +78,7 @@ func InitializeApplication(config2 config.Config) (application, error) {
 	hookService := provideHookService(client, renewer, config2)
 	licenseService := license.NewService(userStore, repositoryStore, buildStore, coreLicense)
 	permStore := perm.New(db)
-	repositoryService := repo.New(client, renewer)
+	repositoryService := provideRepositoryService(client, renewer, config2)
 	session, err := provideSession(userStore, config2)
 	if err != nil {
 		return application{}, err

--- a/service/repo/repo.go
+++ b/service/repo/repo.go
@@ -22,16 +22,18 @@ import (
 )
 
 type service struct {
-	renew  core.Renewer
-	client *scm.Client
+	renew              core.Renewer
+	client             *scm.Client
+	trustedEnvironment bool
 }
 
 // New returns a new Repository service, providing access to the
 // repository information from the source code management system.
-func New(client *scm.Client, renewer core.Renewer) core.RepositoryService {
+func New(client *scm.Client, renewer core.Renewer, trustedEnvironment bool) core.RepositoryService {
 	return &service{
-		renew:  renewer,
-		client: client,
+		renew:              renewer,
+		client:             client,
+		trustedEnvironment: trustedEnvironment,
 	}
 }
 
@@ -52,8 +54,9 @@ func (s *service) List(ctx context.Context, user *core.User) ([]*core.Repository
 		if err != nil {
 			return nil, err
 		}
+
 		for _, src := range result {
-			repos = append(repos, convertRepository(src))
+			repos = append(repos, convertRepository(src, s.trustedEnvironment))
 		}
 		opts.Page = meta.Page.Next
 		opts.URL = meta.Page.NextURL
@@ -79,7 +82,7 @@ func (s *service) Find(ctx context.Context, user *core.User, repo string) (*core
 	if err != nil {
 		return nil, err
 	}
-	return convertRepository(result), nil
+	return convertRepository(result, s.trustedEnvironment), nil
 }
 
 func (s *service) FindPerm(ctx context.Context, user *core.User, repo string) (*core.Perm, error) {

--- a/service/repo/repo_test.go
+++ b/service/repo/repo_test.go
@@ -8,9 +8,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/drone/drone/core"
 	"github.com/drone/drone/mock"
 	"github.com/drone/drone/mock/mockscm"
-	"github.com/drone/drone/core"
 	"github.com/drone/go-scm/scm"
 	"github.com/google/go-cmp/cmp"
 
@@ -38,7 +38,7 @@ func TestFind(t *testing.T) {
 	client := new(scm.Client)
 	client.Repositories = mockRepoService
 
-	service := New(client, mockRenewer)
+	service := New(client, mockRenewer, false)
 
 	want := &core.Repository{
 		Namespace:  "octocat",
@@ -71,7 +71,7 @@ func TestFind_Err(t *testing.T) {
 	client := new(scm.Client)
 	client.Repositories = mockRepoService
 
-	service := New(client, mockRenewer)
+	service := New(client, mockRenewer, false)
 	_, err := service.Find(noContext, mockUser, "octocat/hello-world")
 	if err != scm.ErrNotFound {
 		t.Errorf("Expect not found error, got %v", err)
@@ -87,7 +87,7 @@ func TestFind_RefreshErr(t *testing.T) {
 	mockRenewer := mock.NewMockRenewer(controller)
 	mockRenewer.EXPECT().Renew(gomock.Any(), mockUser, false).Return(scm.ErrNotAuthorized)
 
-	service := New(nil, mockRenewer)
+	service := New(nil, mockRenewer, false)
 	_, err := service.Find(noContext, mockUser, "octocat/hello-world")
 	if err == nil {
 		t.Errorf("Expect error refreshing token")
@@ -114,7 +114,7 @@ func TestFindPerm(t *testing.T) {
 	client := new(scm.Client)
 	client.Repositories = mockRepoService
 
-	service := New(client, mockRenewer)
+	service := New(client, mockRenewer, false)
 
 	want := &core.Perm{
 		Read:  true,
@@ -146,7 +146,7 @@ func TestFindPerm_Err(t *testing.T) {
 	client := new(scm.Client)
 	client.Repositories = mockRepoService
 
-	service := New(client, mockRenewer)
+	service := New(client, mockRenewer, false)
 	_, err := service.FindPerm(noContext, mockUser, "octocat/hello-world")
 	if err != scm.ErrNotFound {
 		t.Errorf("Expect not found error, got %v", err)
@@ -162,7 +162,7 @@ func TestFindPerm_RefreshErr(t *testing.T) {
 	mockRenewer := mock.NewMockRenewer(controller)
 	mockRenewer.EXPECT().Renew(gomock.Any(), mockUser, false).Return(scm.ErrNotAuthorized)
 
-	service := New(nil, mockRenewer)
+	service := New(nil, mockRenewer, false)
 	_, err := service.FindPerm(noContext, mockUser, "octocat/hello-world")
 	if err == nil {
 		t.Errorf("Expect error refreshing token")
@@ -199,7 +199,7 @@ func TestList(t *testing.T) {
 		},
 	}
 
-	service := New(client, mockRenewer)
+	service := New(client, mockRenewer, false)
 	got, err := service.List(noContext, mockUser)
 	if err != nil {
 		t.Error(err)
@@ -224,7 +224,7 @@ func TestList_Err(t *testing.T) {
 	client := new(scm.Client)
 	client.Repositories = mockRepoService
 
-	service := New(client, mockRenewer)
+	service := New(client, mockRenewer, false)
 	_, err := service.List(noContext, mockUser)
 	if err != scm.ErrNotAuthorized {
 		t.Errorf("Want not authorized error, got %v", err)
@@ -240,7 +240,7 @@ func TestList_RefreshErr(t *testing.T) {
 	mockRenewer := mock.NewMockRenewer(controller)
 	mockRenewer.EXPECT().Renew(gomock.Any(), mockUser, false).Return(scm.ErrNotAuthorized)
 
-	service := New(nil, mockRenewer)
+	service := New(nil, mockRenewer, false)
 	_, err := service.List(noContext, mockUser)
 	if err == nil {
 		t.Errorf("Expect error refreshing token")

--- a/service/repo/util.go
+++ b/service/repo/util.go
@@ -22,7 +22,7 @@ import (
 // convertRepository is a helper function that converts a
 // repository from the source code management system to the
 // local datastructure.
-func convertRepository(src *scm.Repository) *core.Repository {
+func convertRepository(src *scm.Repository, TrustedEnvironment bool) *core.Repository {
 	return &core.Repository{
 		UID:        src.ID,
 		Namespace:  src.Namespace,
@@ -34,6 +34,7 @@ func convertRepository(src *scm.Repository) *core.Repository {
 		Private:    src.Private,
 		Visibility: convertVisibility(src),
 		Branch:     src.Branch,
+		Trusted:    TrustedEnvironment,
 	}
 }
 

--- a/service/repo/util_test.go
+++ b/service/repo/util_test.go
@@ -36,7 +36,7 @@ func TestConvertRepository(t *testing.T) {
 		Branch:     "master",
 		Visibility: core.VisibilityPrivate,
 	}
-	got := convertRepository(from)
+	got := convertRepository(from, false)
 	if diff := cmp.Diff(want, got); len(diff) != 0 {
 		t.Errorf(diff)
 	}


### PR DESCRIPTION
This environment variable will allow to make repositories trusted, when enabling them in drone by default
It is recommended to use `DRONE_TRUSTED_ENVIRONMENT=true` only in scenarios, where you are running drone master and drone agents for single trusted organization

