### PR TITLE
Add keyword trigger condition

### DIFF
--- a/trigger/skip.go
+++ b/trigger/skip.go
@@ -53,6 +53,10 @@ func skipCron(document *yaml.Pipeline, cron string) bool {
 	return !document.Trigger.Cron.Match(cron)
 }
 
+func skipKeyword(document *yaml.Pipeline, message string, title string) bool {
+	return !(document.Trigger.Keyword.Match(message) || document.Trigger.Keyword.Match(title))
+}
+
 func skipMessage(hook *core.Hook) bool {
 	switch {
 	case hook.Event == core.EventTag:

--- a/trigger/trigger.go
+++ b/trigger/trigger.go
@@ -321,6 +321,9 @@ func (t *triggerer) Trigger(ctx context.Context, repo *core.Repository, base *co
 		} else if skipCron(pipeline, base.Cron) {
 			logger = logger.WithField("pipeline", pipeline.Name)
 			logger.Infoln("trigger: skipping pipeline, does not match cron job")
+		} else if skipKeyword(pipeline, base.Message, base.Title) {
+			logger = logger.WithField("pipeline", pipeline.Name)
+			logger.Infoln("trigger: skipping pipeline, does not match keywords")
 		} else {
 			matched = append(matched, pipeline)
 			node.Skip = false


### PR DESCRIPTION
This enables a new trigger for keywords in the commit message or title. The usage is as follows:

```
trigger:
  keyword:
  - "*[RUN PIPELINE]*"
```
Should only run if the keyword is matched.

or

```
trigger:
  keyword:
    exclude:
    - "*[SKIP DEPLOY]*"
```
Should not run if the keyword is matched.

I considered simplifying the notation by appending `*` to each end of the keyword strings, but it would give the user less control on matching specific strings.

Note: The way this is currently implemented follows the same syntax as other triggers, but requires adding the `Keyword` condition to `drone-yaml`. However, I see that the GitHub repository is currently archived, so I'm unable to open a PR. 

On further inspection it looks like drone-yaml `Conditions` essentially expects each argument to be a "path" in the matching operation. Passing an arbitrary string (message or title) will probably result in odd behavior. The solution here appears to be to simply create a separate Match function for Condition that uses go `strings.Contains` and remove the wildcard operators above. Again, this is in drone-yaml, which appears to be private.