### PR TITLE
Add DRONE_COMMIT_TIMESTAMP to runner environment

### DIFF
--- a/operator/runner/env.go
+++ b/operator/runner/env.go
@@ -100,7 +100,7 @@ func buildEnviron(build *core.Build) map[string]string {
 		"DRONE_COMMIT_AUTHOR_EMAIL":  build.AuthorEmail,
 		"DRONE_COMMIT_AUTHOR_AVATAR": build.AuthorAvatar,
 		"DRONE_COMMIT_AUTHOR_NAME":   build.AuthorName,
-		"DRONE_COMMIT_TIMESTAMP":     build.Timestamp,
+		"DRONE_COMMIT_TIMESTAMP":     fmt.Sprint(build.Timestamp),
 		"DRONE_BUILD_NUMBER":         fmt.Sprint(build.Number),
 		"DRONE_BUILD_EVENT":          build.Event,
 		"DRONE_BUILD_ACTION":         build.Action,

--- a/operator/runner/env.go
+++ b/operator/runner/env.go
@@ -100,6 +100,7 @@ func buildEnviron(build *core.Build) map[string]string {
 		"DRONE_COMMIT_AUTHOR_EMAIL":  build.AuthorEmail,
 		"DRONE_COMMIT_AUTHOR_AVATAR": build.AuthorAvatar,
 		"DRONE_COMMIT_AUTHOR_NAME":   build.AuthorName,
+		"DRONE_COMMIT_TIMESTAMP":     build.Timestamp,
 		"DRONE_BUILD_NUMBER":         fmt.Sprint(build.Number),
 		"DRONE_BUILD_EVENT":          build.Event,
 		"DRONE_BUILD_ACTION":         build.Action,


### PR DESCRIPTION
Hi,

Our code coverage tool (Codeclimate) requires to access the commit timestamp, which is not accessible right now from the Runner environment. This is a tiny addition just to expose it as an environment variable to the runners.

P.S. I couldn't find a contributing guide, so I just made sure to not break the format, and that all unit tests are passing locally, by running `go test ...`, but didn't add one as these variables don't have unit tests. I just made sure that `build.Timestamp` existed and was accessible.