### PR TITLE
stash needs to get ref via branch, cant via heads same as bitbucket

### DIFF
--- a/service/commit/commit.go
+++ b/service/commit/commit.go
@@ -78,7 +78,7 @@ func (s *service) FindRef(ctx context.Context, user *core.User, repo, ref string
 	})
 
 	switch s.client.Driver {
-	case scm.DriverBitbucket:
+	case scm.DriverBitbucket, scm.DriverStash:
 		ref = scm.TrimRef(ref)
 		branch, _, err := s.client.Git.FindBranch(ctx, repo, ref) // wont work for a Tag
 		if err != nil {


### PR DESCRIPTION
As proposed in https://discourse.drone.io/t/panic-or-undefined-error-when-create-build-from-bitbucket-repository/8549/6 using the workaround from bitbucket also in stash solves the issue, that new builds can not be created without providing a commit.