### PR TITLE
Do not ignore Gitea TagHook

### DIFF
--- a/service/hook/parser/parse.go
+++ b/service/hook/parser/parse.go
@@ -186,7 +186,6 @@ func (p *parser) Parse(req *http.Request, secretFunc func(string) string) (*core
 		// information, so we choose to use the push hook and
 		// ignore the native tag hook.
 		if p.client.Driver == scm.DriverGithub ||
-			p.client.Driver == scm.DriverGitea ||
 			p.client.Driver == scm.DriverGitlab {
 			return nil, nil, nil
 		}

--- a/service/hook/parser/parse.go
+++ b/service/hook/parser/parse.go
@@ -122,6 +122,14 @@ func (p *parser) Parse(req *http.Request, secretFunc func(string) string) (*core
 		// push hook contains more information than the tag hook,
 		// so we choose to use the push hook for tags.
 		if strings.HasPrefix(v.Ref, "refs/tags/") {
+			// gitea versions < 1.12 used to send both push and tag
+			// webhook, however only tag is sent from 1.12 onwards.
+			// ignore push event here so that older versions don't
+			// cause duplicated jobs.
+			if p.client.Driver == scm.DriverGitea {
+				return nil, nil, nil
+			}
+			
 			hook = &core.Hook{
 				Trigger:      core.TriggerHook, // core.TriggerHook
 				Event:        core.EventTag,


### PR DESCRIPTION
Gitea no longer sends push webhook for tag events, as per https://github.com/go-gitea/gitea/pull/11082