### PR TITLE
plugin/webhook: fix dropped error

### DIFF
--- a/plugin/webhook/webhook.go
+++ b/plugin/webhook/webhook.go
@@ -95,6 +95,9 @@ func (s *sender) send(endpoint, secret, event string, data []byte) error {
 	req.Header.Add("Digest", "SHA-256="+digest(data))
 	req.Header.Add("Date", time.Now().UTC().Format(http.TimeFormat))
 	err = signer.SignRequest("hmac-key", s.Secret, req)
+	if err != nil {
+		return err
+	}
 	res, err := s.client().Do(req)
 	if res != nil {
 		res.Body.Close()


### PR DESCRIPTION
This PR fixes a dropped `error` in `plugin/webhook`.