### PR TITLE
Fix Dropped operator Errors

### DIFF
--- a/operator/manager/manager.go
+++ b/operator/manager/manager.go
@@ -294,6 +294,11 @@ func (m *Manager) Details(ctx context.Context, id int64) (*Context, error) {
 		Repo:   repo,
 		User:   user,
 	})
+	if err != nil {
+		logger = logger.WithError(err)
+		logger.Warnln("manager: cannot convert configuration")
+		return nil, err
+	}
 	var secrets []*core.Secret
 	tmpSecrets, err := m.Secrets.List(noContext, repo.ID)
 	if err != nil {

--- a/operator/runner/runner.go
+++ b/operator/runner/runner.go
@@ -204,7 +204,7 @@ func (r *Runner) Run(ctx context.Context, id int64) error {
 		return env
 	})
 	if err != nil {
-		return err
+		return r.handleError(ctx, m.Stage, err)
 	}
 
 	manifest, err := yaml.ParseString(y)

--- a/operator/runner/runner.go
+++ b/operator/runner/runner.go
@@ -203,6 +203,9 @@ func (r *Runner) Run(ctx context.Context, id int64) error {
 		}
 		return env
 	})
+	if err != nil {
+		return err
+	}
 
 	manifest, err := yaml.ParseString(y)
 	if err != nil {


### PR DESCRIPTION
This PR picks off two dropped errors, one in `operator/manager` and the other in `operator/runner`.