### PR TITLE
Update alpine base image to v3.11

### DIFF
--- a/docker/Dockerfile.agent.linux.amd64
+++ b/docker/Dockerfile.agent.linux.amd64
@@ -1,7 +1,7 @@
-FROM alpine:3.9 as alpine
+FROM alpine:3.11 as alpine
 RUN apk add -U --no-cache ca-certificates
 
-FROM alpine:3.9
+FROM alpine:3.11
 ENV GODEBUG netdns=go
 ENV DRONE_RUNNER_OS=linux
 ENV DRONE_RUNNER_ARCH=amd64

--- a/docker/Dockerfile.controller.linux.amd64
+++ b/docker/Dockerfile.controller.linux.amd64
@@ -1,7 +1,7 @@
-FROM alpine:3.9 as alpine
+FROM alpine:3.11 as alpine
 RUN apk add -U --no-cache ca-certificates
 
-FROM alpine:3.9
+FROM alpine:3.11
 ENV GODEBUG netdns=go
 ENV DRONE_RUNNER_OS=linux
 ENV DRONE_RUNNER_ARCH=amd64

--- a/docker/Dockerfile.controller.linux.arm
+++ b/docker/Dockerfile.controller.linux.arm
@@ -1,7 +1,7 @@
-FROM alpine:3.9 as alpine
+FROM alpine:3.11 as alpine
 RUN apk add -U --no-cache ca-certificates
 
-FROM alpine:3.9
+FROM alpine:3.11
 ENV GODEBUG=netdns=go
 ENV DRONE_RUNNER_OS=linux
 ENV DRONE_RUNNER_ARCH=arm

--- a/docker/Dockerfile.controller.linux.arm64
+++ b/docker/Dockerfile.controller.linux.arm64
@@ -1,7 +1,7 @@
-FROM alpine:3.9 as alpine
+FROM alpine:3.11 as alpine
 RUN apk add -U --no-cache ca-certificates
 
-FROM alpine:3.9
+FROM alpine:3.11
 ENV GODEBUG=netdns=go
 ENV DRONE_RUNNER_OS=linux
 ENV DRONE_RUNNER_ARCH=arm64

--- a/docker/Dockerfile.server.linux.amd64
+++ b/docker/Dockerfile.server.linux.amd64
@@ -1,9 +1,9 @@
 # docker build --rm -f docker/Dockerfile -t drone/drone .
 
-FROM alpine:3.9 as alpine
+FROM alpine:3.11 as alpine
 RUN apk add -U --no-cache ca-certificates
 
-FROM alpine:3.9
+FROM alpine:3.11
 EXPOSE 80 443
 VOLUME /data
 

--- a/docker/Dockerfile.server.linux.arm
+++ b/docker/Dockerfile.server.linux.arm
@@ -1,9 +1,9 @@
 # docker build --rm -f docker/Dockerfile -t drone/drone .
 
-FROM alpine:3.9 as alpine
+FROM alpine:3.11 as alpine
 RUN apk add -U --no-cache ca-certificates
 
-FROM alpine:3.9
+FROM alpine:3.11
 EXPOSE 80 443
 VOLUME /data
 

--- a/docker/Dockerfile.server.linux.arm64
+++ b/docker/Dockerfile.server.linux.arm64
@@ -1,9 +1,9 @@
 # docker build --rm -f docker/Dockerfile -t drone/drone .
 
-FROM alpine:3.9 as alpine
+FROM alpine:3.11 as alpine
 RUN apk add -U --no-cache ca-certificates
 
-FROM alpine:3.9
+FROM alpine:3.11
 EXPOSE 80 443
 VOLUME /data
 


### PR DESCRIPTION
Per discussion here:
https://discourse.drone.io/t/alpine-3-9-includes-musl-version-vulnerable-to-cve-2019-14697/6679

