### PR TITLE
Fix bug when refresh gitea access token

### DIFF
--- a/cmd/drone-server/inject_login.go
+++ b/cmd/drone-server/inject_login.go
@@ -24,6 +24,7 @@ import (
 	"github.com/drone/go-login/login/gogs"
 	"github.com/drone/go-login/login/stash"
 	"github.com/drone/go-scm/scm/transport/oauth2"
+	"strings"
 
 	"github.com/google/wire"
 	"github.com/sirupsen/logrus"

--- a/cmd/drone-server/inject_login.go
+++ b/cmd/drone-server/inject_login.go
@@ -169,7 +169,7 @@ func provideRefresher(config config.Config) *oauth2.Refresher {
 		return &oauth2.Refresher{
 			ClientID:     config.Gitea.ClientID,
 			ClientSecret: config.Gitea.ClientSecret,
-			Endpoint:     config.Gitea.Server + "/login/oauth/access_token",
+			Endpoint:     strings.TrimSuffix(config.Gitea.Server, "/") + "/login/oauth/access_token",
 			Source:       oauth2.ContextTokenSource(),
 			Client:       defaultClient(config.Gitea.SkipVerify),
 		}


### PR DESCRIPTION
	When the URI has extra '/' in DRONE_GITEA_SERVER, the drone
	will not pull the repo since it cannot refresh the access token.
	The log in gitea shows the drone try to access '//login/oauth/access_token'

	Related to commit 5414bb75f

