### PR TITLE
fix(trigger) : Change order of skip triggers

### DIFF
--- a/trigger/trigger.go
+++ b/trigger/trigger.go
@@ -94,21 +94,6 @@ func (t *triggerer) Trigger(ctx context.Context, repo *core.Repository, base *co
 		}
 	}()
 
-	if skipMessage(base) {
-		logger.Infoln("trigger: skipping hook. found skip directive")
-		return nil, nil
-	}
-	if base.Event == core.EventPullRequest {
-		if repo.IgnorePulls {
-			logger.Infoln("trigger: skipping hook. project ignores pull requests")
-			return nil, nil
-		}
-		if repo.IgnoreForks && !strings.EqualFold(base.Fork, repo.Slug) {
-			logger.Infoln("trigger: skipping hook. project ignores forks")
-			return nil, nil
-		}
-	}
-
 	user, err := t.users.Find(ctx, repo.UserID)
 	if err != nil {
 		logger = logger.WithError(err)
@@ -137,6 +122,22 @@ func (t *triggerer) Trigger(ctx context.Context, repo *core.Repository, base *co
 			if base.AuthorAvatar == "" {
 				base.AuthorAvatar = commit.Author.Avatar
 			}
+		}
+	}
+	
+	// do skip trigger after base hook has been filled by commit message
+	if skipMessage(base) {
+		logger.Infoln("trigger: skipping hook. found skip directive")
+		return nil, nil
+	}
+	if base.Event == core.EventPullRequest {
+		if repo.IgnorePulls {
+			logger.Infoln("trigger: skipping hook. project ignores pull requests")
+			return nil, nil
+		}
+		if repo.IgnoreForks && !strings.EqualFold(base.Fork, repo.Slug) {
+			logger.Infoln("trigger: skipping hook. project ignores forks")
+			return nil, nil
 		}
 	}
 


### PR DESCRIPTION
Do skip triggers after the base hook object has been filled with commit message when it is empty.

It should fix the issue that the [skip ci] didn't work for recent Bitbucket version because the commit message isn't on the push event but the hash still being in it.

linked to : https://github.com/drone/go-scm/pull/84