### PR TITLE
Only admin can sign

### DIFF
--- a/handler/api/api.go
+++ b/handler/api/api.go
@@ -254,7 +254,7 @@ func (s Server) Handler() http.Handler {
 			})
 
 			r.Route("/sign", func(r chi.Router) {
-				r.Use(acl.CheckWriteAccess())
+				r.Use(acl.CheckAdminAccess())
 				r.Post("/", sign.HandleSign(s.Repos))
 			})
 


### PR DESCRIPTION
Hello everyone,
we noticed some users into our organization, with write access to some repositories, signing `.drone.yml`.
We'd like to change the ACL for `/sign` endpoint by restricting access to admin only.  