### PR TITLE
Allow overriding .drone.yml path globally

### DIFF
--- a/cmd/drone-server/config/config.go
+++ b/cmd/drone-server/config/config.go
@@ -300,6 +300,7 @@ type (
 
 	// Yaml provides the yaml webhook configuration.
 	Yaml struct {
+		File       string `envconfig:"DRONE_YAML_FILE" default:".drone.yml"`
 		Endpoint   string `envconfig:"DRONE_YAML_ENDPOINT"`
 		Secret     string `envconfig:"DRONE_YAML_SECRET"`
 		SkipVerify bool   `envconfig:"DRONE_YAML_SKIP_VERIFY"`

--- a/cmd/drone-server/wire_gen.go
+++ b/cmd/drone-server/wire_gen.go
@@ -90,7 +90,7 @@ func InitializeApplication(config2 config.Config) (application, error) {
 	batcher := provideBatchStore(db, config2)
 	syncer := provideSyncer(repositoryService, repositoryStore, userStore, batcher, config2)
 	userService := user.New(client, renewer)
-	server := api.New(buildStore, commitService, cronStore, corePubsub, globalSecretStore, hookService, logStore, coreLicense, licenseService, organizationService, permStore, repositoryStore, repositoryService, scheduler, secretStore, stageStore, stepStore, statusService, session, logStream, syncer, system, triggerer, userStore, userService, webhookSender)
+	server := api.New(buildStore, commitService, config2, cronStore, corePubsub, globalSecretStore, hookService, logStore, coreLicense, licenseService, organizationService, permStore, repositoryStore, repositoryService, scheduler, secretStore, stageStore, stepStore, statusService, session, logStream, syncer, system, triggerer, userStore, userService, webhookSender)
 	admissionService := provideAdmissionPlugin(client, organizationService, userService, config2)
 	hookParser := parser.New(client)
 	coreLinker := linker.New(client)

--- a/handler/api/api.go
+++ b/handler/api/api.go
@@ -17,6 +17,7 @@ package api
 import (
 	"net/http"
 
+	"github.com/drone/drone/cmd/drone-server/config"
 	"github.com/drone/drone/core"
 	"github.com/drone/drone/handler/api/acl"
 	"github.com/drone/drone/handler/api/auth"
@@ -58,6 +59,7 @@ var corsOpts = cors.Options{
 func New(
 	builds core.BuildStore,
 	commits core.CommitService,
+	config config.Config,
 	cron core.CronStore,
 	events core.Pubsub,
 	globals core.GlobalSecretStore,
@@ -87,6 +89,7 @@ func New(
 		Builds:    builds,
 		Cron:      cron,
 		Commits:   commits,
+		Config:    config,
 		Events:    events,
 		Globals:   globals,
 		Hooks:     hooks,
@@ -118,6 +121,7 @@ type Server struct {
 	Builds    core.BuildStore
 	Cron      core.CronStore
 	Commits   core.CommitService
+	Config    config.Config
 	Events    core.Pubsub
 	Globals   core.GlobalSecretStore
 	Hooks     core.HookService
@@ -169,7 +173,7 @@ func (s Server) Handler() http.Handler {
 			).Patch("/", repos.HandleUpdate(s.Repos))
 			r.With(
 				acl.CheckAdminAccess(),
-			).Post("/", repos.HandleEnable(s.Hooks, s.Repos, s.Webhook))
+			).Post("/", repos.HandleEnable(s.Hooks, s.Repos, s.Webhook, s.Config.Yaml.File))
 			r.With(
 				acl.CheckAdminAccess(),
 			).Delete("/", repos.HandleDisable(s.Repos, s.Webhook))

--- a/handler/api/repos/enable.go
+++ b/handler/api/repos/enable.go
@@ -32,6 +32,7 @@ func HandleEnable(
 	hooks core.HookService,
 	repos core.RepositoryStore,
 	sender core.WebhookSender,
+	defaultConfig string,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var (
@@ -53,7 +54,7 @@ func HandleEnable(
 		repo.UserID = user.ID
 
 		if repo.Config == "" {
-			repo.Config = ".drone.yml"
+			repo.Config = defaultConfig
 		}
 		if repo.Signer == "" {
 			repo.Signer = uniuri.NewLen(32)

--- a/handler/api/repos/enable_test.go
+++ b/handler/api/repos/enable_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
+const defaultConfig = ".drone.yml"
+
 func TestEnable(t *testing.T) {
 	controller := gomock.NewController(t)
 	defer controller.Finish()
@@ -56,7 +58,7 @@ func TestEnable(t *testing.T) {
 		context.WithValue(request.WithUser(r.Context(), &core.User{ID: 1}), chi.RouteCtxKey, c),
 	)
 
-	HandleEnable(service, repos, webhook)(w, r)
+	HandleEnable(service, repos, webhook, defaultConfig)(w, r)
 	if got, want := w.Code, 200; want != got {
 		t.Errorf("Want response code %d, got %d", want, got)
 	}
@@ -90,7 +92,7 @@ func TestEnable_RepoNotFound(t *testing.T) {
 		context.WithValue(context.Background(), chi.RouteCtxKey, c),
 	)
 
-	HandleEnable(nil, repos, nil)(w, r)
+	HandleEnable(nil, repos, nil, defaultConfig)(w, r)
 	if got, want := w.Code, 404; want != got {
 		t.Errorf("Want response code %d, got %d", want, got)
 	}
@@ -129,7 +131,7 @@ func TestEnable_HookError(t *testing.T) {
 		context.WithValue(request.WithUser(r.Context(), &core.User{ID: 1}), chi.RouteCtxKey, c),
 	)
 
-	HandleEnable(service, repos, nil)(w, r)
+	HandleEnable(service, repos, nil, defaultConfig)(w, r)
 	if got, want := w.Code, http.StatusInternalServerError; want != got {
 		t.Errorf("Want response code %d, got %d", want, got)
 	}
@@ -168,7 +170,7 @@ func TestEnable_ActivateError(t *testing.T) {
 		context.WithValue(request.WithUser(r.Context(), &core.User{ID: 1}), chi.RouteCtxKey, c),
 	)
 
-	HandleEnable(service, repos, nil)(w, r)
+	HandleEnable(service, repos, nil, defaultConfig)(w, r)
 	if got, want := w.Code, http.StatusInternalServerError; want != got {
 		t.Errorf("Want response code %d, got %d", want, got)
 	}


### PR DESCRIPTION
### Context for this change:  
We are using starlark for all of our pipelines.   
Currently, we have to manually set the configuration file to `.drone.star` everytime we activate a repository.  
We want drone to use `.drone.star` as default configuration file for newly created repos.

### Change in this PR:
- Add a configuration `DRONE_YAML_FILE` that allows overidding the default `.drone.yml`.
- `DRONE_YAML_FILE` is default to `.drone.yml` for backward compatibility
