### PR TITLE
Add configurable timeout for config, convert, and validate plugins

### DIFF
--- a/cmd/drone-server/config/config.go
+++ b/cmd/drone-server/config/config.go
@@ -98,7 +98,7 @@ type (
 	}
 
 	Cleanup struct {
-		Disabled  bool         `envconfig:"DRONE_CLEANUP_DISABLED"`
+		Disabled bool          `envconfig:"DRONE_CLEANUP_DISABLED"`
 		Interval time.Duration `envconfig:"DRONE_CLEANUP_INTERVAL"         default:"24h"`
 		Running  time.Duration `envconfig:"DRONE_CLEANUP_DEADLINE_RUNNING" default:"24h"`
 		Pending  time.Duration `envconfig:"DRONE_CLEANUP_DEADLINE_PENDING" default:"24h"`
@@ -308,24 +308,27 @@ type (
 
 	// Yaml provides the yaml webhook configuration.
 	Yaml struct {
-		Endpoint   string `envconfig:"DRONE_YAML_ENDPOINT"`
-		Secret     string `envconfig:"DRONE_YAML_SECRET"`
-		SkipVerify bool   `envconfig:"DRONE_YAML_SKIP_VERIFY"`
+		Endpoint   string        `envconfig:"DRONE_YAML_ENDPOINT"`
+		Secret     string        `envconfig:"DRONE_YAML_SECRET"`
+		SkipVerify bool          `envconfig:"DRONE_YAML_SKIP_VERIFY"`
+		Timeout    time.Duration `envconfig:"DRONE_YAML_TIMEOUT" default:"1m"`
 	}
 
 	// Convert provides the converter webhook configuration.
 	Convert struct {
-		Extension  string `envconfig:"DRONE_CONVERT_PLUGIN_EXTENSION"`
-		Endpoint   string `envconfig:"DRONE_CONVERT_PLUGIN_ENDPOINT"`
-		Secret     string `envconfig:"DRONE_CONVERT_PLUGIN_SECRET"`
-		SkipVerify bool   `envconfig:"DRONE_CONVERT_PLUGIN_SKIP_VERIFY"`
+		Extension  string        `envconfig:"DRONE_CONVERT_PLUGIN_EXTENSION"`
+		Endpoint   string        `envconfig:"DRONE_CONVERT_PLUGIN_ENDPOINT"`
+		Secret     string        `envconfig:"DRONE_CONVERT_PLUGIN_SECRET"`
+		SkipVerify bool          `envconfig:"DRONE_CONVERT_PLUGIN_SKIP_VERIFY"`
+		Timeout    time.Duration `envconfig:"DRONE_CONVERT_TIMEOUT" default:"1m"`
 	}
 
 	// Validate provides the validation webhook configuration.
 	Validate struct {
-		Endpoint   string `envconfig:"DRONE_VALIDATE_PLUGIN_ENDPOINT"`
-		Secret     string `envconfig:"DRONE_VALIDATE_PLUGIN_SECRET"`
-		SkipVerify bool   `envconfig:"DRONE_VALIDATE_PLUGIN_SKIP_VERIFY"`
+		Endpoint   string        `envconfig:"DRONE_VALIDATE_PLUGIN_ENDPOINT"`
+		Secret     string        `envconfig:"DRONE_VALIDATE_PLUGIN_SECRET"`
+		SkipVerify bool          `envconfig:"DRONE_VALIDATE_PLUGIN_SKIP_VERIFY"`
+		Timeout    time.Duration `envconfig:"DRONE_VALIDATE_TIMEOUT" default:"1m"`
 	}
 
 	//

--- a/cmd/drone-server/inject_plugin.go
+++ b/cmd/drone-server/inject_plugin.go
@@ -65,6 +65,7 @@ func provideConfigPlugin(client *scm.Client, contents core.FileService, conf spe
 			conf.Yaml.Endpoint,
 			conf.Yaml.Secret,
 			conf.Yaml.SkipVerify,
+			conf.Yaml.Timeout,
 		),
 		config.Repository(contents),
 	)
@@ -85,6 +86,7 @@ func provideConvertPlugin(client *scm.Client, conf spec.Config) core.ConvertServ
 			conf.Convert.Secret,
 			conf.Convert.Extension,
 			conf.Convert.SkipVerify,
+			conf.Convert.Timeout,
 		),
 	)
 }
@@ -129,6 +131,7 @@ func provideValidatePlugin(conf spec.Config) core.ValidateService {
 			conf.Validate.Endpoint,
 			conf.Validate.Secret,
 			conf.Validate.SkipVerify,
+			conf.Validate.Timeout,
 		),
 	)
 }

