### PR TITLE
Upgraded to Go 1.13.0 due to segmentation faults on ARM devices

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,12 +9,12 @@ platform:
 
 steps:
 - name: test
-  image: golang:1.12.9
+  image: golang:1.13.0
   commands:
   - go test ./...
   
 - name: build
-  image: golang:1.12.9
+  image: golang:1.13.0
   commands:
   - sh scripts/build.sh
   environment:
@@ -80,7 +80,7 @@ platform:
 
 steps:
 - name: build
-  image: golang:1.12.9
+  image: golang:1.13.0
   commands:
   - sh scripts/build.sh
   environment:
@@ -142,7 +142,7 @@ platform:
 
 steps:
 - name: build
-  image: golang:1.12.9
+  image: golang:1.13.0
   commands:
   - sh scripts/build.sh
   environment:


### PR DESCRIPTION
Upgraded to Go 1.13.0 due to segmentation faults on ARM devices (Fixed #2823)

