### PR TITLE
Pick up security fixes for golang 1.14.x

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,12 +9,12 @@ platform:
 
 steps:
 - name: test
-  image: golang:1.14.4
+  image: golang:1.14.15
   commands:
   - go test ./...
   
 - name: build
-  image: golang:1.14.4
+  image: golang:1.14.15
   commands:
   - sh scripts/build.sh
   environment:
@@ -48,7 +48,7 @@ platform:
 
 steps:
 - name: build
-  image: golang:1.14.4
+  image: golang:1.14.15
   commands:
   - sh scripts/build.sh
   environment:
@@ -86,7 +86,7 @@ platform:
 
 steps:
 - name: build
-  image: golang:1.14.4
+  image: golang:1.14.15
   commands:
   - sh scripts/build.sh
   environment:


### PR DESCRIPTION
golang `1.14.14` is scheduled to be released on `Jan 19, 2021`

golang `1.14.4` ~ `1.14.14` contains multiple security fixes and we should
consider to pick them up.

ref: https://golang.org/doc/devel/release.html#go1.14

