### PR TITLE
manager: send webhook after build finishes

### DIFF
--- a/operator/manager/manager.go
+++ b/operator/manager/manager.go
@@ -437,6 +437,7 @@ func (m *Manager) AfterAll(ctx context.Context, stage *core.Stage) error {
 		Stages:    m.Stages,
 		Status:    m.Status,
 		Users:     m.Users,
+		Webhook:   m.Webhook,
 	}
 	return t.do(ctx, stage)
 }

--- a/plugin/webhook/webhook.go
+++ b/plugin/webhook/webhook.go
@@ -19,6 +19,7 @@ import (
 	"github.com/drone/drone/core"
 
 	"github.com/99designs/httpsignatures-go"
+	"github.com/sirupsen/logrus"
 )
 
 // required http headers
@@ -64,6 +65,21 @@ func (s *sender) Send(ctx context.Context, in *core.WebhookData) error {
 	if s.match(in.Event, in.Action) == false {
 		return nil
 	}
+
+	logger := logrus.
+		WithField("event", in.Event).
+		WithField("action", in.Action)
+	if in.Repo != nil {
+		logger = logger.WithField("repo", in.Repo.Name)
+	}
+	if in.Build != nil {
+		logger = logger.
+			WithField("build.id", in.Build.ID).
+			WithField("build.number", in.Build.Number).
+			WithField("build.status", in.Build.Status)
+	}
+	logger.Debugln("webhook: sending global webhook")
+
 	wrapper := payload{
 		WebhookData: in,
 		System:      s.System,

--- a/plugin/webhook/webhook.go
+++ b/plugin/webhook/webhook.go
@@ -19,7 +19,6 @@ import (
 	"github.com/drone/drone/core"
 
 	"github.com/99designs/httpsignatures-go"
-	"github.com/sirupsen/logrus"
 )
 
 // required http headers
@@ -65,21 +64,6 @@ func (s *sender) Send(ctx context.Context, in *core.WebhookData) error {
 	if s.match(in.Event, in.Action) == false {
 		return nil
 	}
-
-	logger := logrus.
-		WithField("event", in.Event).
-		WithField("action", in.Action)
-	if in.Repo != nil {
-		logger = logger.WithField("repo", in.Repo.Name)
-	}
-	if in.Build != nil {
-		logger = logger.
-			WithField("build.id", in.Build.ID).
-			WithField("build.number", in.Build.Number).
-			WithField("build.status", in.Build.Status)
-	}
-	logger.Debugln("webhook: sending global webhook")
-
 	wrapper := payload{
 		WebhookData: in,
 		System:      s.System,


### PR DESCRIPTION
Add an additional and final webhook that notifies of the build status after completion (success/failure)

### Before
Hook payloads: https://hookbin.com/xY86gGQEnZSLMbORNYLN
```
DEBU[0008] manager: accept stage                         machine=7c8b53f9f78e stage-id=109
DEBU[0008] manager: stage accepted                       machine=7c8b53f9f78e stage-id=109
DEBU[0008] manager: fetching stage details               step-id=109
DEBU[0008] manager: request queue item                   arch=amd64 kernel= kind=pipeline os=linux type=docker variant=
DEBU[0008] manager: updating step status                 step.id=263 step.name=clone step.status=running
DEBU[0010] manager: updating step status                 step.id=263 step.name=clone step.status=success
DEBU[0010] manager: updating step status                 step.id=264 step.name=test step.status=running
DEBU[0013] manager: updating step status                 step.id=264 step.name=test step.status=success
DEBU[0013] manager: stage is complete. teardown          stage.id=109
DEBU[0013] manager: build is finished, teardown          build.id=75 build.number=61 repo.id=7 stage.id=109
```

### After
Hook payloads: https://hookbin.com/3OQjWOXYEgTL6JexajLO
```
DEBU[0031] manager: accept stage                         machine=7c8b53f9f78e stage-id=108
DEBU[0031] manager: stage accepted                       machine=7c8b53f9f78e stage-id=108
DEBU[0031] manager: fetching stage details               step-id=108
DEBU[0032] manager: updating step status                 step.id=261 step.name=clone step.status=running
DEBU[0032] manager: sending global webhook               action=updated event=build stage.id=108 stage.status=running
DEBU[0033] manager: updating step status                 step.id=261 step.name=clone step.status=success
DEBU[0033] manager: sending global webhook               action=updated event=build stage.id=108 stage.status=running
DEBU[0033] manager: updating step status                 step.id=262 step.name=test step.status=running
DEBU[0033] manager: sending global webhook               action=updated event=build stage.id=108 stage.status=running
DEBU[0036] manager: updating step status                 step.id=262 step.name=test step.status=success
DEBU[0036] manager: sending global webhook               action=updated event=build stage.id=108 stage.status=running
DEBU[0036] manager: updating stage status                stage.id=108 stage.status=success
DEBU[0036] manager: stage is complete. teardown          stage.id=108
DEBU[0036] manager: build is finished, teardown          build.id=74 build.number=60 repo.id=7 stage.id=108
DEBU[0036] manager: sending global webhook               action=updated event=build stage.id=108 stage.status=success
```