### PR TITLE
DRONE_REPOSITORY_TRUSTED env variable added:

### DIFF
--- a/cmd/drone-server/config/config.go
+++ b/cmd/drone-server/config/config.go
@@ -175,6 +175,7 @@ type (
 	Repository struct {
 		Filter     []string `envconfig:"DRONE_REPOSITORY_FILTER"`
 		Visibility string   `envconfig:"DRONE_REPOSITORY_VISIBILITY"`
+		Trusted    bool     `envconfig:"DRONE_REPOSITORY_TRUSTED"`
 	}
 
 	// Registries provides the registry configuration.

--- a/cmd/drone-server/inject_service.go
+++ b/cmd/drone-server/inject_service.go
@@ -97,6 +97,7 @@ func provideRepositoryService(client *scm.Client, renewer core.Renewer, config c
 		client,
 		renewer,
 		config.Repository.Visibility,
+		config.Repository.Trusted,
 	)
 }
 

--- a/service/repo/repo.go
+++ b/service/repo/repo.go
@@ -25,15 +25,17 @@ type service struct {
 	renew      core.Renewer
 	client     *scm.Client
 	visibility string
+	trusted    bool
 }
 
 // New returns a new Repository service, providing access to the
 // repository information from the source code management system.
-func New(client *scm.Client, renewer core.Renewer, visibility string) core.RepositoryService {
+func New(client *scm.Client, renewer core.Renewer, visibility string, trusted bool) core.RepositoryService {
 	return &service{
 		renew:      renewer,
 		client:     client,
 		visibility: visibility,
+		trusted:    trusted,
 	}
 }
 
@@ -55,7 +57,7 @@ func (s *service) List(ctx context.Context, user *core.User) ([]*core.Repository
 			return nil, err
 		}
 		for _, src := range result {
-			repos = append(repos, convertRepository(src, s.visibility))
+			repos = append(repos, convertRepository(src, s.visibility, s.trusted))
 		}
 		opts.Page = meta.Page.Next
 		opts.URL = meta.Page.NextURL
@@ -81,7 +83,7 @@ func (s *service) Find(ctx context.Context, user *core.User, repo string) (*core
 	if err != nil {
 		return nil, err
 	}
-	return convertRepository(result, s.visibility), nil
+	return convertRepository(result, s.visibility, s.trusted), nil
 }
 
 func (s *service) FindPerm(ctx context.Context, user *core.User, repo string) (*core.Perm, error) {

--- a/service/repo/repo_test.go
+++ b/service/repo/repo_test.go
@@ -38,7 +38,7 @@ func TestFind(t *testing.T) {
 	client := new(scm.Client)
 	client.Repositories = mockRepoService
 
-	service := New(client, mockRenewer, "")
+	service := New(client, mockRenewer, "", false)
 
 	want := &core.Repository{
 		Namespace:  "octocat",
@@ -71,7 +71,7 @@ func TestFind_Err(t *testing.T) {
 	client := new(scm.Client)
 	client.Repositories = mockRepoService
 
-	service := New(client, mockRenewer, "")
+	service := New(client, mockRenewer, "", false)
 	_, err := service.Find(noContext, mockUser, "octocat/hello-world")
 	if err != scm.ErrNotFound {
 		t.Errorf("Expect not found error, got %v", err)
@@ -87,7 +87,7 @@ func TestFind_RefreshErr(t *testing.T) {
 	mockRenewer := mock.NewMockRenewer(controller)
 	mockRenewer.EXPECT().Renew(gomock.Any(), mockUser, false).Return(scm.ErrNotAuthorized)
 
-	service := New(nil, mockRenewer, "")
+	service := New(nil, mockRenewer, "", false)
 	_, err := service.Find(noContext, mockUser, "octocat/hello-world")
 	if err == nil {
 		t.Errorf("Expect error refreshing token")
@@ -114,7 +114,7 @@ func TestFindPerm(t *testing.T) {
 	client := new(scm.Client)
 	client.Repositories = mockRepoService
 
-	service := New(client, mockRenewer, "")
+	service := New(client, mockRenewer, "", false)
 
 	want := &core.Perm{
 		Read:  true,
@@ -146,7 +146,7 @@ func TestFindPerm_Err(t *testing.T) {
 	client := new(scm.Client)
 	client.Repositories = mockRepoService
 
-	service := New(client, mockRenewer, "")
+	service := New(client, mockRenewer, "", false)
 	_, err := service.FindPerm(noContext, mockUser, "octocat/hello-world")
 	if err != scm.ErrNotFound {
 		t.Errorf("Expect not found error, got %v", err)
@@ -162,7 +162,7 @@ func TestFindPerm_RefreshErr(t *testing.T) {
 	mockRenewer := mock.NewMockRenewer(controller)
 	mockRenewer.EXPECT().Renew(gomock.Any(), mockUser, false).Return(scm.ErrNotAuthorized)
 
-	service := New(nil, mockRenewer, "")
+	service := New(nil, mockRenewer, "", false)
 	_, err := service.FindPerm(noContext, mockUser, "octocat/hello-world")
 	if err == nil {
 		t.Errorf("Expect error refreshing token")
@@ -199,7 +199,7 @@ func TestList(t *testing.T) {
 		},
 	}
 
-	service := New(client, mockRenewer, "")
+	service := New(client, mockRenewer, "", false)
 	got, err := service.List(noContext, mockUser)
 	if err != nil {
 		t.Error(err)
@@ -224,7 +224,7 @@ func TestList_Err(t *testing.T) {
 	client := new(scm.Client)
 	client.Repositories = mockRepoService
 
-	service := New(client, mockRenewer, "")
+	service := New(client, mockRenewer, "", false)
 	_, err := service.List(noContext, mockUser)
 	if err != scm.ErrNotAuthorized {
 		t.Errorf("Want not authorized error, got %v", err)
@@ -240,7 +240,7 @@ func TestList_RefreshErr(t *testing.T) {
 	mockRenewer := mock.NewMockRenewer(controller)
 	mockRenewer.EXPECT().Renew(gomock.Any(), mockUser, false).Return(scm.ErrNotAuthorized)
 
-	service := New(nil, mockRenewer, "")
+	service := New(nil, mockRenewer, "", false)
 	_, err := service.List(noContext, mockUser)
 	if err == nil {
 		t.Errorf("Expect error refreshing token")

--- a/service/repo/util.go
+++ b/service/repo/util.go
@@ -22,7 +22,7 @@ import (
 // convertRepository is a helper function that converts a
 // repository from the source code management system to the
 // local datastructure.
-func convertRepository(src *scm.Repository, visibility string) *core.Repository {
+func convertRepository(src *scm.Repository, visibility string, trusted bool) *core.Repository {
 	return &core.Repository{
 		UID:        src.ID,
 		Namespace:  src.Namespace,
@@ -34,6 +34,7 @@ func convertRepository(src *scm.Repository, visibility string) *core.Repository 
 		Private:    src.Private,
 		Visibility: convertVisibility(src, visibility),
 		Branch:     src.Branch,
+		Trusted:    trusted,
 	}
 }
 

--- a/service/repo/util_test.go
+++ b/service/repo/util_test.go
@@ -36,7 +36,7 @@ func TestConvertRepository(t *testing.T) {
 		Branch:     "master",
 		Visibility: core.VisibilityPrivate,
 	}
-	got := convertRepository(from, "")
+	got := convertRepository(from, "", false)
 	if diff := cmp.Diff(want, got); len(diff) != 0 {
 		t.Errorf(diff)
 	}
@@ -87,7 +87,7 @@ func TestDefinedVisibility(t *testing.T) {
 		Branch:     "master",
 		Visibility: core.VisibilityInternal,
 	}
-	got := convertRepository(from, "internal")
+	got := convertRepository(from, "internal", false)
 	if diff := cmp.Diff(want, got); len(diff) != 0 {
 		t.Errorf(diff)
 	}


### PR DESCRIPTION
This environment variable will allow to make repositories trusted, when enabling them in drone by default
It is recommended to use `DRONE_REPOSITORY_TRUSTED=true` only in scenarios, where you are running drone master and drone agents for single trusted organization

