### PR TITLE
add check on template extension type - throw error if invalid

### DIFF
--- a/handler/api/template/all_test.go
+++ b/handler/api/template/all_test.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	dummyTemplate = &core.Template{
-		Name:      "my_template",
+		Name:      "my_template.yml",
 		Data:      "my_data",
 		Created:   1,
 		Updated:   2,

--- a/handler/api/template/create_test.go
+++ b/handler/api/template/create_test.go
@@ -48,13 +48,13 @@ func TestHandleCreate(t *testing.T) {
 	}
 }
 
-func TestHandleCreate_ValidationErrorName(t *testing.T) {
+func TestHandleCreate_NotValidTemplateExtensionName(t *testing.T) {
 	controller := gomock.NewController(t)
 	defer controller.Finish()
 
 	c := new(chi.Context)
 	in := new(bytes.Buffer)
-	json.NewEncoder(in).Encode(&core.Template{Name: "", Data: "my_data"})
+	json.NewEncoder(in).Encode(&core.Template{Name: "my_template", Data: "my_data"})
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "/", in)
@@ -67,7 +67,7 @@ func TestHandleCreate_ValidationErrorName(t *testing.T) {
 		t.Errorf("Want response code %d, got %d", want, got)
 	}
 
-	got, want := &errors.Error{}, &errors.Error{Message: "No Template Name Provided"}
+	got, want := &errors.Error{}, &errors.Error{Message: "Template extension invalid. Must be yaml, starlark or jsonnet"}
 	json.NewDecoder(w.Body).Decode(got)
 	if diff := cmp.Diff(got, want); len(diff) != 0 {
 		t.Errorf(diff)
@@ -80,7 +80,7 @@ func TestHandleCreate_ValidationErrorData(t *testing.T) {
 
 	c := new(chi.Context)
 	in := new(bytes.Buffer)
-	json.NewEncoder(in).Encode(&core.Template{Name: "my_template", Data: ""})
+	json.NewEncoder(in).Encode(&core.Template{Name: "my_template.yml", Data: ""})
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "/", in)

--- a/handler/api/template/delete_test.go
+++ b/handler/api/template/delete_test.go
@@ -30,7 +30,7 @@ func TestHandleDelete(t *testing.T) {
 	template.EXPECT().Delete(gomock.Any(), dummyTemplate).Return(nil)
 
 	c := new(chi.Context)
-	c.URLParams.Add("name", "my_template")
+	c.URLParams.Add("name", "my_template.yml")
 	c.URLParams.Add("namespace", "my_org")
 
 	w := httptest.NewRecorder()
@@ -53,7 +53,7 @@ func TestHandleDelete_TemplateNotFound(t *testing.T) {
 	template.EXPECT().FindName(gomock.Any(), dummyTemplate.Name, dummyTemplate.Namespace).Return(nil, errors.ErrNotFound)
 
 	c := new(chi.Context)
-	c.URLParams.Add("name", "my_template")
+	c.URLParams.Add("name", "my_template.yml")
 	c.URLParams.Add("namespace", "my_org")
 
 	w := httptest.NewRecorder()
@@ -83,7 +83,7 @@ func TestHandleDelete_DeleteError(t *testing.T) {
 	template.EXPECT().Delete(gomock.Any(), dummyTemplate).Return(errors.ErrNotFound)
 
 	c := new(chi.Context)
-	c.URLParams.Add("name", "my_template")
+	c.URLParams.Add("name", "my_template.yml")
 	c.URLParams.Add("namespace", "my_org")
 
 	w := httptest.NewRecorder()

--- a/handler/api/template/find_test.go
+++ b/handler/api/template/find_test.go
@@ -29,7 +29,7 @@ func TestHandleFind(t *testing.T) {
 	template.EXPECT().FindName(gomock.Any(), dummyTemplate.Name, dummyTemplate.Namespace).Return(dummyTemplate, nil)
 
 	c := new(chi.Context)
-	c.URLParams.Add("name", "my_template")
+	c.URLParams.Add("name", "my_template.yml")
 	c.URLParams.Add("namespace", "my_org")
 
 	w := httptest.NewRecorder()
@@ -52,7 +52,7 @@ func TestHandleFind_TemplateNotFound(t *testing.T) {
 	template.EXPECT().FindName(gomock.Any(), dummyTemplate.Name, dummyTemplate.Namespace).Return(nil, errors.ErrNotFound)
 
 	c := new(chi.Context)
-	c.URLParams.Add("name", "my_template")
+	c.URLParams.Add("name", "my_template.yml")
 	c.URLParams.Add("namespace", "my_org")
 
 	w := httptest.NewRecorder()

--- a/handler/api/template/update_test.go
+++ b/handler/api/template/update_test.go
@@ -32,7 +32,7 @@ func TestHandleUpdate(t *testing.T) {
 	template.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
 
 	c := new(chi.Context)
-	c.URLParams.Add("name", "my_template")
+	c.URLParams.Add("name", "my_template.yml")
 	c.URLParams.Add("namespace", "my_org")
 
 	in := new(bytes.Buffer)
@@ -55,10 +55,10 @@ func TestHandleUpdate_ValidationErrorData(t *testing.T) {
 	defer controller.Finish()
 
 	template := mock.NewMockTemplateStore(controller)
-	template.EXPECT().FindName(gomock.Any(), dummyTemplate.Name, dummyTemplate.Namespace).Return(&core.Template{Name: "my_template"}, nil)
+	template.EXPECT().FindName(gomock.Any(), dummyTemplate.Name, dummyTemplate.Namespace).Return(&core.Template{Name: "my_template.yml"}, nil)
 
 	c := new(chi.Context)
-	c.URLParams.Add("name", "my_template")
+	c.URLParams.Add("name", "my_template.yml")
 	c.URLParams.Add("namespace", "my_org")
 
 	in := new(bytes.Buffer)
@@ -90,7 +90,7 @@ func TestHandleUpdate_TemplateNotFound(t *testing.T) {
 	template.EXPECT().FindName(gomock.Any(), dummyTemplate.Name, dummyTemplate.Namespace).Return(nil, errors.ErrNotFound)
 
 	c := new(chi.Context)
-	c.URLParams.Add("name", "my_template")
+	c.URLParams.Add("name", "my_template.yml")
 	c.URLParams.Add("namespace", "my_org")
 
 	in := new(bytes.Buffer)
@@ -119,11 +119,11 @@ func TestHandleUpdate_UpdateError(t *testing.T) {
 	defer controller.Finish()
 
 	template := mock.NewMockTemplateStore(controller)
-	template.EXPECT().FindName(gomock.Any(), dummyTemplate.Name, dummyTemplate.Namespace).Return(&core.Template{Name: "my_template"}, nil)
+	template.EXPECT().FindName(gomock.Any(), dummyTemplate.Name, dummyTemplate.Namespace).Return(&core.Template{Name: "my_template.yml"}, nil)
 	template.EXPECT().Update(gomock.Any(), gomock.Any()).Return(errors.ErrNotFound)
 
 	c := new(chi.Context)
-	c.URLParams.Add("name", "my_template")
+	c.URLParams.Add("name", "my_template.yml")
 	c.URLParams.Add("namespace", "my_org")
 
 	in := new(bytes.Buffer)

--- a/plugin/converter/template.go
+++ b/plugin/converter/template.go
@@ -39,6 +39,7 @@ var (
 	TemplateFileRE          = regexp.MustCompile("^kind:\\s+template+\\n")
 	ErrTemplateNotFound     = errors.New("template converter: template name given not found")
 	ErrTemplateSyntaxErrors = errors.New("template converter: there is a problem with the yaml file provided")
+	errTemplateExtensionInvalid = errors.New("template extension invalid. must be yaml, starlark or jsonnet")
 )
 
 func Template(templateStore core.TemplateStore) core.ConvertService {
@@ -84,9 +85,8 @@ func (p *templatePlugin) Convert(ctx context.Context, req *core.ConvertArgs) (*c
 	case ".jsonnet":
 		return parseJsonnet(req, template, templateArgs)
 	default:
+		return nil, errTemplateExtensionInvalid
 	}
-
-	return nil, nil
 }
 
 func parseYaml(req *core.ConvertArgs, template *core.Template, templateArgs core.TemplateArgs) (*core.Config, error) {

--- a/plugin/converter/template.go
+++ b/plugin/converter/template.go
@@ -36,9 +36,9 @@ import (
 
 var (
 	// TemplateFileRE regex to verifying kind is template.
-	TemplateFileRE          = regexp.MustCompile("^kind:\\s+template+\\n")
-	ErrTemplateNotFound     = errors.New("template converter: template name given not found")
-	ErrTemplateSyntaxErrors = errors.New("template converter: there is a problem with the yaml file provided")
+	TemplateFileRE              = regexp.MustCompile("^kind:\\s+template+\\n")
+	ErrTemplateNotFound         = errors.New("template converter: template name given not found")
+	ErrTemplateSyntaxErrors     = errors.New("template converter: there is a problem with the yaml file provided")
 	errTemplateExtensionInvalid = errors.New("template extension invalid. must be yaml, starlark or jsonnet")
 )
 

--- a/plugin/converter/template.go
+++ b/plugin/converter/template.go
@@ -35,10 +35,10 @@ import (
 )
 
 var (
-	// TemplateFileRE regex to verifying kind is template.
-	TemplateFileRE              = regexp.MustCompile("^kind:\\s+template+\\n")
-	ErrTemplateNotFound         = errors.New("template converter: template name given not found")
-	ErrTemplateSyntaxErrors     = errors.New("template converter: there is a problem with the yaml file provided")
+	// templateFileRE regex to verifying kind is template.
+	templateFileRE              = regexp.MustCompile("^kind:\\s+template+\\n")
+	errTemplateNotFound         = errors.New("template converter: template name given not found")
+	errTemplateSyntaxErrors     = errors.New("template converter: there is a problem with the yaml file provided")
 	errTemplateExtensionInvalid = errors.New("template extension invalid. must be yaml, starlark or jsonnet")
 )
 
@@ -59,19 +59,19 @@ func (p *templatePlugin) Convert(ctx context.Context, req *core.ConvertArgs) (*c
 	}
 
 	// check kind is template
-	if TemplateFileRE.MatchString(req.Config.Data) == false {
+	if templateFileRE.MatchString(req.Config.Data) == false {
 		return nil, nil
 	}
 	// map to templateArgs
 	var templateArgs core.TemplateArgs
 	err := yaml.Unmarshal([]byte(req.Config.Data), &templateArgs)
 	if err != nil {
-		return nil, ErrTemplateSyntaxErrors
+		return nil, errTemplateSyntaxErrors
 	}
 	// get template from db
 	template, err := p.templateStore.FindName(ctx, templateArgs.Load, req.Repo.Namespace)
 	if err == sql.ErrNoRows {
-		return nil, ErrTemplateNotFound
+		return nil, errTemplateNotFound
 	}
 	if err != nil {
 		return nil, err

--- a/plugin/converter/testdata/yaml.template.invalid.yml
+++ b/plugin/converter/testdata/yaml.template.invalid.yml
@@ -1,0 +1,6 @@
+kind: template
+load: plugin.txt
+data:
+  stepName: my_step
+  image: my_image
+  commands: my_command


### PR DESCRIPTION
An issue has occurred where users have saved unsupported template file types.
Therefore I have added a check when a user uploads a template file, it has to be yaml, starlark or jsonnet.