### PR TITLE
fix(bug): build failed with tag "oss"

### DIFF
--- a/store/shared/db/conn_oss.go
+++ b/store/shared/db/conn_oss.go
@@ -26,11 +26,14 @@ import (
 )
 
 // Connect to an embedded sqlite database.
-func Connect(driver, datasource string) (*DB, error) {
+func Connect(driver, datasource string, maxOpenConnections int) (*DB, error) {
 	db, err := sql.Open(driver, datasource)
 	if err != nil {
 		return nil, err
 	}
+
+	db.SetMaxOpenConns(maxOpenConnections)
+
 	if err := sqlite.Migrate(db); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Tried to build with v2.0.2, and quickly found out it's unable to build when tag `oss` is set.

```
cmd/drone-server/inject_store.go:63:19: too many arguments in call to db.Connect

    have (string, string, int)
    want (string, string)
```

introduced by https://github.com/drone/drone/pull/3089