### PR TITLE
CheckMembership return forbidden if not found.

### DIFF
--- a/handler/api/acl/org.go
+++ b/handler/api/acl/org.go
@@ -58,7 +58,7 @@ func CheckMembership(service core.OrganizationService, admin bool) func(http.Han
 
 			isMember, isAdmin, err := service.Membership(ctx, user, namespace)
 			if err != nil {
-				render.Unauthorized(w, errors.ErrNotFound)
+				render.Unauthorized(w, errors.ErrForbidden)
 				log.Debugln("api: organization membership not found")
 				return
 			}
@@ -68,13 +68,13 @@ func CheckMembership(service core.OrganizationService, admin bool) func(http.Han
 				WithField("organization.admin", isAdmin)
 
 			if isMember == false {
-				render.Unauthorized(w, errors.ErrNotFound)
+				render.Unauthorized(w, errors.ErrForbidden)
 				log.Debugln("api: organization membership is required")
 				return
 			}
 
 			if isAdmin == false && admin == true {
-				render.Unauthorized(w, errors.ErrNotFound)
+				render.Unauthorized(w, errors.ErrForbidden)
 				log.Debugln("api: organization administrator is required")
 				return
 			}


### PR DESCRIPTION
If a users membership to an organisation is not found, instead of return error message of not found, which is a little confusing it will now return a forbidden. 