### PR TITLE
dot is valid for username

### DIFF
--- a/core/user.go
+++ b/core/user.go
@@ -94,7 +94,7 @@ func (u *User) Validate() error {
 	switch {
 	case !govalidator.IsByteLength(u.Login, 1, 50):
 		return errUsernameLen
-	case !govalidator.Matches(u.Login, "^[a-zA-Z0-9_-]+$"):
+	case !govalidator.Matches(u.Login, "^[.a-zA-Z0-9_-]+$"):
 		return errUsernameChar
 	default:
 		return nil

--- a/core/user_test.go
+++ b/core/user_test.go
@@ -40,6 +40,10 @@ func TestValidateUser(t *testing.T) {
 			err:  nil,
 		},
 		{
+			user: &User{Login: "octocat.with.dot"},
+			err:  nil,
+		},
+		{
 			user: &User{Login: "OctO-Cat_01"},
 			err:  nil,
 		},


### PR DESCRIPTION
Currently Drone doesn't allow (.) in username but thats valid (at least in gitlab)
example: https://gitlab.com/hadi.farnoud
![Screenshot from 2020-04-30 00-59-45](https://user-images.githubusercontent.com/10362398/80643845-fc7fcb00-8a7d-11ea-8fb4-7815a28f60df.png)
