### PR TITLE
added endpoints for branch / pr / deployment summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-# Fixed
+### Added
+- endpoint to display the latest build by branch. [#2940](https://github.com/drone/drone/pull/2940).
+- endpoint to display the latest build by pull request. [#2940](https://github.com/drone/drone/pull/2940).
+- endpoint to delete a branch from the index. [#2940](https://github.com/drone/drone/pull/2940).
+- endpoint to delete a pull request from the index. [#2940](https://github.com/drone/drone/pull/2940).
+
+### Fixed
 - do not execute cron job for disabled repositories. [#2931](https://github.com/drone/drone/issues/2931).
 - remove trailing slash from gitea url to prevent oauth2 token refresh errors, by [@cmj0121](https://github.com/cmj0121). [#2920](https://github.com/drone/drone/issues/2920). 
 
 ## [1.6.5] - 2020-01-29
-# Changed
+### Changed
 - update version of go-scm
 - update alpine version in docker images
 - use ticker for cron jobs for more accurate timing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - endpoint to display the latest build by branch. [#2940](https://github.com/drone/drone/pull/2940).
 - endpoint to display the latest build by pull request. [#2940](https://github.com/drone/drone/pull/2940).
+- endpoint to display the latest build by environment. [#2940](https://github.com/drone/drone/pull/2940).
 - endpoint to delete a branch from the index. [#2940](https://github.com/drone/drone/pull/2940).
 - endpoint to delete a pull request from the index. [#2940](https://github.com/drone/drone/pull/2940).
+- endpoint to delete an environment from the index. [#2940](https://github.com/drone/drone/pull/2940).
 
 ### Fixed
 - do not execute cron job for disabled repositories. [#2931](https://github.com/drone/drone/issues/2931).

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -143,16 +143,17 @@ tasks:
   test-postgres:
     env:
       DRONE_DATABASE_DRIVER: postgres
-      DRONE_DATABASE_DATASOURCE: host=localhost user=postgres dbname=postgres sslmode=disable
+      DRONE_DATABASE_DATASOURCE: host=localhost user=postgres password=postgres dbname=postgres sslmode=disable
       GO111MODULE: 'on'
     cmds:
       - cmd: docker kill postgres
         ignore_error: true
-        silent: true
-      - silent: true
+        silent: false
+      - silent: false
         cmd: >
           docker run
           -p 5432:5432
+          --env POSTGRES_PASSWORD=postgres
           --env POSTGRES_USER=postgres
           --name postgres
           --detach

--- a/core/build.go
+++ b/core/build.go
@@ -79,6 +79,10 @@ type BuildStore interface {
 	// datastore by pull requeset.
 	LatestPulls(context.Context, int64) ([]*Build, error)
 
+	// LatestDeploys returns the latest builds from the
+	// datastore by deployment target.
+	LatestDeploys(context.Context, int64) ([]*Build, error)
+
 	// Pending returns a list of pending builds from the
 	// datastore by repository id (DEPRECATED).
 	Pending(context.Context) ([]*Build, error)

--- a/core/build.go
+++ b/core/build.go
@@ -71,6 +71,14 @@ type BuildStore interface {
 	// ListRef returns a list of builds from the datastore by ref.
 	ListRef(context.Context, int64, string, int, int) ([]*Build, error)
 
+	// LatestBranches returns the latest builds from the
+	// datastore by branch.
+	LatestBranches(context.Context, int64) ([]*Build, error)
+
+	// LatestPulls returns the latest builds from the
+	// datastore by pull requeset.
+	LatestPulls(context.Context, int64) ([]*Build, error)
+
 	// Pending returns a list of pending builds from the
 	// datastore by repository id (DEPRECATED).
 	Pending(context.Context) ([]*Build, error)
@@ -87,6 +95,15 @@ type BuildStore interface {
 
 	// Delete deletes a build from the datastore.
 	Delete(context.Context, *Build) error
+
+	// DeletePull deletes a pull request index from the datastore.
+	DeletePull(context.Context, int64, int) error
+
+	// DeleteBranch deletes a branch index from the datastore.
+	DeleteBranch(context.Context, int64, string) error
+
+	// DeleteDeploy deletes a deploy index from the datastore.
+	DeleteDeploy(context.Context, int64, string) error
 
 	// Purge deletes builds from the database where the build number is less than n.
 	Purge(context.Context, int64, int64) error

--- a/core/hook.go
+++ b/core/hook.go
@@ -22,6 +22,7 @@ import (
 // Hook action constants.
 const (
 	ActionOpen   = "open"
+	ActionClose  = "close"
 	ActionCreate = "create"
 	ActionDelete = "delete"
 	ActionSync   = "sync"

--- a/go.mod
+++ b/go.mod
@@ -100,3 +100,5 @@ require (
 )
 
 replace github.com/h2non/gock => gopkg.in/h2non/gock.v1 v1.0.14
+
+go 1.13

--- a/handler/api/api.go
+++ b/handler/api/api.go
@@ -27,7 +27,9 @@ import (
 	"github.com/drone/drone/handler/api/queue"
 	"github.com/drone/drone/handler/api/repos"
 	"github.com/drone/drone/handler/api/repos/builds"
+	"github.com/drone/drone/handler/api/repos/builds/branches"
 	"github.com/drone/drone/handler/api/repos/builds/logs"
+	"github.com/drone/drone/handler/api/repos/builds/pulls"
 	"github.com/drone/drone/handler/api/repos/builds/stages"
 	"github.com/drone/drone/handler/api/repos/collabs"
 	"github.com/drone/drone/handler/api/repos/crons"
@@ -183,6 +185,12 @@ func (s Server) Handler() http.Handler {
 			r.Route("/builds", func(r chi.Router) {
 				r.Get("/", builds.HandleList(s.Repos, s.Builds))
 				r.With(acl.CheckWriteAccess()).Post("/", builds.HandleCreate(s.Repos, s.Commits, s.Triggerer))
+
+				r.Get("/branches", branches.HandleList(s.Repos, s.Builds))
+				r.With(acl.CheckWriteAccess()).Delete("/branches/*", branches.HandleDelete(s.Repos, s.Builds))
+
+				r.Get("/pulls", pulls.HandleList(s.Repos, s.Builds))
+				r.With(acl.CheckWriteAccess()).Delete("/pulls/{pull}", pulls.HandleDelete(s.Repos, s.Builds))
 
 				r.Get("/latest", builds.HandleLast(s.Repos, s.Builds, s.Stages))
 				r.Get("/{number}", builds.HandleFind(s.Repos, s.Builds, s.Stages))

--- a/handler/api/api.go
+++ b/handler/api/api.go
@@ -28,6 +28,7 @@ import (
 	"github.com/drone/drone/handler/api/repos"
 	"github.com/drone/drone/handler/api/repos/builds"
 	"github.com/drone/drone/handler/api/repos/builds/branches"
+	"github.com/drone/drone/handler/api/repos/builds/deploys"
 	"github.com/drone/drone/handler/api/repos/builds/logs"
 	"github.com/drone/drone/handler/api/repos/builds/pulls"
 	"github.com/drone/drone/handler/api/repos/builds/stages"
@@ -191,6 +192,9 @@ func (s Server) Handler() http.Handler {
 
 				r.Get("/pulls", pulls.HandleList(s.Repos, s.Builds))
 				r.With(acl.CheckWriteAccess()).Delete("/pulls/{pull}", pulls.HandleDelete(s.Repos, s.Builds))
+
+				r.Get("/deployments", deploys.HandleList(s.Repos, s.Builds))
+				r.With(acl.CheckWriteAccess()).Delete("/deployments/*", deploys.HandleDelete(s.Repos, s.Builds))
 
 				r.Get("/latest", builds.HandleLast(s.Repos, s.Builds, s.Stages))
 				r.Get("/{number}", builds.HandleFind(s.Repos, s.Builds, s.Stages))

--- a/handler/api/repos/builds/branches/create.go
+++ b/handler/api/repos/builds/branches/create.go
@@ -1,0 +1,15 @@
+// Copyright 2019 Drone IO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package branches

--- a/handler/api/repos/builds/branches/create_test.go
+++ b/handler/api/repos/builds/branches/create_test.go
@@ -1,0 +1,5 @@
+// Copyright 2019 Drone.IO Inc. All rights reserved.
+// Use of this source code is governed by the Drone Non-Commercial License
+// that can be found in the LICENSE file.
+
+package branches

--- a/handler/api/repos/builds/branches/delete.go
+++ b/handler/api/repos/builds/branches/delete.go
@@ -1,0 +1,62 @@
+// Copyright 2019 Drone IO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package branches
+
+import (
+	"net/http"
+
+	"github.com/drone/drone/core"
+	"github.com/drone/drone/handler/api/render"
+	"github.com/drone/drone/logger"
+
+	"github.com/go-chi/chi"
+)
+
+// HandleDelete returns an http.HandlerFunc that handles an
+// http.Request to delete a branch entry from the datastore.
+func HandleDelete(
+	repos core.RepositoryStore,
+	builds core.BuildStore,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var (
+			namespace = chi.URLParam(r, "owner")
+			name      = chi.URLParam(r, "name")
+			branch    = chi.URLParam(r, "*")
+		)
+		repo, err := repos.FindName(r.Context(), namespace, name)
+		if err != nil {
+			render.NotFound(w, err)
+			logger.FromRequest(r).
+				WithError(err).
+				WithField("namespace", namespace).
+				WithField("name", name).
+				Debugln("api: cannot find repository")
+			return
+		}
+
+		err = builds.DeleteBranch(r.Context(), repo.ID, branch)
+		if err != nil {
+			render.InternalError(w, err)
+			logger.FromRequest(r).
+				WithError(err).
+				WithField("namespace", namespace).
+				WithField("name", name).
+				Debugln("api: cannot delete branch")
+		} else {
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}
+}

--- a/handler/api/repos/builds/branches/delete_test.go
+++ b/handler/api/repos/builds/branches/delete_test.go
@@ -1,0 +1,5 @@
+// Copyright 2019 Drone.IO Inc. All rights reserved.
+// Use of this source code is governed by the Drone Non-Commercial License
+// that can be found in the LICENSE file.
+
+package branches

--- a/handler/api/repos/builds/branches/list.go
+++ b/handler/api/repos/builds/branches/list.go
@@ -1,0 +1,61 @@
+// Copyright 2019 Drone IO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package branches
+
+import (
+	"net/http"
+
+	"github.com/drone/drone/core"
+	"github.com/drone/drone/handler/api/render"
+	"github.com/drone/drone/logger"
+
+	"github.com/go-chi/chi"
+)
+
+// HandleList returns an http.HandlerFunc that writes a json-encoded
+// list of build history to the response body.
+func HandleList(
+	repos core.RepositoryStore,
+	builds core.BuildStore,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var (
+			namespace = chi.URLParam(r, "owner")
+			name      = chi.URLParam(r, "name")
+		)
+		repo, err := repos.FindName(r.Context(), namespace, name)
+		if err != nil {
+			render.NotFound(w, err)
+			logger.FromRequest(r).
+				WithError(err).
+				WithField("namespace", namespace).
+				WithField("name", name).
+				Debugln("api: cannot find repository")
+			return
+		}
+
+		results, err := builds.LatestBranches(r.Context(), repo.ID)
+		if err != nil {
+			render.InternalError(w, err)
+			logger.FromRequest(r).
+				WithError(err).
+				WithField("namespace", namespace).
+				WithField("name", name).
+				Debugln("api: cannot list builds")
+		} else {
+			render.JSON(w, results, 200)
+		}
+	}
+}

--- a/handler/api/repos/builds/branches/list_test.go
+++ b/handler/api/repos/builds/branches/list_test.go
@@ -1,0 +1,5 @@
+// Copyright 2019 Drone.IO Inc. All rights reserved.
+// Use of this source code is governed by the Drone Non-Commercial License
+// that can be found in the LICENSE file.
+
+package branches

--- a/handler/api/repos/builds/deploys/create.go
+++ b/handler/api/repos/builds/deploys/create.go
@@ -1,0 +1,15 @@
+// Copyright 2019 Drone IO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploys

--- a/handler/api/repos/builds/deploys/create_test.go
+++ b/handler/api/repos/builds/deploys/create_test.go
@@ -1,0 +1,5 @@
+// Copyright 2019 Drone.IO Inc. All rights reserved.
+// Use of this source code is governed by the Drone Non-Commercial License
+// that can be found in the LICENSE file.
+
+package deploys

--- a/handler/api/repos/builds/deploys/delete.go
+++ b/handler/api/repos/builds/deploys/delete.go
@@ -1,0 +1,62 @@
+// Copyright 2019 Drone IO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploys
+
+import (
+	"net/http"
+
+	"github.com/drone/drone/core"
+	"github.com/drone/drone/handler/api/render"
+	"github.com/drone/drone/logger"
+
+	"github.com/go-chi/chi"
+)
+
+// HandleDelete returns an http.HandlerFunc that handles an
+// http.Request to delete a branch entry from the datastore.
+func HandleDelete(
+	repos core.RepositoryStore,
+	builds core.BuildStore,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var (
+			namespace = chi.URLParam(r, "owner")
+			name      = chi.URLParam(r, "name")
+			target    = chi.URLParam(r, "*")
+		)
+		repo, err := repos.FindName(r.Context(), namespace, name)
+		if err != nil {
+			render.NotFound(w, err)
+			logger.FromRequest(r).
+				WithError(err).
+				WithField("namespace", namespace).
+				WithField("name", name).
+				Debugln("api: cannot find repository")
+			return
+		}
+
+		err = builds.DeleteDeploy(r.Context(), repo.ID, target)
+		if err != nil {
+			render.InternalError(w, err)
+			logger.FromRequest(r).
+				WithError(err).
+				WithField("namespace", namespace).
+				WithField("name", name).
+				Debugln("api: cannot delete deployment")
+		} else {
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}
+}

--- a/handler/api/repos/builds/deploys/delete_test.go
+++ b/handler/api/repos/builds/deploys/delete_test.go
@@ -1,0 +1,5 @@
+// Copyright 2019 Drone.IO Inc. All rights reserved.
+// Use of this source code is governed by the Drone Non-Commercial License
+// that can be found in the LICENSE file.
+
+package deploys

--- a/handler/api/repos/builds/deploys/list.go
+++ b/handler/api/repos/builds/deploys/list.go
@@ -1,0 +1,61 @@
+// Copyright 2019 Drone IO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploys
+
+import (
+	"net/http"
+
+	"github.com/drone/drone/core"
+	"github.com/drone/drone/handler/api/render"
+	"github.com/drone/drone/logger"
+
+	"github.com/go-chi/chi"
+)
+
+// HandleList returns an http.HandlerFunc that writes a json-encoded
+// list of build history to the response body.
+func HandleList(
+	repos core.RepositoryStore,
+	builds core.BuildStore,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var (
+			namespace = chi.URLParam(r, "owner")
+			name      = chi.URLParam(r, "name")
+		)
+		repo, err := repos.FindName(r.Context(), namespace, name)
+		if err != nil {
+			render.NotFound(w, err)
+			logger.FromRequest(r).
+				WithError(err).
+				WithField("namespace", namespace).
+				WithField("name", name).
+				Debugln("api: cannot find repository")
+			return
+		}
+
+		results, err := builds.LatestDeploys(r.Context(), repo.ID)
+		if err != nil {
+			render.InternalError(w, err)
+			logger.FromRequest(r).
+				WithError(err).
+				WithField("namespace", namespace).
+				WithField("name", name).
+				Debugln("api: cannot list builds")
+		} else {
+			render.JSON(w, results, 200)
+		}
+	}
+}

--- a/handler/api/repos/builds/deploys/list_test.go
+++ b/handler/api/repos/builds/deploys/list_test.go
@@ -1,0 +1,5 @@
+// Copyright 2019 Drone.IO Inc. All rights reserved.
+// Use of this source code is governed by the Drone Non-Commercial License
+// that can be found in the LICENSE file.
+
+package deploys

--- a/handler/api/repos/builds/find_test.go
+++ b/handler/api/repos/builds/find_test.go
@@ -10,8 +10,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/drone/drone/mock"
 	"github.com/drone/drone/handler/api/errors"
+	"github.com/drone/drone/mock"
 
 	"github.com/go-chi/chi"
 	"github.com/golang/mock/gomock"

--- a/handler/api/repos/builds/pulls/create.go
+++ b/handler/api/repos/builds/pulls/create.go
@@ -1,0 +1,15 @@
+// Copyright 2019 Drone IO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pulls

--- a/handler/api/repos/builds/pulls/create_test.go
+++ b/handler/api/repos/builds/pulls/create_test.go
@@ -1,0 +1,5 @@
+// Copyright 2019 Drone.IO Inc. All rights reserved.
+// Use of this source code is governed by the Drone Non-Commercial License
+// that can be found in the LICENSE file.
+
+package pulls

--- a/handler/api/repos/builds/pulls/delete.go
+++ b/handler/api/repos/builds/pulls/delete.go
@@ -1,0 +1,62 @@
+// Copyright 2019 Drone IO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pulls
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/drone/drone/core"
+	"github.com/drone/drone/handler/api/render"
+	"github.com/drone/drone/logger"
+	"github.com/go-chi/chi"
+)
+
+// HandleDelete returns an http.HandlerFunc that handles an
+// http.Request to delete a branch entry from the datastore.
+func HandleDelete(
+	repos core.RepositoryStore,
+	builds core.BuildStore,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var (
+			namespace = chi.URLParam(r, "owner")
+			name      = chi.URLParam(r, "name")
+			number, _ = strconv.Atoi(chi.URLParam(r, "pull"))
+		)
+		repo, err := repos.FindName(r.Context(), namespace, name)
+		if err != nil {
+			render.NotFound(w, err)
+			logger.FromRequest(r).
+				WithError(err).
+				WithField("namespace", namespace).
+				WithField("name", name).
+				Debugln("api: cannot find repository")
+			return
+		}
+
+		err = builds.DeletePull(r.Context(), repo.ID, number)
+		if err != nil {
+			render.InternalError(w, err)
+			logger.FromRequest(r).
+				WithError(err).
+				WithField("namespace", namespace).
+				WithField("name", name).
+				Debugln("api: cannot delete pr")
+		} else {
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}
+}

--- a/handler/api/repos/builds/pulls/delete_test.go
+++ b/handler/api/repos/builds/pulls/delete_test.go
@@ -1,0 +1,5 @@
+// Copyright 2019 Drone.IO Inc. All rights reserved.
+// Use of this source code is governed by the Drone Non-Commercial License
+// that can be found in the LICENSE file.
+
+package pulls

--- a/handler/api/repos/builds/pulls/list.go
+++ b/handler/api/repos/builds/pulls/list.go
@@ -1,0 +1,61 @@
+// Copyright 2019 Drone IO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pulls
+
+import (
+	"net/http"
+
+	"github.com/drone/drone/core"
+	"github.com/drone/drone/handler/api/render"
+	"github.com/drone/drone/logger"
+
+	"github.com/go-chi/chi"
+)
+
+// HandleList returns an http.HandlerFunc that writes a json-encoded
+// list of build history to the response body.
+func HandleList(
+	repos core.RepositoryStore,
+	builds core.BuildStore,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var (
+			namespace = chi.URLParam(r, "owner")
+			name      = chi.URLParam(r, "name")
+		)
+		repo, err := repos.FindName(r.Context(), namespace, name)
+		if err != nil {
+			render.NotFound(w, err)
+			logger.FromRequest(r).
+				WithError(err).
+				WithField("namespace", namespace).
+				WithField("name", name).
+				Debugln("api: cannot find repository")
+			return
+		}
+
+		results, err := builds.LatestPulls(r.Context(), repo.ID)
+		if err != nil {
+			render.InternalError(w, err)
+			logger.FromRequest(r).
+				WithError(err).
+				WithField("namespace", namespace).
+				WithField("name", name).
+				Debugln("api: cannot list builds")
+		} else {
+			render.JSON(w, results, 200)
+		}
+	}
+}

--- a/handler/api/repos/builds/pulls/list_test.go
+++ b/handler/api/repos/builds/pulls/list_test.go
@@ -1,0 +1,5 @@
+// Copyright 2019 Drone.IO Inc. All rights reserved.
+// Use of this source code is governed by the Drone Non-Commercial License
+// that can be found in the LICENSE file.
+
+package pulls

--- a/handler/web/hook.go
+++ b/handler/web/hook.go
@@ -84,146 +84,6 @@ func HandleHook(
 		// TODO handle ping requests
 		// TODO consider using scm.Repository in the function callback.
 
-		// // TODO break this to a separate function that
-		// // we can unit test.
-		// fn := func(webhook interface{}) (string, error) {
-		// 	var remote scm.Repository
-		// 	switch v := core.(type) {
-		// 	case *scm.PushHook:
-		// 		remote = v.Repo
-		// 	case *scm.BranchHook:
-		// 		remote = v.Repo
-		// 	case *scm.TagHook:
-		// 		remote = v.Repo
-		// 	case *scm.PullRequestHook:
-		// 		remote = v.Repo
-		// 	case *scm.IssueHook:
-		// 		remote = v.Repo
-		// 	case *scm.IssueCommentHook:
-		// 		remote = v.Repo
-		// 	case *scm.PullRequestCommentHook:
-		// 		remote = v.Repo
-		// 	case *scm.ReviewCommentHook:
-		// 		remote = v.Repo
-		// 	}
-		// 	repo, err := repos.FindName(r.Context(), remote.Namespace, remote.Name)
-		// 	if err != nil {
-		// 		hlog.FromRequest(r).Error().
-		// 			Err(err).
-		// 			Str("namespace", remote.Namespace).
-		// 			Str("name", remote.Name).
-		// 			Msg("cannot find repository")
-		// 		return "", err
-		// 	}
-		// 	return repo.Token, nil
-		// }
-
-		// hook, err := client.Webhooks.Parse(r, fn)
-		// if err != nil {
-		// 	hlog.FromRequest(r).Error().
-		// 		Err(err).
-		// 		Msg("cannot parse webhook")
-		// 	writeError(w, err)
-		// 	return
-		// }
-
-		// var name, namespace string
-		// var base = new(core.Build)
-		// switch v := hook.(type) {
-		// case *scm.PushHook:
-		// 	namespace, name = v.Repo.Namespace, v.Repo.Name
-		// 	base.Event = core.EventPush
-
-		// 	base.Link = v.Commit.Link
-		// 	base.Timestamp = v.Commit.Author.Date.Unix()
-		// 	base.Title = ""
-		// 	base.Message = v.Commit.Message
-		// 	base.Before = ""
-		// 	base.After = v.Commit.Sha
-		// 	base.Ref = v.Ref
-		// 	base.Source = strings.TrimPrefix(v.Ref, "refs/heads/")
-		// 	base.Target = strings.TrimPrefix(v.Ref, "refs/heads/")
-		// 	base.Author = v.Commit.Author.Login
-		// 	base.AuthorName = v.Commit.Author.Name
-		// 	base.AuthorEmail = v.Commit.Author.Email
-		// 	base.AuthorAvatar = v.Commit.Author.Avatar
-		// 	base.Sender = v.Sender.Login
-
-		// 	// TODO: this is a deficiency with gogs
-		// 	if base.AuthorAvatar == "" {
-		// 		base.AuthorAvatar = v.Sender.Avatar
-		// 	}
-		// case *scm.TagHook:
-
-		// 	namespace, name = v.Repo.Namespace, v.Repo.Name
-		// 	base.Event = core.EventTag
-		// 	base.Action = v.Action.String()
-
-		// 	base.Link = ""     // TODO
-		// 	base.Timestamp = 0 // TODO
-		// 	base.Title = ""
-		// 	base.Message = "" // TODO
-		// 	base.Before = ""  // TODO
-		// 	base.After = v.Ref.Sha
-		// 	base.Ref = v.Ref.Name // TODO prepend refs/tags?
-		// 	base.Source = ""
-		// 	base.Target = ""
-		// 	base.Author = v.Sender.Login
-		// 	base.AuthorName = v.Sender.Name
-		// 	base.AuthorEmail = v.Sender.Email
-		// 	base.AuthorAvatar = v.Sender.Avatar
-		// 	base.Sender = v.Sender.Login
-
-		// 	switch v.Action {
-		// 	case scm.ActionCreate:
-		// 	default:
-		// 		hlog.FromRequest(r).Debug().
-		// 			Str("namespace", namespace).
-		// 			Str("name", name).
-		// 			Str("event", base.Event).
-		// 			Str("action", base.Action).
-		// 			Msgf("ignore webhook with action %s", base.Action)
-		// 		w.WriteHeader(200)
-		// 		return
-		// 	}
-
-		// case *scm.PullRequestHook:
-		// 	namespace, name = v.Repo.Namespace, v.Repo.Name
-		// 	base.Event = core.EventPullRequest
-		// 	base.Action = v.Action.String()
-
-		// 	base.Link = v.PullRequest.Link
-		// 	base.Timestamp = v.PullRequest.Created.Unix()
-		// 	base.Title = v.PullRequest.Title
-		// 	base.Message = "" // TODO
-		// 	base.Before = ""  // TODO
-		// 	base.After = v.PullRequest.Sha
-		// 	base.Ref = v.PullRequest.Ref
-		// 	base.Source = v.PullRequest.Source
-		// 	base.Target = v.PullRequest.Target
-		// 	base.Author = v.PullRequest.Author.Login
-		// 	base.AuthorName = v.PullRequest.Author.Name
-		// 	base.AuthorEmail = v.PullRequest.Author.Email
-		// 	base.AuthorAvatar = v.PullRequest.Author.Avatar
-		// 	base.Sender = v.Sender.Login
-
-		// 	switch v.Action {
-		// 	case scm.ActionCreate, scm.ActionOpen, scm.ActionSync:
-		// 	default:
-		// 		hlog.FromRequest(r).Debug().
-		// 			Str("namespace", namespace).
-		// 			Str("name", name).
-		// 			Str("event", base.Event).
-		// 			Str("action", base.Action).
-		// 			Msgf("ignore pull request hook with action %s", base.Action)
-		// 		w.WriteHeader(200)
-		// 		return
-		// 	}
-		// default:
-		// 	w.WriteHeader(200)
-		// 	return
-		// }
-
 		log := logrus.WithFields(logrus.Fields{
 			"namespace": remote.Namespace,
 			"name":      remote.Name,
@@ -250,6 +110,19 @@ func HandleHook(
 		ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 		ctx = logger.WithContext(ctx, log)
 		defer cancel()
+
+		if hook.Event == core.EventPush && hook.Action == core.ActionDelete {
+			log.WithField("branch", hook.Target).Debugln("branch deleted")
+			builds.DeleteBranch(ctx, repo.ID, hook.Target)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if hook.Event == core.EventPullRequest && hook.Action == core.ActionClose {
+			log.WithField("ref", hook.Ref).Debugln("pull request closed")
+			builds.DeletePull(ctx, repo.ID, scm.ExtractPullRequest(hook.Ref))
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
 
 		builds, err := triggerer.Trigger(ctx, repo, hook)
 		if err != nil {

--- a/mock/mock_gen.go
+++ b/mock/mock_gen.go
@@ -737,6 +737,48 @@ func (mr *MockBuildStoreMockRecorder) Delete(arg0, arg1 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockBuildStore)(nil).Delete), arg0, arg1)
 }
 
+// DeleteBranch mocks base method
+func (m *MockBuildStore) DeleteBranch(arg0 context.Context, arg1 int64, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteBranch", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteBranch indicates an expected call of DeleteBranch
+func (mr *MockBuildStoreMockRecorder) DeleteBranch(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBranch", reflect.TypeOf((*MockBuildStore)(nil).DeleteBranch), arg0, arg1, arg2)
+}
+
+// DeleteDeploy mocks base method
+func (m *MockBuildStore) DeleteDeploy(arg0 context.Context, arg1 int64, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteDeploy", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteDeploy indicates an expected call of DeleteDeploy
+func (mr *MockBuildStoreMockRecorder) DeleteDeploy(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDeploy", reflect.TypeOf((*MockBuildStore)(nil).DeleteDeploy), arg0, arg1, arg2)
+}
+
+// DeletePull mocks base method
+func (m *MockBuildStore) DeletePull(arg0 context.Context, arg1 int64, arg2 int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeletePull", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeletePull indicates an expected call of DeletePull
+func (mr *MockBuildStoreMockRecorder) DeletePull(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePull", reflect.TypeOf((*MockBuildStore)(nil).DeletePull), arg0, arg1, arg2)
+}
+
 // Find mocks base method
 func (m *MockBuildStore) Find(arg0 context.Context, arg1 int64) (*core.Build, error) {
 	m.ctrl.T.Helper()
@@ -780,6 +822,36 @@ func (m *MockBuildStore) FindRef(arg0 context.Context, arg1 int64, arg2 string) 
 func (mr *MockBuildStoreMockRecorder) FindRef(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindRef", reflect.TypeOf((*MockBuildStore)(nil).FindRef), arg0, arg1, arg2)
+}
+
+// LatestBranches mocks base method
+func (m *MockBuildStore) LatestBranches(arg0 context.Context, arg1 int64) ([]*core.Build, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LatestBranches", arg0, arg1)
+	ret0, _ := ret[0].([]*core.Build)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LatestBranches indicates an expected call of LatestBranches
+func (mr *MockBuildStoreMockRecorder) LatestBranches(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LatestBranches", reflect.TypeOf((*MockBuildStore)(nil).LatestBranches), arg0, arg1)
+}
+
+// LatestPulls mocks base method
+func (m *MockBuildStore) LatestPulls(arg0 context.Context, arg1 int64) ([]*core.Build, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LatestPulls", arg0, arg1)
+	ret0, _ := ret[0].([]*core.Build)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LatestPulls indicates an expected call of LatestPulls
+func (mr *MockBuildStoreMockRecorder) LatestPulls(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LatestPulls", reflect.TypeOf((*MockBuildStore)(nil).LatestPulls), arg0, arg1)
 }
 
 // List mocks base method

--- a/mock/mock_gen.go
+++ b/mock/mock_gen.go
@@ -839,6 +839,21 @@ func (mr *MockBuildStoreMockRecorder) LatestBranches(arg0, arg1 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LatestBranches", reflect.TypeOf((*MockBuildStore)(nil).LatestBranches), arg0, arg1)
 }
 
+// LatestDeploys mocks base method
+func (m *MockBuildStore) LatestDeploys(arg0 context.Context, arg1 int64) ([]*core.Build, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LatestDeploys", arg0, arg1)
+	ret0, _ := ret[0].([]*core.Build)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LatestDeploys indicates an expected call of LatestDeploys
+func (mr *MockBuildStoreMockRecorder) LatestDeploys(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LatestDeploys", reflect.TypeOf((*MockBuildStore)(nil).LatestDeploys), arg0, arg1)
+}
+
 // LatestPulls mocks base method
 func (m *MockBuildStore) LatestPulls(arg0 context.Context, arg1 int64) ([]*core.Build, error) {
 	m.ctrl.T.Helper()

--- a/service/hook/parser/parse.go
+++ b/service/hook/parser/parse.go
@@ -232,6 +232,23 @@ func (p *parser) Parse(req *http.Request, secretFunc func(string) string) (*core
 		}
 		return hook, repo, nil
 	case *scm.PullRequestHook:
+
+		// TODO(bradrydzewski) cleanup the pr close hook code.
+		if v.Action == scm.ActionClose {
+			return &core.Hook{
+					Trigger: core.TriggerHook,
+					Event:   core.EventPullRequest,
+					Action:  core.ActionClose,
+					After:   v.PullRequest.Sha,
+					Ref:     v.PullRequest.Ref,
+				}, &core.Repository{
+					UID:       v.Repo.ID,
+					Namespace: v.Repo.Namespace,
+					Name:      v.Repo.Name,
+					Slug:      scm.Join(v.Repo.Namespace, v.Repo.Name),
+				}, nil
+		}
+
 		if v.Action != scm.ActionOpen && v.Action != scm.ActionSync {
 			return nil, nil, nil
 		}
@@ -284,6 +301,23 @@ func (p *parser) Parse(req *http.Request, secretFunc func(string) string) (*core
 		}
 		return hook, repo, nil
 	case *scm.BranchHook:
+
+		// TODO(bradrydzewski) cleanup the branch hook code.
+		if v.Action == scm.ActionDelete {
+			return &core.Hook{
+					Trigger: core.TriggerHook,
+					Event:   core.EventPush,
+					After:   v.Ref.Sha,
+					Action:  core.ActionDelete,
+					Target:  scm.TrimRef(v.Ref.Name),
+				}, &core.Repository{
+					UID:       v.Repo.ID,
+					Namespace: v.Repo.Namespace,
+					Name:      v.Repo.Name,
+					Slug:      scm.Join(v.Repo.Namespace, v.Repo.Name),
+				}, nil
+		}
+
 		if v.Action != scm.ActionCreate {
 			return nil, nil, nil
 		}

--- a/store/shared/db/dbtest/dbtest.go
+++ b/store/shared/db/dbtest/dbtest.go
@@ -47,6 +47,7 @@ func Reset(d *db.DB) {
 		tx.Exec("DELETE FROM logs")
 		tx.Exec("DELETE FROM steps")
 		tx.Exec("DELETE FROM stages")
+		tx.Exec("DELETE FROM latest")
 		tx.Exec("DELETE FROM builds")
 		tx.Exec("DELETE FROM perms")
 		tx.Exec("DELETE FROM repos")

--- a/store/shared/migrate/mysql/ddl_gen.go
+++ b/store/shared/migrate/mysql/ddl_gen.go
@@ -136,6 +136,14 @@ var migrations = []struct {
 		name: "alter-table-builds-add-column-deploy-id",
 		stmt: alterTableBuildsAddColumnDeployId,
 	},
+	{
+		name: "create-table-latest",
+		stmt: createTableLatest,
+	},
+	{
+		name: "create-index-latest-repo",
+		stmt: createIndexLatestRepo,
+	},
 }
 
 // Migrate performs the database migration. If the migration fails
@@ -604,4 +612,25 @@ CREATE TABLE IF NOT EXISTS orgsecrets (
 
 var alterTableBuildsAddColumnDeployId = `
 ALTER TABLE builds ADD COLUMN build_deploy_id INTEGER NOT NULL DEFAULT 0;
+`
+
+//
+// 014_create_table_refs.sql
+//
+
+var createTableLatest = `
+CREATE TABLE IF NOT EXISTS latest (
+ latest_repo_id  INTEGER
+,latest_build_id INTEGER
+,latest_type     VARCHAR(50)
+,latest_name     VARCHAR(500)
+,latest_created  INTEGER
+,latest_updated  INTEGER
+,latest_deleted  INTEGER
+,PRIMARY KEY(latest_repo_id, latest_type, latest_name)
+);
+`
+
+var createIndexLatestRepo = `
+CREATE INDEX ix_latest_repo ON latest (latest_repo_id);
 `

--- a/store/shared/migrate/mysql/files/014_create_table_refs.sql
+++ b/store/shared/migrate/mysql/files/014_create_table_refs.sql
@@ -1,0 +1,16 @@
+-- name: create-table-latest
+
+CREATE TABLE IF NOT EXISTS latest (
+ latest_repo_id  INTEGER
+,latest_build_id INTEGER
+,latest_type     VARCHAR(50)
+,latest_name     VARCHAR(500)
+,latest_created  INTEGER
+,latest_updated  INTEGER
+,latest_deleted  INTEGER
+,PRIMARY KEY(latest_repo_id, latest_type, latest_name)
+);
+
+-- name: create-index-latest-repo
+
+CREATE INDEX ix_latest_repo ON latest (latest_repo_id);

--- a/store/shared/migrate/postgres/ddl_gen.go
+++ b/store/shared/migrate/postgres/ddl_gen.go
@@ -132,6 +132,14 @@ var migrations = []struct {
 		name: "alter-table-builds-add-column-deploy-id",
 		stmt: alterTableBuildsAddColumnDeployId,
 	},
+	{
+		name: "create-table-latest",
+		stmt: createTableLatest,
+	},
+	{
+		name: "create-index-latest-repo",
+		stmt: createIndexLatestRepo,
+	},
 }
 
 // Migrate performs the database migration. If the migration fails
@@ -582,4 +590,25 @@ CREATE TABLE IF NOT EXISTS orgsecrets (
 
 var alterTableBuildsAddColumnDeployId = `
 ALTER TABLE builds ADD COLUMN build_deploy_id INTEGER NOT NULL DEFAULT 0;
+`
+
+//
+// 015_create_table_refs.sql
+//
+
+var createTableLatest = `
+CREATE TABLE IF NOT EXISTS latest (
+ latest_repo_id  INTEGER
+,latest_build_id INTEGER
+,latest_type     VARCHAR(50)
+,latest_name     VARCHAR(500)
+,latest_created  INTEGER
+,latest_updated  INTEGER
+,latest_deleted  INTEGER
+,PRIMARY KEY(latest_repo_id, latest_type, latest_name)
+);
+`
+
+var createIndexLatestRepo = `
+CREATE INDEX IF NOT EXISTS ix_latest_repo ON latest (latest_repo_id);
 `

--- a/store/shared/migrate/postgres/files/015_create_table_refs.sql
+++ b/store/shared/migrate/postgres/files/015_create_table_refs.sql
@@ -1,0 +1,16 @@
+-- name: create-table-latest
+
+CREATE TABLE IF NOT EXISTS latest (
+ latest_repo_id  INTEGER
+,latest_build_id INTEGER
+,latest_type     VARCHAR(50)
+,latest_name     VARCHAR(500)
+,latest_created  INTEGER
+,latest_updated  INTEGER
+,latest_deleted  INTEGER
+,PRIMARY KEY(latest_repo_id, latest_type, latest_name)
+);
+
+-- name: create-index-latest-repo
+
+CREATE INDEX IF NOT EXISTS ix_latest_repo ON latest (latest_repo_id);

--- a/store/shared/migrate/sqlite/ddl_gen.go
+++ b/store/shared/migrate/sqlite/ddl_gen.go
@@ -132,6 +132,14 @@ var migrations = []struct {
 		name: "alter-table-builds-add-column-deploy-id",
 		stmt: alterTableBuildsAddColumnDeployId,
 	},
+	{
+		name: "create-table-latest",
+		stmt: createTableLatest,
+	},
+	{
+		name: "create-index-latest-repo",
+		stmt: createIndexLatestRepo,
+	},
 }
 
 // Migrate performs the database migration. If the migration fails
@@ -584,4 +592,25 @@ CREATE TABLE IF NOT EXISTS orgsecrets (
 
 var alterTableBuildsAddColumnDeployId = `
 ALTER TABLE builds ADD COLUMN build_deploy_id NUMBER NOT NULL DEFAULT 0;
+`
+
+//
+// 014_create_table_refs.sql
+//
+
+var createTableLatest = `
+CREATE TABLE IF NOT EXISTS latest (
+ latest_repo_id  INTEGER
+,latest_build_id INTEGER
+,latest_type     TEXT -- branch | tag     | pull_request | promote
+,latest_name     TEXT -- master | v1.0.0, | 42           | production
+,latest_created  INTEGER
+,latest_updated  INTEGER
+,latest_deleted  INTEGER
+,PRIMARY KEY(latest_repo_id, latest_type, latest_name)
+);
+`
+
+var createIndexLatestRepo = `
+CREATE INDEX IF NOT EXISTS ix_latest_repo ON latest (latest_repo_id);
 `

--- a/store/shared/migrate/sqlite/files/014_create_table_refs.sql
+++ b/store/shared/migrate/sqlite/files/014_create_table_refs.sql
@@ -1,0 +1,16 @@
+-- name: create-table-latest
+
+CREATE TABLE IF NOT EXISTS latest (
+ latest_repo_id  INTEGER
+,latest_build_id INTEGER
+,latest_type     TEXT -- branch | tag     | pull_request | promote
+,latest_name     TEXT -- master | v1.0.0, | 42           | production
+,latest_created  INTEGER
+,latest_updated  INTEGER
+,latest_deleted  INTEGER
+,PRIMARY KEY(latest_repo_id, latest_type, latest_name)
+);
+
+-- name: create-index-latest-repo
+
+CREATE INDEX IF NOT EXISTS ix_latest_repo ON latest (latest_repo_id);


### PR DESCRIPTION
This pull request adds new database capabilities to index the latest build for each branch, tag, pull request and deployment for efficient retrieval.  It also updates our webhook code to process branch delete hooks and pull request close hooks to remove from the index.

The latest build data per branch and pull request is exposed via the below endpoints. We also added endpoints to remove an entry from the index.

```
GET    /api/repos/{namespace}/{name}/builds/branches
DELETE /api/repos/{namespace}/{name}/builds/branches/{branch}
GET    /api/repos/{namespace}/{name}/builds/pulls
DELETE /api/repos/{namespace}/{name}/builds/pulls/{pr}
```

The purpose of these endpoints is to facilitate screens in the user interface that display the latest branch, pull request and deployment details. Example deployment screen:

<img width="1012" alt="66261742-b7194a80-e787-11e9-8ce8-c95e1bede497" src="https://user-images.githubusercontent.com/817538/76646144-dc796400-6530-11ea-90f8-f6bb8d781179.png">
