### PR TITLE
Ignore skip trigger for promote events

### DIFF
--- a/trigger/skip.go
+++ b/trigger/skip.go
@@ -59,6 +59,8 @@ func skipMessage(hook *core.Hook) bool {
 		return false
 	case hook.Event == core.EventCron:
 		return false
+	case hook.Event == core.EventPromote:
+		return false
 	case hook.Event == core.EventCustom:
 		return false
 	case skipMessageEval(hook.Message):

--- a/trigger/skip_test.go
+++ b/trigger/skip_test.go
@@ -191,6 +191,16 @@ func Test_skipMessage(t *testing.T) {
 			want:  false,
 		},
 		{
+			event:   "promote",
+			message: "update readme",
+			want:    false,
+		},
+		{
+			event:   "promote",
+			message: "update readme [CI SKIP]",
+			want:    false,
+		},
+		{
 			event: "custom",
 			title: "update readme [CI SKIP]",
 			want:  false,


### PR DESCRIPTION
In the current implementation, a build can not be promoted if its
message contains the skip ci directive. According to the drone
documentation, the skip directive should be ignored for promotion
events. We added a missing switch case to the skipMessage function
so that promotion events are not skipped.

