### PR TITLE
Implement DRONE_RPC_SKIP_VERIFY for drone-agent and drone-controller

### DIFF
--- a/cmd/drone-agent/config/config.go
+++ b/cmd/drone-agent/config/config.go
@@ -73,11 +73,12 @@ type (
 
 	// RPC provides the rpc configuration.
 	RPC struct {
-		Server string `envconfig:"DRONE_RPC_SERVER"`
-		Secret string `envconfig:"DRONE_RPC_SECRET"`
-		Debug  bool   `envconfig:"DRONE_RPC_DEBUG"`
-		Host   string `envconfig:"DRONE_RPC_HOST"`
-		Proto  string `envconfig:"DRONE_RPC_PROTO"`
+		Server     string `envconfig:"DRONE_RPC_SERVER"`
+		Secret     string `envconfig:"DRONE_RPC_SECRET"`
+		Debug      bool   `envconfig:"DRONE_RPC_DEBUG"`
+		Host       string `envconfig:"DRONE_RPC_HOST"`
+		Proto      string `envconfig:"DRONE_RPC_PROTO"`
+		SkipVerify bool   `envconfig:"DRONE_RPC_SKIP_VERIFY"`
 		// Hosts  map[string]string `envconfig:"DRONE_RPC_EXTRA_HOSTS"`
 	}
 

--- a/cmd/drone-agent/main.go
+++ b/cmd/drone-agent/main.go
@@ -67,6 +67,7 @@ func main() {
 	manager := rpc.NewClient(
 		config.RPC.Proto+"://"+config.RPC.Host,
 		config.RPC.Secret,
+		config.RPC.SkipVerify,
 	)
 	if config.RPC.Debug {
 		manager.SetDebug(true)

--- a/cmd/drone-controller/config/config.go
+++ b/cmd/drone-controller/config/config.go
@@ -72,11 +72,12 @@ type (
 
 	// RPC provides the rpc configuration.
 	RPC struct {
-		Server string `envconfig:"DRONE_RPC_SERVER"`
-		Secret string `envconfig:"DRONE_RPC_SECRET"`
-		Debug  bool   `envconfig:"DRONE_RPC_DEBUG"`
-		Host   string `envconfig:"DRONE_RPC_HOST"`
-		Proto  string `envconfig:"DRONE_RPC_PROTO"`
+		Server     string `envconfig:"DRONE_RPC_SERVER"`
+		Secret     string `envconfig:"DRONE_RPC_SECRET"`
+		Debug      bool   `envconfig:"DRONE_RPC_DEBUG"`
+		Host       string `envconfig:"DRONE_RPC_HOST"`
+		Proto      string `envconfig:"DRONE_RPC_PROTO"`
+		SkipVerify bool   `envconfig:"DRONE_RPC_SKIP_VERIFY"`
 		// Hosts  map[string]string `envconfig:"DRONE_RPC_EXTRA_HOSTS"`
 	}
 

--- a/cmd/drone-controller/main.go
+++ b/cmd/drone-controller/main.go
@@ -62,6 +62,7 @@ func main() {
 	manager := rpc.NewClient(
 		config.RPC.Proto+"://"+config.RPC.Host,
 		config.RPC.Secret,
+		config.RPC.SkipVerify,
 	)
 	if config.RPC.Debug {
 		manager.SetDebug(true)

--- a/operator/manager/rpc/client.go
+++ b/operator/manager/rpc/client.go
@@ -8,6 +8,7 @@ package rpc
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -41,12 +42,13 @@ type Client struct {
 // NewClient returns a new rpc client that is able to
 // interact with a remote build controller using the
 // http transport.
-func NewClient(server, token string) *Client {
+func NewClient(server, token string, skipVerify bool) *Client {
 	client := retryablehttp.NewClient()
 	client.RetryMax = 30
 	client.RetryWaitMax = time.Second * 10
 	client.RetryWaitMin = time.Second * 1
 	client.Logger = nil
+	client.HTTPClient.Transport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: skipVerify}
 	return &Client{
 		client: client,
 		server: strings.TrimSuffix(server, "/"),

--- a/operator/manager/rpc/client_test.go
+++ b/operator/manager/rpc/client_test.go
@@ -42,7 +42,7 @@ func TestRequest(t *testing.T) {
 		Version:  1,
 	}
 
-	client := NewClient("http://drone.company.com", "correct-horse-battery-staple")
+	client := NewClient("http://drone.company.com", "correct-horse-battery-staple", false)
 	gock.InterceptClient(client.client.HTTPClient)
 	got, err := client.Request(noContext, &manager.Request{OS: "linux", Arch: "amd64"})
 	if err != nil {
@@ -67,7 +67,7 @@ func TestAccept(t *testing.T) {
 		BodyString(`{"Stage":1,"Machine":"localhost"}`).
 		Reply(204)
 
-	client := NewClient("http://drone.company.com", "correct-horse-battery-staple")
+	client := NewClient("http://drone.company.com", "correct-horse-battery-staple", false)
 	gock.InterceptClient(client.client.HTTPClient)
 	_, err := client.Accept(noContext, 1, "localhost")
 	if err != nil {
@@ -90,7 +90,7 @@ func TestNetrc(t *testing.T) {
 		Type("application/json").
 		BodyString(`{"machine":"github.com","login":"octocat","password":"12345"}`)
 
-	client := NewClient("http://drone.company.com", "correct-horse-battery-staple")
+	client := NewClient("http://drone.company.com", "correct-horse-battery-staple", false)
 	gock.InterceptClient(client.client.HTTPClient)
 	got, err := client.Netrc(noContext, 1)
 	if err != nil {
@@ -125,7 +125,7 @@ func TestDetails(t *testing.T) {
 	// TODO(bradrydzewski) return a mock core.BuildContext
 	// and validate the unmarshaled results.
 
-	client := NewClient("http://drone.company.com", "correct-horse-battery-staple")
+	client := NewClient("http://drone.company.com", "correct-horse-battery-staple", false)
 	gock.InterceptClient(client.client.HTTPClient)
 	out, err := client.Details(noContext, 1)
 	if err != nil {
@@ -163,7 +163,7 @@ func TestBefore(t *testing.T) {
 		Version:  1,
 	}
 
-	client := NewClient("http://drone.company.com", "correct-horse-battery-staple")
+	client := NewClient("http://drone.company.com", "correct-horse-battery-staple", false)
 	gock.InterceptClient(client.client.HTTPClient)
 	err := client.Before(noContext, before)
 	if err != nil {
@@ -210,7 +210,7 @@ func TestAfter(t *testing.T) {
 		Version:  2,
 	}
 
-	client := NewClient("http://drone.company.com", "correct-horse-battery-staple")
+	client := NewClient("http://drone.company.com", "correct-horse-battery-staple", false)
 	gock.InterceptClient(client.client.HTTPClient)
 	err := client.After(noContext, before)
 	if err != nil {
@@ -260,7 +260,7 @@ func TestBeforeAll(t *testing.T) {
 		Version:  1,
 	}
 
-	client := NewClient("http://drone.company.com", "correct-horse-battery-staple")
+	client := NewClient("http://drone.company.com", "correct-horse-battery-staple", false)
 	gock.InterceptClient(client.client.HTTPClient)
 	err := client.BeforeAll(noContext, before)
 	if err != nil {
@@ -313,7 +313,7 @@ func TestAfterAll(t *testing.T) {
 		Version:  1,
 	}
 
-	client := NewClient("http://drone.company.com", "correct-horse-battery-staple")
+	client := NewClient("http://drone.company.com", "correct-horse-battery-staple", false)
 	gock.InterceptClient(client.client.HTTPClient)
 	err := client.AfterAll(noContext, before)
 	if err != nil {
@@ -349,7 +349,7 @@ func TestBefore_OptimisticLock(t *testing.T) {
 		Post("/rpc/v1/before").
 		Reply(409)
 
-	client := NewClient("http://drone.company.com", "correct-horse-battery-staple")
+	client := NewClient("http://drone.company.com", "correct-horse-battery-staple", false)
 	gock.InterceptClient(client.client.HTTPClient)
 	err := client.Before(noContext, new(core.Step))
 	if err != db.ErrOptimisticLock {
@@ -367,7 +367,7 @@ func TestAfter_OptimisticLock(t *testing.T) {
 		Post("/rpc/v1/after").
 		Reply(409)
 
-	client := NewClient("http://drone.company.com", "correct-horse-battery-staple")
+	client := NewClient("http://drone.company.com", "correct-horse-battery-staple", false)
 	gock.InterceptClient(client.client.HTTPClient)
 	err := client.After(noContext, new(core.Step))
 	if err != db.ErrOptimisticLock {
@@ -385,7 +385,7 @@ func TestBeforeAll_OptimisticLock(t *testing.T) {
 		Post("/rpc/v1/beforeAll").
 		Reply(409)
 
-	client := NewClient("http://drone.company.com", "correct-horse-battery-staple")
+	client := NewClient("http://drone.company.com", "correct-horse-battery-staple", false)
 	gock.InterceptClient(client.client.HTTPClient)
 	err := client.BeforeAll(noContext, new(core.Stage))
 	if err != db.ErrOptimisticLock {
@@ -403,7 +403,7 @@ func TestAfterAll_OptimisticLock(t *testing.T) {
 		Post("/rpc/v1/afterAll").
 		Reply(409)
 
-	client := NewClient("http://drone.company.com", "correct-horse-battery-staple")
+	client := NewClient("http://drone.company.com", "correct-horse-battery-staple", false)
 	gock.InterceptClient(client.client.HTTPClient)
 	err := client.AfterAll(noContext, new(core.Stage))
 	if err != db.ErrOptimisticLock {
@@ -425,7 +425,7 @@ func TestWatch(t *testing.T) {
 		Type("application/json").
 		BodyString(`{"Done":true}`)
 
-	client := NewClient("http://drone.company.com", "correct-horse-battery-staple")
+	client := NewClient("http://drone.company.com", "correct-horse-battery-staple", false)
 	gock.InterceptClient(client.client.HTTPClient)
 	done, err := client.Watch(noContext, 1)
 	if err != nil {
@@ -450,7 +450,7 @@ func TestWrite(t *testing.T) {
 		BodyString(`{"pos":1,"out":"whoami","time":0}`).
 		Reply(204)
 
-	client := NewClient("http://drone.company.com", "correct-horse-battery-staple")
+	client := NewClient("http://drone.company.com", "correct-horse-battery-staple", false)
 	gock.InterceptClient(client.client.HTTPClient)
 	err := client.Write(noContext, 1, &core.Line{Number: 1, Message: "whoami", Timestamp: 0})
 	if err != nil {
@@ -474,7 +474,7 @@ func TestUpload(t *testing.T) {
 		BodyString(`[{"pos":1,"out":"whoami","time":0}]`).
 		Reply(200)
 
-	client := NewClient("http://drone.company.com", "correct-horse-battery-staple")
+	client := NewClient("http://drone.company.com", "correct-horse-battery-staple", false)
 	gock.InterceptClient(client.client.HTTPClient)
 	err := client.Upload(noContext, 1, buf)
 	if err != nil {


### PR DESCRIPTION
## Background

The `DRONE_RPC_SKIP_VERIFY` is described in the https://docker-runner.docs.drone.io/installation/reference/drone-rpc-skip-verify/ for docker runner. But it has not been implemented in the source code.

This env variable can be useful when the drone server is deployed behind the proxy with dynamically generated self-signed certificates. And adding the certs to the trusted roots of the drone-agent (docker runner) is a complicated operation overhead.

## How the changes have been tested

### All the unit test cases passed.

### Setup the local testing environment

1. **Clone the repo**

```sh
git clone https://github.com/mdluo/drone
cd drone
```

2. **Generate self-signed certificate (refer to https://letsencrypt.org/docs/certificates-for-localhost/):**

```sh
openssl req -x509 -out tmp/localhost.crt -keyout tmp/localhost.key \
  -newkey rsa:2048 -nodes -sha256 \
  -subj '/CN=localhost' -extensions EXT -config <( \
   printf "[dn]\nCN=localhost\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:localhost\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth")
```

3. **Prepare nginx config (`tmp/nginx.conf`).**

```conf
server {
  listen 443 ssl;
  ssl_certificate /etc/nginx/conf.d/localhost.crt;
  ssl_certificate_key /etc/nginx/conf.d/localhost.key;
  location / {
    proxy_pass http://drone-server;
  }
}
```

3. **Create `docker-compose.yml`**

```yml
version: '3'
services:
  nginx:
    image: nginx
    volumes: 
      - ./tmp:/etc/nginx/conf.d
    ports: 
      - 443:443
  drone-server:
    image: drone/drone
    environment:
      - DRONE_AGENTS_ENABLED=true
      - DRONE_GITHUB_SERVER=https://github.com
      - DRONE_GITHUB_CLIENT_ID=<github-client-id>
      - DRONE_GITHUB_CLIENT_SECRET=<github-client-secret>
      - DRONE_SERVER_HOST=drone-server
      - DRONE_SERVER_PROTO=http
      - DRONE_RPC_SECRET=<rpc-secret>
  drone-agent:
    image: golang:1.13.0
    environment:
      - DRONE_LOGS_DEBUG=true
      - DRONE_LOGS_TRACE=true
      - DRONE_SERVER_HOST=nginx
      - DRONE_SERVER_PROTO=https
      - DRONE_RPC_SECRET=<rpc-secret>
      - DRONE_RPC_SKIP_VERIFY=false
    working_dir: /var/drone
    command: go run cmd/drone-agent/main.go
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock
      - .:/var/drone
```

4. **Start with `docker-compose up`**

For now the `DRONE_RPC_SKIP_VERIFY` is set to `false`, so I'm getting error messages:

```log
drone-agent_1   | {"level":"debug","msg":"successfully pinged the docker daemon","time":"2019-10-06T04:59:27Z"}
drone-agent_1   | {"arch":"amd64","level":"debug","machine":"13bdcd2bcdde","msg":"runner: polling queue","os":"linux","time":"2019-10-06T04:59:27Z"}
drone-agent_1   | 2019/10/06 04:59:27 [DEBUG] POST https://nginx/rpc/v1/request
drone-agent_1   | {"arch":"amd64","level":"debug","machine":"13bdcd2bcdde","msg":"runner: polling queue","os":"linux","time":"2019-10-06T04:59:27Z"}
drone-agent_1   | 2019/10/06 04:59:27 [DEBUG] POST https://nginx/rpc/v1/request
drone-agent_1   | 2019/10/06 04:59:27 [ERR] POST https://nginx/rpc/v1/request request failed: Post https://nginx/rpc/v1/request: x509: certificate is valid for localhost, not nginx
drone-agent_1   | 2019/10/06 04:59:27 [DEBUG] POST https://nginx/rpc/v1/request: retrying in 1s (30 left)
drone-agent_1   | 2019/10/06 04:59:27 [ERR] POST https://nginx/rpc/v1/request request failed: Post https://nginx/rpc/v1/request: x509: certificate is valid for localhost, not nginx
```

5. **Change the `DRONE_RPC_SKIP_VERIFY` to `true` and restart**

```log
drone-agent_1   | {"level":"debug","msg":"successfully pinged the docker daemon","time":"2019-10-06T05:00:29Z"}
drone-agent_1   | {"arch":"amd64","level":"debug","machine":"4ca57c88486d","msg":"runner: polling queue","os":"linux","time":"2019-10-06T05:00:29Z"}
drone-agent_1   | 2019/10/06 05:00:29 [DEBUG] POST https://nginx/rpc/v1/request
drone-agent_1   | {"arch":"amd64","level":"debug","machine":"4ca57c88486d","msg":"runner: polling queue","os":"linux","time":"2019-10-06T05:00:29Z"}
drone-agent_1   | 2019/10/06 05:00:29 [DEBUG] POST https://nginx/rpc/v1/request
drone-agent_1   | 2019/10/06 05:00:59 [DEBUG] POST https://nginx/rpc/v1/request (status: 524): retrying in 1s (30 left)
nginx_1         | 172.29.0.4 - - [06/Oct/2019:05:00:59 +0000] "POST /rpc/v1/request HTTP/1.1" 524 25 "-" "Go-http-client/1.1" "-"
nginx_1         | 172.29.0.4 - - [06/Oct/2019:05:00:59 +0000] "POST /rpc/v1/request HTTP/1.1" 524 25 "-" "Go-http-client/1.1" "-"
drone-agent_1   | 2019/10/06 05:00:59 [DEBUG] POST https://nginx/rpc/v1/request (status: 524): retrying in 1s (30 left)
nginx_1         | 172.29.0.4 - - [06/Oct/2019:05:01:29 +0000] "POST /rpc/v1/request HTTP/1.1" 499 0 "-" "Go-http-client/1.1" "-"
drone-agent_1   | 2019/10/06 05:01:29 [ERR] POST https://nginx/rpc/v1/request request failed: Post https://nginx/rpc/v1/request: context deadline exceeded
drone-agent_1   | {"arch":"amd64","level":"debug","machine":"4ca57c88486d","msg":"runner: polling queue","os":"linux","time":"2019-10-06T05:01:29Z"}
drone-agent_1   | 2019/10/06 05:01:29 [DEBUG] POST https://nginx/rpc/v1/request
drone-agent_1   | 2019/10/06 05:01:29 [ERR] POST https://nginx/rpc/v1/request request failed: Post https://nginx/rpc/v1/request: context deadline exceeded
drone-agent_1   | {"arch":"amd64","level":"debug","machine":"4ca57c88486d","msg":"runner: polling queue","os":"linux","time":"2019-10-06T05:01:29Z"}
drone-agent_1   | 2019/10/06 05:01:29 [DEBUG] POST https://nginx/rpc/v1/request
```

Now the drone-agent connect to the drone-server successfully.

###  Tested with GitHub pull request pipeline

Use ngrok as GitHub webhook tunnel

```sh
ngrok http https://localhost
```

If the `DRONE_RPC_SKIP_VERIFY` is set to `true`, the pipeline can be finished successfully.

![image](https://user-images.githubusercontent.com/4597409/66265090-eccf3980-e842-11e9-873c-8cb73faf3626.png)

If the `DRONE_RPC_SKIP_VERIFY` is set to `false`, the pipeline gets stuck at the first step and can never move forward.

![image](https://user-images.githubusercontent.com/4597409/66265079-bbef0480-e842-11e9-909b-f4f69558c6db.png)

Notice the console output of the second build, the drone-agent is not even connected to the drone server, so there should be no output at all. 
Looks like it's syncing from the first build, it might be a bug.
