### PR TITLE
fix oss build: wrong type for Memoize parameter and return value

### DIFF
--- a/plugin/config/memoize_oss.go
+++ b/plugin/config/memoize_oss.go
@@ -24,6 +24,6 @@ import (
 // This micro-optimization is intended for multi-pipeline
 // projects that would otherwise covert the file for each
 // pipeline execution.
-func Memoize(base core.ConvertService) core.ConvertService {
+func Memoize(base core.ConfigService) core.ConfigService {
 	return new(noop)
 }


### PR DESCRIPTION
I noticed that oss builds are currently failing due to an invalid argument and return type.