### PR TITLE
Allow jsonnet imports in pipeline configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Allow jsonnet imports in pipeline configuration
 
 ## [2.0.4]
 ### Fixed

--- a/cmd/drone-server/config/config.go
+++ b/cmd/drone-server/config/config.go
@@ -139,7 +139,8 @@ type (
 
 	// Jsonnet configures the jsonnet plugin
 	Jsonnet struct {
-		Enabled bool `envconfig:"DRONE_JSONNET_ENABLED"`
+		Enabled     bool `envconfig:"DRONE_JSONNET_ENABLED"`
+		ImportLimit int  `envconfig:"DRONE_JSONNET_IMPORT_LIMIT" default:"0"`
 	}
 
 	// Starlark configures the starlark plugin

--- a/cmd/drone-server/inject_plugin.go
+++ b/cmd/drone-server/inject_plugin.go
@@ -76,7 +76,7 @@ func provideConfigPlugin(client *scm.Client, contents core.FileService, conf spe
 // provideConvertPlugin is a Wire provider function that returns
 // a yaml conversion plugin based on the environment
 // configuration.
-func provideConvertPlugin(client *scm.Client, conf spec.Config, templateStore core.TemplateStore) core.ConvertService {
+func provideConvertPlugin(client *scm.Client, fileService core.FileService, conf spec.Config, templateStore core.TemplateStore) core.ConvertService {
 	return converter.Combine(
 		converter.Legacy(false),
 		converter.Starlark(
@@ -85,6 +85,8 @@ func provideConvertPlugin(client *scm.Client, conf spec.Config, templateStore co
 		),
 		converter.Jsonnet(
 			conf.Jsonnet.Enabled,
+			conf.Jsonnet.ImportLimit,
+			fileService,
 		),
 		converter.Template(
 			templateStore,

--- a/cmd/drone-server/wire_gen.go
+++ b/cmd/drone-server/wire_gen.go
@@ -70,7 +70,7 @@ func InitializeApplication(config2 config.Config) (application, error) {
 	fileService := provideContentService(client, renewer)
 	configService := provideConfigPlugin(client, fileService, config2)
 	templateStore := template.New(db)
-	convertService := provideConvertPlugin(client, config2, templateStore)
+	convertService := provideConvertPlugin(client, fileService, config2, templateStore)
 	validateService := provideValidatePlugin(config2)
 	triggerer := trigger.New(coreCanceler, configService, convertService, commitService, statusService, buildStore, scheduler, repositoryStore, userStore, validateService, webhookSender)
 	cronScheduler := cron2.New(commitService, cronStore, repositoryStore, userStore, triggerer)

--- a/go.sum
+++ b/go.sum
@@ -352,6 +352,7 @@ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135 h1:5Beo0mZN8dRzgrMMkDp0jc8YXQKx9DiJ2k1dkvGsn5A=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=

--- a/plugin/converter/jsonnet.go
+++ b/plugin/converter/jsonnet.go
@@ -19,14 +19,18 @@ import (
 
 // Jsonnet returns a conversion service that converts the
 // jsonnet file to a yaml file.
-func Jsonnet(enabled bool) core.ConvertService {
+func Jsonnet(enabled bool, limit int, fileService core.FileService) core.ConvertService {
 	return &jsonnetPlugin{
-		enabled: enabled,
+		enabled:     enabled,
+		limit:       limit,
+		fileService: fileService,
 	}
 }
 
 type jsonnetPlugin struct {
-	enabled bool
+	enabled     bool
+	limit       int
+	fileService core.FileService
 }
 
 func (p *jsonnetPlugin) Convert(ctx context.Context, req *core.ConvertArgs) (*core.Config, error) {
@@ -40,7 +44,7 @@ func (p *jsonnetPlugin) Convert(ctx context.Context, req *core.ConvertArgs) (*co
 		return nil, nil
 	}
 
-	file, err := jsonnet.Parse(req, nil, nil)
+	file, err := jsonnet.Parse(req, p.fileService, p.limit, nil, nil)
 
 	if err != nil {
 		return nil, err

--- a/plugin/converter/jsonnet/jsonnet.go
+++ b/plugin/converter/jsonnet/jsonnet.go
@@ -2,10 +2,14 @@ package jsonnet
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"path"
 	"strconv"
+	"strings"
 
 	"github.com/drone/drone/core"
+	"github.com/drone/drone/handler/api/errors"
 
 	"github.com/google/go-jsonnet"
 )
@@ -14,11 +18,91 @@ const repo = "repo."
 const build = "build."
 const param = "param."
 
-func Parse(req *core.ConvertArgs, template *core.Template, templateData map[string]interface{}) (string, error) {
+var noContext = context.Background()
+
+type importer struct {
+	repo  *core.Repository
+	build *core.Build
+
+	// jsonnet does not cache file imports and may request
+	// the same file multiple times. We cache the files to
+	// duplicate API calls.
+	cache map[string]jsonnet.Contents
+
+	// limit the number of outbound requests. github limits
+	// the number of api requests per hour, so we should
+	// make sure that a single build does not abuse the api
+	// by importing dozens of files.
+	limit int
+
+	// counts the number of outbound requests. if the count
+	// exceeds the limit, the importer will return errors.
+	count int
+
+	fileService core.FileService
+	user        *core.User
+}
+
+func (i *importer) Import(importedFrom, importedPath string) (contents jsonnet.Contents, foundAt string, err error) {
+	if i.cache == nil {
+		i.cache = map[string]jsonnet.Contents{}
+	}
+
+	// the import is relative to the imported from path. the
+	// imported path must resolve to a filepath relative to
+	// the root of the repository.
+	importedPath = path.Join(
+		path.Dir(importedFrom),
+		importedPath,
+	)
+
+	if strings.HasPrefix(importedFrom, "../") {
+		err = fmt.Errorf("jsonnet: cannot resolve import: %s", importedPath)
+		return contents, foundAt, err
+	}
+
+	// if the contents exist in the cache, return the
+	// cached item.
+	if contents, ok := i.cache[importedPath]; ok {
+		return contents, importedPath, nil
+	}
+
+	defer func() {
+		i.count++
+	}()
+
+	// if the import limit is exceeded log an error message.
+	if i.limit > 0 && i.count >= i.limit {
+		return contents, foundAt, errors.New("jsonnet: import limit exceeded")
+	}
+
+	find, err := i.fileService.Find(noContext, i.user, i.repo.Slug, i.build.After, i.build.Ref, importedPath)
+
+	if err != nil {
+		return contents, foundAt, err
+	}
+
+	i.cache[importedPath] = jsonnet.MakeContents(string(find.Data))
+
+	return i.cache[importedPath], importedPath, err
+}
+
+func Parse(req *core.ConvertArgs, fileService core.FileService, limit int, template *core.Template, templateData map[string]interface{}) (string, error) {
 	vm := jsonnet.MakeVM()
 	vm.MaxStack = 500
 	vm.StringOutput = false
 	vm.ErrorFormatter.SetMaxStackTraceSize(20)
+	if fileService != nil && limit > 0 {
+		vm.Importer(
+			&importer{
+				repo:        req.Repo,
+				build:       req.Build,
+				limit:       limit,
+				user:        req.User,
+				fileService: fileService,
+			},
+		)
+	}
 
 	//map build/repo parameters
 	if req.Build != nil {
@@ -48,9 +132,9 @@ func Parse(req *core.ConvertArgs, template *core.Template, templateData map[stri
 
 	// convert the jsonnet file to yaml
 	buf := new(bytes.Buffer)
-	docs, err := vm.EvaluateSnippetStream(jsonnetFileName, jsonnetFile)
+	docs, err := vm.EvaluateAnonymousSnippetStream(jsonnetFileName, jsonnetFile)
 	if err != nil {
-		doc, err2 := vm.EvaluateSnippet(jsonnetFileName, jsonnetFile)
+		doc, err2 := vm.EvaluateAnonymousSnippet(jsonnetFileName, jsonnetFile)
 		if err2 != nil {
 			return "", err
 		}

--- a/plugin/converter/jsonnet/jsonnet_test.go
+++ b/plugin/converter/jsonnet/jsonnet_test.go
@@ -44,7 +44,7 @@ func TestParse(t *testing.T) {
 
 	req.Config.Data = string(before)
 
-	parsedFile, err := Parse(req, template, templateData)
+	parsedFile, err := Parse(req, nil, 0, template, templateData)
 	if err != nil {
 		t.Error(err)
 		return
@@ -82,7 +82,7 @@ func TestParseJsonnetNotTemplateFile(t *testing.T) {
 	req.Repo.Config = "plugin.jsonnet"
 	req.Config.Data = string(before)
 
-	parsedFile, err := Parse(req, nil, nil)
+	parsedFile, err := Parse(req, nil, 0, nil, nil)
 	if err != nil {
 		t.Error(err)
 		return

--- a/plugin/converter/jsonnet_oss.go
+++ b/plugin/converter/jsonnet_oss.go
@@ -22,6 +22,6 @@ import (
 
 // Jsonnet returns a conversion service that converts the
 // jsonnet file to a yaml file.
-func Jsonnet(enabled bool) core.ConvertService {
+func Jsonnet(enabled bool, limit int, fileService core.FileService) core.ConvertService {
 	return new(noop)
 }

--- a/plugin/converter/jsonnet_test.go
+++ b/plugin/converter/jsonnet_test.go
@@ -10,6 +10,9 @@ import (
 	"testing"
 
 	"github.com/drone/drone/core"
+	"github.com/drone/drone/mock"
+
+	"github.com/golang/mock/gomock"
 )
 
 const jsonnetFile = `{"foo": "bar"}`
@@ -26,12 +29,32 @@ const jsonnetStreamAfter = `---
 }
 `
 
+const jsonnetFileImport = `local step = import '.step.libsonnet';
+{"foo": ["bar"], "steps": [step]}`
+const jsonnetFileImportLib = `{"image": "app"}`
+const jsonnetFileImportAfter = `---
+{
+   "foo": [
+      "bar"
+   ],
+   "steps": [
+      {
+         "image": "app"
+      }
+   ]
+}
+`
+
+const jsonnetFileMultipleImports = `local step = import '.step.libsonnet';
+local step2 = import '.step2.jsonnet';
+{"foo": ["bar"], "steps": [step, step2]}`
+
 func TestJsonnet_Stream(t *testing.T) {
 	args := &core.ConvertArgs{
 		Repo:   &core.Repository{Config: ".drone.jsonnet"},
 		Config: &core.Config{Data: jsonnetStream},
 	}
-	service := Jsonnet(true)
+	service := Jsonnet(true, 0, nil)
 	res, err := service.Convert(noContext, args)
 	if err != nil {
 		t.Error(err)
@@ -51,7 +74,7 @@ func TestJsonnet_Snippet(t *testing.T) {
 		Repo:   &core.Repository{Config: ".drone.jsonnet"},
 		Config: &core.Config{Data: jsonnetFile},
 	}
-	service := Jsonnet(true)
+	service := Jsonnet(true, 0, nil)
 	res, err := service.Convert(noContext, args)
 	if err != nil {
 		t.Error(err)
@@ -71,7 +94,7 @@ func TestJsonnet_Error(t *testing.T) {
 		Repo:   &core.Repository{Config: ".drone.jsonnet"},
 		Config: &core.Config{Data: "\\"}, // invalid jsonnet
 	}
-	service := Jsonnet(true)
+	service := Jsonnet(true, 0, nil)
 	_, err := service.Convert(noContext, args)
 	if err == nil {
 		t.Errorf("Expect jsonnet parsing error, got nil")
@@ -79,7 +102,7 @@ func TestJsonnet_Error(t *testing.T) {
 }
 
 func TestJsonnet_Disabled(t *testing.T) {
-	service := Jsonnet(false)
+	service := Jsonnet(false, 0, nil)
 	res, err := service.Convert(noContext, nil)
 	if err != nil {
 		t.Error(err)
@@ -93,12 +116,178 @@ func TestJsonnet_NotJsonnet(t *testing.T) {
 	args := &core.ConvertArgs{
 		Repo: &core.Repository{Config: ".drone.yml"},
 	}
-	service := Jsonnet(true)
+	service := Jsonnet(true, 0, nil)
 	res, err := service.Convert(noContext, args)
 	if err != nil {
 		t.Error(err)
 	}
 	if res != nil {
 		t.Errorf("Expect nil response when not jsonnet")
+	}
+}
+
+func TestJsonnet_Import(t *testing.T) {
+	args := &core.ConvertArgs{
+		Build: &core.Build{
+			Ref:   "a6586b3db244fb6b1198f2b25c213ded5b44f9fa",
+			After: "542ed565d03dab86f079798f937663ec1f05360b",
+		},
+		Repo: &core.Repository{
+			Slug:   "octocat/hello-world",
+			Config: ".drone.jsonnet"},
+		Config: &core.Config{Data: jsonnetFileImport},
+		User: &core.User{
+			Token: "foobar",
+		},
+	}
+	importedContent := &core.File{
+		Data: []byte(jsonnetFileImportLib),
+	}
+	controller := gomock.NewController(t)
+	mockFileService := mock.NewMockFileService(controller)
+	mockFileService.EXPECT().Find(gomock.Any(), &core.User{Token: "foobar"}, "octocat/hello-world", "542ed565d03dab86f079798f937663ec1f05360b", "a6586b3db244fb6b1198f2b25c213ded5b44f9fa", ".step.libsonnet").Return(importedContent, nil).Times(2)
+	service := Jsonnet(true, 1, mockFileService)
+	res, err := service.Convert(noContext, args)
+	if err != nil {
+		t.Error(err)
+	}
+	if got, want := res.Data, jsonnetFileImportAfter; got != want {
+		t.Errorf("Want converted file:\n%q\ngot\n%q", want, got)
+	}
+}
+
+func TestJsonnet_ImportLimit(t *testing.T) {
+	args := &core.ConvertArgs{
+		Build: &core.Build{
+			Ref:   "a6586b3db244fb6b1198f2b25c213ded5b44f9fa",
+			After: "542ed565d03dab86f079798f937663ec1f05360b",
+		},
+		Repo: &core.Repository{
+			Slug:   "octocat/hello-world",
+			Config: ".drone.jsonnet"},
+		Config: &core.Config{Data: jsonnetFileMultipleImports},
+		User: &core.User{
+			Token: "foobar",
+		},
+	}
+	importedContent := &core.File{
+		Data: []byte(jsonnetFileImportLib),
+	}
+	controller := gomock.NewController(t)
+	mockFileService := mock.NewMockFileService(controller)
+	mockFileService.EXPECT().Find(gomock.Any(), &core.User{Token: "foobar"}, "octocat/hello-world", "542ed565d03dab86f079798f937663ec1f05360b", "a6586b3db244fb6b1198f2b25c213ded5b44f9fa", ".step.libsonnet").Return(importedContent, nil).Times(2)
+
+	service := Jsonnet(true, 1, mockFileService)
+	_, err := service.Convert(noContext, args)
+	if err == nil {
+		t.Errorf("Expect nil response when jsonnet import limit is exceeded")
+	}
+}
+
+func TestJsonnet_LimitZero(t *testing.T) {
+	args := &core.ConvertArgs{
+		Build: &core.Build{
+			Ref:   "a6586b3db244fb6b1198f2b25c213ded5b44f9fa",
+			After: "542ed565d03dab86f079798f937663ec1f05360b",
+		},
+		Repo: &core.Repository{
+			Slug:   "octocat/hello-world",
+			Config: ".drone.jsonnet"},
+		Config: &core.Config{Data: jsonnetFile},
+		User: &core.User{
+			Token: "foobar",
+		},
+	}
+
+	controller := gomock.NewController(t)
+	mockFileService := mock.NewMockFileService(controller)
+	mockFileService.EXPECT().Find(gomock.Any(), &core.User{Token: "foobar"}, "octocat/hello-world", "542ed565d03dab86f079798f937663ec1f05360b", "a6586b3db244fb6b1198f2b25c213ded5b44f9fa", ".step.libsonnet").Times(0)
+
+	service := Jsonnet(true, 0, mockFileService)
+	res, err := service.Convert(noContext, args)
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if got, want := res.Data, jsonnetFileAfter; got != want {
+		t.Errorf("Want converted file %q, got %q", want, got)
+	}
+}
+
+func TestJsonnet_ImportLimitZero(t *testing.T) {
+	args := &core.ConvertArgs{
+		Build: &core.Build{
+			Ref:   "a6586b3db244fb6b1198f2b25c213ded5b44f9fa",
+			After: "542ed565d03dab86f079798f937663ec1f05360b",
+		},
+		Repo: &core.Repository{
+			Slug:   "octocat/hello-world",
+			Config: ".drone.jsonnet"},
+		Config: &core.Config{Data: jsonnetFileImport},
+		User: &core.User{
+			Token: "foobar",
+		},
+	}
+	importedContent := &core.File{
+		Data: []byte(jsonnetFileImportLib),
+	}
+	controller := gomock.NewController(t)
+	mockFileService := mock.NewMockFileService(controller)
+	mockFileService.EXPECT().Find(gomock.Any(), &core.User{Token: "foobar"}, "octocat/hello-world", "542ed565d03dab86f079798f937663ec1f05360b", "a6586b3db244fb6b1198f2b25c213ded5b44f9fa", ".step.libsonnet").Return(importedContent, nil).Times(2)
+
+	service := Jsonnet(true, 0, mockFileService)
+	_, err := service.Convert(noContext, args)
+	if err == nil {
+		t.Errorf("Expect nil response when jsonnet import limit is exceeded")
+	}
+}
+
+func TestJsonnet_ImportFileServiceNil(t *testing.T) {
+	args := &core.ConvertArgs{
+		Build: &core.Build{
+			Ref:   "a6586b3db244fb6b1198f2b25c213ded5b44f9fa",
+			After: "542ed565d03dab86f079798f937663ec1f05360b",
+		},
+		Repo: &core.Repository{
+			Slug:   "octocat/hello-world",
+			Config: ".drone.jsonnet"},
+		Config: &core.Config{Data: jsonnetFileMultipleImports},
+		User: &core.User{
+			Token: "foobar",
+		},
+	}
+
+	service := Jsonnet(true, 1, nil)
+	_, err := service.Convert(noContext, args)
+	if err == nil {
+		t.Errorf("Expect nil response when jsonnet import limit is exceeded")
+	}
+}
+
+func TestJsonnet_FileServiceNil(t *testing.T) {
+	args := &core.ConvertArgs{
+		Build: &core.Build{
+			Ref:   "a6586b3db244fb6b1198f2b25c213ded5b44f9fa",
+			After: "542ed565d03dab86f079798f937663ec1f05360b",
+		},
+		Repo: &core.Repository{
+			Slug:   "octocat/hello-world",
+			Config: ".drone.jsonnet"},
+		Config: &core.Config{Data: jsonnetFile},
+		User: &core.User{
+			Token: "foobar",
+		},
+	}
+
+	service := Jsonnet(true, 1, nil)
+	res, err := service.Convert(noContext, args)
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if got, want := res.Data, jsonnetFileAfter; got != want {
+		t.Errorf("Want converted file %q, got %q", want, got)
 	}
 }

--- a/plugin/converter/template.go
+++ b/plugin/converter/template.go
@@ -112,7 +112,7 @@ func parseYaml(req *core.ConvertArgs, template *core.Template, templateArgs core
 }
 
 func parseJsonnet(req *core.ConvertArgs, template *core.Template, templateArgs core.TemplateArgs) (*core.Config, error) {
-	file, err := jsonnet.Parse(req, template, templateArgs.Data)
+	file, err := jsonnet.Parse(req, nil, 0, template, templateArgs.Data)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Having large projects using e.g., mono repo managing pipeline configurations becomes quickly quite cumbersome and error-prone. Having the ability to split the single pipeline configuration into multiple jsonnet files makes it a bit easier to manage.

Implementation in this pull request is based on old drone/drone-jsonnet-config with updates.

I've tested this to work with gitea. I've an open question still which token should be used in the scm Find call, now it's using user token, but this likely should be a token bound to drone SCM user itself. But is there any preferable way to retrieve that?


