### PR TITLE
[feature] allow starlark loading in trusted repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- support for relative module loading in starlark scripts.
+
 ### Breaking
 - removed deprecated kubernetes integration in favor of official kubernetes runner.
 - removed deprecated nomad integration in favor of official nomad runner.

--- a/plugin/converter/starlark/testdata/module_a.star
+++ b/plugin/converter/starlark/testdata/module_a.star
@@ -1,0 +1,8 @@
+load("testdata/module_b.star", "pipeline_b")
+
+def main(ctx):
+  return [{
+    'kind': 'pipeline',
+    'type': 'docker',
+    'name': 'default'
+  }, pipeline_b(ctx)] 

--- a/plugin/converter/starlark/testdata/module_a.star.golden
+++ b/plugin/converter/starlark/testdata/module_a.star.golden
@@ -1,0 +1,4 @@
+---
+{"kind": "pipeline", "type": "docker", "name": "default"}
+---
+{"kind": "pipeline", "type": "docker", "name": "default"}

--- a/plugin/converter/starlark/testdata/module_b.star
+++ b/plugin/converter/starlark/testdata/module_b.star
@@ -1,0 +1,6 @@
+def pipeline_b(ctx):
+    return {
+        'kind': 'pipeline',
+        'type': 'docker',
+        'name': 'default'
+    }


### PR DESCRIPTION
We tested switching to the starlark plugin by using `drone-cli` to template our `.drone.yml` in a pull request before merging and switching over entirely to starlark. Unfortunately, this exposes a gap between `drone-cli` and `drone` server, which does not support module loads. For us, this is the primary reason we want to use starlark as our `.drone.yml` has grown to an unpleasant size for a monolithic piece of configuration.

This PR makes an assumption we don't want to let users load modules in un-trusted repos. I'm not sure that matters in practice, but assumed that might be one reason for not implementing the loader func originally.