### PR TITLE
update template create api to accept namespace

### DIFF
--- a/handler/api/acl/org.go
+++ b/handler/api/acl/org.go
@@ -51,6 +51,11 @@ func CheckMembership(service core.OrganizationService, admin bool) func(http.Han
 				return
 			}
 
+			if user.Login == namespace {
+				next.ServeHTTP(w, r)
+				return
+			}
+
 			isMember, isAdmin, err := service.Membership(ctx, user, namespace)
 			if err != nil {
 				render.Unauthorized(w, errors.ErrNotFound)

--- a/handler/api/api.go
+++ b/handler/api/api.go
@@ -359,7 +359,7 @@ func (s Server) Handler() http.Handler {
 
 	r.Route("/templates", func(r chi.Router) {
 		r.With(acl.CheckMembership(s.Orgs, false)).Get("/", template.HandleListAll(s.Template))
-		r.With(acl.CheckMembership(s.Orgs, true)).Post("/", template.HandleCreate(s.Template))
+		r.With(acl.CheckMembership(s.Orgs, true)).Post("/{namespace}", template.HandleCreate(s.Template))
 		r.With(acl.CheckMembership(s.Orgs, false)).Get("/{namespace}", template.HandleList(s.Template))
 		r.With(acl.CheckMembership(s.Orgs, false)).Get("/{namespace}/{name}", template.HandleFind(s.Template))
 		r.With(acl.CheckMembership(s.Orgs, true)).Put("/{namespace}/{name}", template.HandleUpdate(s.Template))

--- a/handler/api/template/create.go
+++ b/handler/api/template/create.go
@@ -8,6 +8,7 @@ package template
 
 import (
 	"encoding/json"
+	"github.com/go-chi/chi"
 	"net/http"
 
 	"github.com/drone/drone/core"
@@ -17,13 +18,13 @@ import (
 type templateInput struct {
 	Name      string `json:"name"`
 	Data      string `json:"data"`
-	Namespace string `json:"namespace"`
 }
 
 // HandleCreate returns an http.HandlerFunc that processes http
 // requests to create a new template.
 func HandleCreate(templateStore core.TemplateStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		namespace := chi.URLParam(r, "namespace")
 		in := new(templateInput)
 		err := json.NewDecoder(r.Body).Decode(in)
 		if err != nil {
@@ -34,7 +35,7 @@ func HandleCreate(templateStore core.TemplateStore) http.HandlerFunc {
 		t := &core.Template{
 			Name:      in.Name,
 			Data:      in.Data,
-			Namespace: in.Namespace,
+			Namespace: namespace,
 		}
 
 		err = t.Validate()


### PR DESCRIPTION
Identified as issue where namespace was getting passed in on the payload rather than a URL param. This caused an issue during the checkmembership check on drone server as it requires namespace to be set.