### PR TITLE
Fix stepLimit param in Starlark and Template OSS code

### DIFF
--- a/plugin/converter/starlark_oss.go
+++ b/plugin/converter/starlark_oss.go
@@ -18,6 +18,6 @@ package converter
 
 import "github.com/drone/drone/core"
 
-func Starlark(enabled bool) core.ConvertService {
+func Starlark(enabled bool, stepLimit uint64) core.ConvertService {
 	return new(noop)
 }

--- a/plugin/converter/template_oss.go
+++ b/plugin/converter/template_oss.go
@@ -22,7 +22,7 @@ import (
 	"github.com/drone/drone/core"
 )
 
-func Template(templateStore core.TemplateStore) core.ConvertService {
+func Template(templateStore core.TemplateStore, stepLimit uint64) core.ConvertService {
 	return &templatePlugin{
 		templateStore: templateStore,
 	}


### PR DESCRIPTION
`stepLimit` was introduced in PR #3134 

https://github.com/drone/drone/pull/3134#issuecomment-917596906 reported:
"This commit has broken compilation of the OSS build"

Sadly, CI passed in that PR, so it was not noticed.

This change should get the declarations up-to-date in the OSS code.