### PR TITLE
Remove Potential Race Conditions From Tests

### DIFF
--- a/livelog/livelog_test.go
+++ b/livelog/livelog_test.go
@@ -27,10 +27,8 @@ func TestStreamer(t *testing.T) {
 	}
 
 	w := sync.WaitGroup{}
-	w.Add(1)
-
+	w.Add(4)
 	go func() {
-		w.Add(3)
 		s.Write(context.Background(), 1, &core.Line{})
 		s.Write(context.Background(), 1, &core.Line{})
 		s.Write(context.Background(), 1, &core.Line{})

--- a/livelog/stream_test.go
+++ b/livelog/stream_test.go
@@ -34,9 +34,8 @@ func TestStream(t *testing.T) {
 
 	stream, errc := s.subscribe(ctx)
 
-	w.Add(1)
+	w.Add(4)
 	go func() {
-		w.Add(3)
 		s.write(&core.Line{Number: 4})
 		s.write(&core.Line{Number: 5})
 		s.write(&core.Line{Number: 6})


### PR DESCRIPTION
There are a couple of tests in `livelog` where `WaitGroup`s are being added to inside of goroutines. Better to increment the `WaitGroup` outside the goroutine, and decrement inside.