### PR TITLE
bump ui to v2.2.1 - https://github.com/drone/drone-ui/blob/main/CHANGELOG.md

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/dchest/uniuri v0.0.0-20160212164326-8902c56451e9
 	github.com/drone/drone-go v1.4.1-0.20201109202657-b9e58bbbcf27
 	github.com/drone/drone-runtime v1.1.1-0.20200623162453-61e33e2cab5d
-	github.com/drone/drone-ui v2.2.0+incompatible
+	github.com/drone/drone-ui v2.2.1+incompatible
 	github.com/drone/drone-yaml v1.2.4-0.20200326192514-6f4d6dfb39e4
 	github.com/drone/envsubst v1.0.3-0.20200709231038-aa43e1c1a629
 	github.com/drone/funcmap v0.0.0-20210823160631-9e9dec149056

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/drone/drone-ui v2.1.0+incompatible h1:mxRP0Oauq4M+HiDIxSiI3P2/hkmyxR+
 github.com/drone/drone-ui v2.1.0+incompatible/go.mod h1:NBtVWW7NNJpD9+huMD/5TAE1db2nrEh0i35/9Rf1MPI=
 github.com/drone/drone-ui v2.2.0+incompatible h1:De3m4tFw/hg7/6Bap6t8x9M31dByavmvwpJlqUJdKvY=
 github.com/drone/drone-ui v2.2.0+incompatible/go.mod h1:NBtVWW7NNJpD9+huMD/5TAE1db2nrEh0i35/9Rf1MPI=
+github.com/drone/drone-ui v2.2.1+incompatible h1:j5Py26SOjyPHCp294qmVCASeCQ+Q8l/fBNw8UqBPyNU=
+github.com/drone/drone-ui v2.2.1+incompatible/go.mod h1:NBtVWW7NNJpD9+huMD/5TAE1db2nrEh0i35/9Rf1MPI=
 github.com/drone/drone-yaml v1.2.4-0.20200326192514-6f4d6dfb39e4 h1:XsstoCeXC2t8lA9OLTdoFwckaptqahxwjCWsenySfX8=
 github.com/drone/drone-yaml v1.2.4-0.20200326192514-6f4d6dfb39e4/go.mod h1:QsqliFK8nG04AHFN9tTn9XJomRBQHD4wcejWW1uz/10=
 github.com/drone/envsubst v1.0.3-0.20200709231038-aa43e1c1a629 h1:rIaZZalMGGPb2cU/+ypuggZ8aMlpa17RUlJUtsMv8pw=


### PR DESCRIPTION
bump ui version to v2.2.1

[changelog can be found here](https://github.com/drone/drone-ui/blob/main/CHANGELOG.md)