### PR TITLE
Fix Gitea branch builds

### DIFF
--- a/service/commit/commit.go
+++ b/service/commit/commit.go
@@ -78,7 +78,7 @@ func (s *service) FindRef(ctx context.Context, user *core.User, repo, ref string
 	})
 
 	switch s.client.Driver {
-	case scm.DriverBitbucket:
+	case scm.DriverBitbucket, scm.DriverGitea:
 		ref = scm.TrimRef(ref)
 		branch, _, err := s.client.Git.FindBranch(ctx, repo, ref) // wont work for a Tag
 		if err != nil {


### PR DESCRIPTION
Drone prefixes a branch build ref with `ref/heads/`, which results in
go-scm constructing a URL to Gitea's commits API as
`.../commits/ref%2Fheads%2fmy-branch`, which gets a 404 response from
Gitea. Removing the prefix and only using `my-branch` for the full ref
now correctly has drone getting the commit details for the branch and
builds are built successfully.

Tested with Gitea 1.13.6 (released March 24, 2021).

