### PR TITLE
Fix incorrect return value from toMap function

### DIFF
--- a/service/hook/parser/parse.go
+++ b/service/hook/parser/parse.go
@@ -364,5 +364,5 @@ func toMap(src interface{}) map[string]string {
 	for k, v := range set {
 		dst[k] = fmt.Sprint(v)
 	}
-	return nil
+	return dst
 }


### PR DESCRIPTION
Github deployments can include a `payload` object that is read by drone and the resulting key/value pairs should be injected into the build step as environment variables.

This fix correctly returns the constructed map of key/values from the `payload` object so they can be injected into the builds environment later.