### PR TITLE
feat(repo): allow internal project visibility by default

### DIFF
--- a/cmd/drone-server/config/config.go
+++ b/cmd/drone-server/config/config.go
@@ -173,7 +173,8 @@ type (
 
 	// Repository provides the repository configuration.
 	Repository struct {
-		Filter []string `envconfig:"DRONE_REPOSITORY_FILTER"`
+		Filter     []string `envconfig:"DRONE_REPOSITORY_FILTER"`
+		Visibility string   `envconfig:"DRONE_REPOSITORY_VISIBILITY"`
 	}
 
 	// Registries provides the registry configuration.

--- a/cmd/drone-server/inject_service.go
+++ b/cmd/drone-server/inject_service.go
@@ -49,11 +49,11 @@ var serviceSet = wire.NewSet(
 	orgs.New,
 	parser.New,
 	pubsub.New,
-	repo.New,
 	token.Renewer,
 	trigger.New,
 	user.New,
 
+	provideRepositoryService,
 	provideContentService,
 	provideDatadog,
 	provideHookService,
@@ -87,6 +87,16 @@ func provideNetrcService(client *scm.Client, renewer core.Renewer, config config
 		config.Cloning.AlwaysAuth,
 		config.Cloning.Username,
 		config.Cloning.Password,
+	)
+}
+
+// provideRepo is a Wire provider function that returns
+// a repo based on the environment configuration
+func provideRepositoryService(client *scm.Client, renewer core.Renewer, config config.Config) core.RepositoryService {
+	return repo.New(
+		client,
+		renewer,
+		config.Repository.Visibility,
 	)
 }
 

--- a/cmd/drone-server/wire_gen.go
+++ b/cmd/drone-server/wire_gen.go
@@ -16,7 +16,6 @@ import (
 	"github.com/drone/drone/service/hook/parser"
 	"github.com/drone/drone/service/license"
 	"github.com/drone/drone/service/org"
-	"github.com/drone/drone/service/repo"
 	"github.com/drone/drone/service/token"
 	"github.com/drone/drone/service/user"
 	"github.com/drone/drone/store/batch"
@@ -81,7 +80,7 @@ func InitializeApplication(config2 config.Config) (application, error) {
 	hookService := provideHookService(client, renewer, config2)
 	licenseService := license.NewService(userStore, repositoryStore, buildStore, coreLicense)
 	permStore := perm.New(db)
-	repositoryService := repo.New(client, renewer)
+	repositoryService := provideRepositoryService(client, renewer, config2)
 	session, err := provideSession(userStore, config2)
 	if err != nil {
 		return application{}, err

--- a/service/repo/repo.go
+++ b/service/repo/repo.go
@@ -22,16 +22,18 @@ import (
 )
 
 type service struct {
-	renew  core.Renewer
-	client *scm.Client
+	renew      core.Renewer
+	client     *scm.Client
+	visibility string
 }
 
 // New returns a new Repository service, providing access to the
 // repository information from the source code management system.
-func New(client *scm.Client, renewer core.Renewer) core.RepositoryService {
+func New(client *scm.Client, renewer core.Renewer, visibility string) core.RepositoryService {
 	return &service{
-		renew:  renewer,
-		client: client,
+		renew:      renewer,
+		client:     client,
+		visibility: visibility,
 	}
 }
 
@@ -53,7 +55,7 @@ func (s *service) List(ctx context.Context, user *core.User) ([]*core.Repository
 			return nil, err
 		}
 		for _, src := range result {
-			repos = append(repos, convertRepository(src))
+			repos = append(repos, convertRepository(src, s.visibility))
 		}
 		opts.Page = meta.Page.Next
 		opts.URL = meta.Page.NextURL
@@ -79,7 +81,7 @@ func (s *service) Find(ctx context.Context, user *core.User, repo string) (*core
 	if err != nil {
 		return nil, err
 	}
-	return convertRepository(result), nil
+	return convertRepository(result, s.visibility), nil
 }
 
 func (s *service) FindPerm(ctx context.Context, user *core.User, repo string) (*core.Perm, error) {

--- a/service/repo/repo_test.go
+++ b/service/repo/repo_test.go
@@ -8,9 +8,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/drone/drone/core"
 	"github.com/drone/drone/mock"
 	"github.com/drone/drone/mock/mockscm"
-	"github.com/drone/drone/core"
 	"github.com/drone/go-scm/scm"
 	"github.com/google/go-cmp/cmp"
 
@@ -38,7 +38,7 @@ func TestFind(t *testing.T) {
 	client := new(scm.Client)
 	client.Repositories = mockRepoService
 
-	service := New(client, mockRenewer)
+	service := New(client, mockRenewer, "")
 
 	want := &core.Repository{
 		Namespace:  "octocat",
@@ -71,7 +71,7 @@ func TestFind_Err(t *testing.T) {
 	client := new(scm.Client)
 	client.Repositories = mockRepoService
 
-	service := New(client, mockRenewer)
+	service := New(client, mockRenewer, "")
 	_, err := service.Find(noContext, mockUser, "octocat/hello-world")
 	if err != scm.ErrNotFound {
 		t.Errorf("Expect not found error, got %v", err)
@@ -87,7 +87,7 @@ func TestFind_RefreshErr(t *testing.T) {
 	mockRenewer := mock.NewMockRenewer(controller)
 	mockRenewer.EXPECT().Renew(gomock.Any(), mockUser, false).Return(scm.ErrNotAuthorized)
 
-	service := New(nil, mockRenewer)
+	service := New(nil, mockRenewer, "")
 	_, err := service.Find(noContext, mockUser, "octocat/hello-world")
 	if err == nil {
 		t.Errorf("Expect error refreshing token")
@@ -114,7 +114,7 @@ func TestFindPerm(t *testing.T) {
 	client := new(scm.Client)
 	client.Repositories = mockRepoService
 
-	service := New(client, mockRenewer)
+	service := New(client, mockRenewer, "")
 
 	want := &core.Perm{
 		Read:  true,
@@ -146,7 +146,7 @@ func TestFindPerm_Err(t *testing.T) {
 	client := new(scm.Client)
 	client.Repositories = mockRepoService
 
-	service := New(client, mockRenewer)
+	service := New(client, mockRenewer, "")
 	_, err := service.FindPerm(noContext, mockUser, "octocat/hello-world")
 	if err != scm.ErrNotFound {
 		t.Errorf("Expect not found error, got %v", err)
@@ -162,7 +162,7 @@ func TestFindPerm_RefreshErr(t *testing.T) {
 	mockRenewer := mock.NewMockRenewer(controller)
 	mockRenewer.EXPECT().Renew(gomock.Any(), mockUser, false).Return(scm.ErrNotAuthorized)
 
-	service := New(nil, mockRenewer)
+	service := New(nil, mockRenewer, "")
 	_, err := service.FindPerm(noContext, mockUser, "octocat/hello-world")
 	if err == nil {
 		t.Errorf("Expect error refreshing token")
@@ -199,7 +199,7 @@ func TestList(t *testing.T) {
 		},
 	}
 
-	service := New(client, mockRenewer)
+	service := New(client, mockRenewer, "")
 	got, err := service.List(noContext, mockUser)
 	if err != nil {
 		t.Error(err)
@@ -224,7 +224,7 @@ func TestList_Err(t *testing.T) {
 	client := new(scm.Client)
 	client.Repositories = mockRepoService
 
-	service := New(client, mockRenewer)
+	service := New(client, mockRenewer, "")
 	_, err := service.List(noContext, mockUser)
 	if err != scm.ErrNotAuthorized {
 		t.Errorf("Want not authorized error, got %v", err)
@@ -240,7 +240,7 @@ func TestList_RefreshErr(t *testing.T) {
 	mockRenewer := mock.NewMockRenewer(controller)
 	mockRenewer.EXPECT().Renew(gomock.Any(), mockUser, false).Return(scm.ErrNotAuthorized)
 
-	service := New(nil, mockRenewer)
+	service := New(nil, mockRenewer, "")
 	_, err := service.List(noContext, mockUser)
 	if err == nil {
 		t.Errorf("Expect error refreshing token")

--- a/service/repo/util.go
+++ b/service/repo/util.go
@@ -22,7 +22,7 @@ import (
 // convertRepository is a helper function that converts a
 // repository from the source code management system to the
 // local datastructure.
-func convertRepository(src *scm.Repository) *core.Repository {
+func convertRepository(src *scm.Repository, visibility string) *core.Repository {
 	return &core.Repository{
 		UID:        src.ID,
 		Namespace:  src.Namespace,
@@ -32,17 +32,19 @@ func convertRepository(src *scm.Repository) *core.Repository {
 		SSHURL:     src.CloneSSH,
 		Link:       src.Link,
 		Private:    src.Private,
-		Visibility: convertVisibility(src),
+		Visibility: convertVisibility(src, visibility),
 		Branch:     src.Branch,
 	}
 }
 
 // convertVisibility is a helper function that returns the
 // repository visibility based on the privacy flag.
-func convertVisibility(src *scm.Repository) string {
+func convertVisibility(src *scm.Repository, visibility string) string {
 	switch {
 	case src.Private == true:
 		return core.VisibilityPrivate
+	case visibility == core.VisibilityInternal:
+		return core.VisibilityInternal
 	default:
 		return core.VisibilityPublic
 	}

--- a/service/repo/util_test.go
+++ b/service/repo/util_test.go
@@ -36,7 +36,7 @@ func TestConvertRepository(t *testing.T) {
 		Branch:     "master",
 		Visibility: core.VisibilityPrivate,
 	}
-	got := convertRepository(from)
+	got := convertRepository(from, "")
 	if diff := cmp.Diff(want, got); len(diff) != 0 {
 		t.Errorf(diff)
 	}
@@ -58,8 +58,37 @@ func TestConvertVisibility(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if got, want := convertVisibility(test.r), test.v; got != want {
+		if got, want := convertVisibility(test.r, ""), test.v; got != want {
 			t.Errorf("Want visibility %s, got %s for index %d", got, want, i)
 		}
+	}
+}
+
+func TestDefinedVisibility(t *testing.T) {
+	from := &scm.Repository{
+		ID:        "42",
+		Namespace: "octocat",
+		Name:      "hello-world",
+		Branch:    "master",
+		Private:   false,
+		Clone:     "https://github.com/octocat/hello-world.git",
+		CloneSSH:  "git@github.com:octocat/hello-world.git",
+		Link:      "https://github.com/octocat/hello-world",
+	}
+	want := &core.Repository{
+		UID:        "42",
+		Namespace:  "octocat",
+		Name:       "hello-world",
+		Slug:       "octocat/hello-world",
+		HTTPURL:    "https://github.com/octocat/hello-world.git",
+		SSHURL:     "git@github.com:octocat/hello-world.git",
+		Link:       "https://github.com/octocat/hello-world",
+		Private:    false,
+		Branch:     "master",
+		Visibility: core.VisibilityInternal,
+	}
+	got := convertRepository(from, "internal")
+	if diff := cmp.Diff(want, got); len(diff) != 0 {
+		t.Errorf(diff)
 	}
 }


### PR DESCRIPTION
This partially solves the issue #2825. However, I ran into issues when testing this on an existing drone instance/database where existing repositories (unactivated) are already written to the database with the relevant visibility, and this code does **not** update the database in that scenario. Creating net-new repos in the scm or utilizing a new-net database makes the code work as expected.

Open to suggestions on resolving the database for existing instances.