### PR TITLE
event-stream supports timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ release/
 scripts/*.go
 docker/**/data
 TODO*
+.idea

--- a/handler/api/events/build.go
+++ b/handler/api/events/build.go
@@ -82,7 +82,7 @@ func HandleEvents(
 		events, errc := events.Subscribe(ctx)
 		logger.Debugln("events: stream opened")
 
-		timeoutChan := time.After(time.Hour)
+		timeoutChan := time.After(24 * time.Hour)
 	L:
 		for {
 			select {

--- a/handler/api/events/build.go
+++ b/handler/api/events/build.go
@@ -82,6 +82,7 @@ func HandleEvents(
 		events, errc := events.Subscribe(ctx)
 		logger.Debugln("events: stream opened")
 
+		timeoutChan := time.After(time.Hour)
 	L:
 		for {
 			select {
@@ -91,7 +92,7 @@ func HandleEvents(
 			case <-errc:
 				logger.Debugln("events: stream error")
 				break L
-			case <-time.After(time.Hour):
+			case <-timeoutChan:
 				logger.Debugln("events: stream timeout")
 				break L
 			case <-time.After(pingInterval):

--- a/handler/api/events/global.go
+++ b/handler/api/events/global.go
@@ -63,7 +63,7 @@ func HandleGlobal(
 		events, errc := events.Subscribe(ctx)
 		logger.Debugln("events: stream opened")
 
-		timeoutChan := time.After(time.Hour)
+		timeoutChan := time.After(24 * time.Hour)
 	L:
 		for {
 			select {

--- a/handler/api/events/global.go
+++ b/handler/api/events/global.go
@@ -63,6 +63,7 @@ func HandleGlobal(
 		events, errc := events.Subscribe(ctx)
 		logger.Debugln("events: stream opened")
 
+		timeoutChan := time.After(time.Hour)
 	L:
 		for {
 			select {
@@ -72,7 +73,7 @@ func HandleGlobal(
 			case <-errc:
 				logger.Debugln("events: stream error")
 				break L
-			case <-time.After(time.Hour):
+			case <-timeoutChan:
 				logger.Debugln("events: stream timeout")
 				break L
 			case <-time.After(pingInterval):

--- a/handler/api/events/logs.go
+++ b/handler/api/events/logs.go
@@ -102,7 +102,7 @@ func HandleLogStream(
 			return
 		}
 
-		timeoutChan := time.After(time.Hour)
+		timeoutChan := time.After(24 * time.Hour)
 	L:
 		for {
 			select {

--- a/handler/api/events/logs.go
+++ b/handler/api/events/logs.go
@@ -102,6 +102,7 @@ func HandleLogStream(
 			return
 		}
 
+		timeoutChan := time.After(time.Hour)
 	L:
 		for {
 			select {
@@ -109,7 +110,7 @@ func HandleLogStream(
 				break L
 			case <-errc:
 				break L
-			case <-time.After(time.Hour):
+			case <-timeoutChan:
 				break L
 			case <-time.After(pingInterval):
 				io.WriteString(w, ": ping\n\n")


### PR DESCRIPTION
```golang
for {
    select {
        case <-time.After(time.Hour):
            break T
        case <-time.After(pingInterval):
    }
}
```
As the method shows, ` case <-time.After(pingInterval)` Will invalidate the `timeout definition`