### PR TITLE
fix templating reg expression to match if .drone.yml contains --- characters 

### DIFF
--- a/plugin/converter/template.go
+++ b/plugin/converter/template.go
@@ -36,7 +36,7 @@ import (
 
 var (
 	// templateFileRE regex to verifying kind is template.
-	templateFileRE              = regexp.MustCompilePOSIX("^kind:[[:space:]]+template[[:space:]]?\\+$")
+	templateFileRE              = regexp.MustCompilePOSIX("^kind:[[:space:]]+template[[:space:]]?+$")
 	errTemplateNotFound         = errors.New("template converter: template name given not found")
 	errTemplateSyntaxErrors     = errors.New("template converter: there is a problem with the yaml file provided")
 	errTemplateExtensionInvalid = errors.New("template extension invalid. must be yaml, starlark or jsonnet")

--- a/plugin/converter/template.go
+++ b/plugin/converter/template.go
@@ -36,7 +36,7 @@ import (
 
 var (
 	// templateFileRE regex to verifying kind is template.
-	templateFileRE              = regexp.MustCompile("^kind:\\s+template+\\n")
+	templateFileRE              = regexp.MustCompilePOSIX("^kind:[[:space:]]+template[[:space:]]?\\+$")
 	errTemplateNotFound         = errors.New("template converter: template name given not found")
 	errTemplateSyntaxErrors     = errors.New("template converter: there is a problem with the yaml file provided")
 	errTemplateExtensionInvalid = errors.New("template extension invalid. must be yaml, starlark or jsonnet")

--- a/plugin/converter/testdata/starlark.template.yml
+++ b/plugin/converter/testdata/starlark.template.yml
@@ -1,3 +1,4 @@
+---
 kind: template
 load: plugin.starlark
 data:


### PR DESCRIPTION
There's been an issue identified with templating. If a user has --- in their drone.yml, the regular expression checker for type template won't match. Therefore this PR updates the expression to fix it.
`regexp.MustCompilePOSIX("^kind:[[:space:]]+template[[:space:]]?\\+?")`