--- a/plugin/config/global_oss.go
+++ b/plugin/config/global_oss.go
@@ -18,12 +18,13 @@ package config
 
 import (
 	"context"
+	"time"
 
 	"github.com/drone/drone/core"
 )
 
 // Global returns a no-op configuration service.
-func Global(string, string, bool) core.ConfigService {
+func Global(string, string, bool, time.Duration) core.ConfigService {
 	return new(noop)
 }
 

--- a/plugin/config/global_test.go
+++ b/plugin/config/global_test.go
@@ -8,6 +8,7 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	"github.com/drone/drone/core"
 	"github.com/h2non/gock"
@@ -31,7 +32,8 @@ func TestGlobal(t *testing.T) {
 		Build: &core.Build{After: "6d144de7"},
 	}
 
-	service := Global("https://company.com/config", "GMEuUHQfmrMRsseWxi9YlIeBtn9lm6im", false)
+	service := Global("https://company.com/config", "GMEuUHQfmrMRsseWxi9YlIeBtn9lm6im",
+		false, time.Minute)
 	result, err := service.Find(noContext, args)
 	if err != nil {
 		t.Error(err)
@@ -65,7 +67,8 @@ func TestGlobalErr(t *testing.T) {
 		Build: &core.Build{After: "6d144de7"},
 	}
 
-	service := Global("https://company.com/config", "GMEuUHQfmrMRsseWxi9YlIeBtn9lm6im", false)
+	service := Global("https://company.com/config", "GMEuUHQfmrMRsseWxi9YlIeBtn9lm6im",
+		false, time.Minute)
 	_, err := service.Find(noContext, args)
 	if err == nil {
 		t.Errorf("Expect http.Reponse error")
@@ -95,7 +98,8 @@ func TestGlobalEmpty(t *testing.T) {
 		Build: &core.Build{After: "6d144de7"},
 	}
 
-	service := Global("https://company.com/config", "GMEuUHQfmrMRsseWxi9YlIeBtn9lm6im", false)
+	service := Global("https://company.com/config", "GMEuUHQfmrMRsseWxi9YlIeBtn9lm6im",
+		false, time.Minute)
 	result, err := service.Find(noContext, args)
 	if err != nil {
 		t.Error(err)
@@ -112,7 +116,7 @@ func TestGlobalEmpty(t *testing.T) {
 }
 
 func TestGlobalDisabled(t *testing.T) {
-	res, err := Global("", "", false).Find(noContext, nil)
+	res, err := Global("", "", false, time.Minute).Find(noContext, nil)
 	if err != nil {
 		t.Error(err)
 	}

--- a/plugin/converter/remote_oss.go
+++ b/plugin/converter/remote_oss.go
@@ -17,11 +17,13 @@
 package converter
 
 import (
+	"time"
+
 	"github.com/drone/drone/core"
 )
 
 // Remote returns a conversion service that converts the
 // configuration file using a remote http service.
-func Remote(endpoint, signer, extension string, skipVerify bool) core.ConvertService {
+func Remote(endpoint, signer, extension string, skipVerify bool, timeout time.Duration) core.ConvertService {
 	return new(noop)
 }

--- a/plugin/converter/remote_test.go
+++ b/plugin/converter/remote_test.go
@@ -9,6 +9,7 @@ package converter
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/drone/drone/core"
 	"github.com/h2non/gock"
@@ -35,7 +36,8 @@ func TestConvert(t *testing.T) {
 		},
 	}
 
-	service := Remote("https://company.com/convert", "GMEuUHQfmrMRsseWxi9YlIeBtn9lm6im", "", false)
+	service := Remote("https://company.com/convert", "GMEuUHQfmrMRsseWxi9YlIeBtn9lm6im", "",
+		false, time.Minute)
 	result, err := service.Convert(context.Background(), args)
 	if err != nil {
 		t.Error(err)

--- a/plugin/validator/remote_oss.go
+++ b/plugin/validator/remote_oss.go
@@ -17,11 +17,13 @@
 package validator
 
 import (
+	"time"
+
 	"github.com/drone/drone/core"
 )
 
 // Remote returns a conversion service that converts the
 // configuration file using a remote http service.
-func Remote(endpoint, signer string, skipVerify bool) core.ValidateService {
+func Remote(endpoint, signer string, skipVerify bool, timeout time.Duration) core.ValidateService {
 	return new(noop)
 }


### PR DESCRIPTION
Also run 'go fmt' on changed files

--- 
Justification for this PR - See 2. in https://github.com/bitsbeats/drone-tree-config/issues/26

Though the issue was specific to a `config` plugin, I implemented the timeout option for `validate` and `convert` also. Projecting a bit -- it seemed useful to do so.