### PR TITLE
Bump to Go 1.14

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,12 +9,12 @@ platform:
 
 steps:
 - name: test
-  image: golang:1.13.0
+  image: golang:1.14
   commands:
   - go test ./...
   
 - name: build
-  image: golang:1.13.0
+  image: golang:1.14
   commands:
   - sh scripts/build.sh
   environment:
@@ -48,7 +48,7 @@ platform:
 
 steps:
 - name: build
-  image: golang:1.13.0
+  image: golang:1.14
   commands:
   - sh scripts/build.sh
   environment:
@@ -86,7 +86,7 @@ platform:
 
 steps:
 - name: build
-  image: golang:1.13.0
+  image: golang:1.14
   commands:
   - sh scripts/build.sh
   environment:


### PR DESCRIPTION
Bump to `go` `1.14`.

Previously this pinned to `1.13.0`, but I think it's sufficient to pin only to the minor version and not worry about pinning the patch release.  The odds are higher that no one will remember to bump the patch release than that the patch upgrade would actually break something.

