### PR TITLE
Add build.number variable to jsonnet and starlark

### DIFF
--- a/plugin/converter/jsonnet/jsonnet.go
+++ b/plugin/converter/jsonnet/jsonnet.go
@@ -71,6 +71,7 @@ func Parse(req *core.ConvertArgs, template *core.Template, templateData map[stri
 func mapBuild(v *core.Build, vm *jsonnet.VM) {
 	vm.ExtVar(build+"event", v.Event)
 	vm.ExtVar(build+"action", v.Action)
+	vm.ExtVar(build+"action", strconv.FormatInt(v.Number, 10))
 	vm.ExtVar(build+"environment", v.Deploy)
 	vm.ExtVar(build+"link", v.Link)
 	vm.ExtVar(build+"branch", v.Target)

--- a/plugin/converter/remote.go
+++ b/plugin/converter/remote.go
@@ -36,7 +36,7 @@ func Remote(endpoint, signer, extension string, skipVerify bool, timeout time.Du
 type remote struct {
 	client    converter.Plugin
 	extension string
-	timeout time.Duration
+	timeout   time.Duration
 }
 
 func (g *remote) Convert(ctx context.Context, in *core.ConvertArgs) (*core.Config, error) {

--- a/plugin/converter/starlark/args.go
+++ b/plugin/converter/starlark/args.go
@@ -124,6 +124,7 @@ func fromBuild(v *core.Build) starlark.StringDict {
 		"event":         starlark.String(v.Event),
 		"action":        starlark.String(v.Action),
 		"cron":          starlark.String(v.Cron),
+		"number":        starlark.MakeInt64(v.Number),
 		"environment":   starlark.String(v.Deploy),
 		"link":          starlark.String(v.Link),
 		"branch":        starlark.String(v.Target),

--- a/plugin/converter/template.go
+++ b/plugin/converter/template.go
@@ -45,13 +45,13 @@ var (
 func Template(templateStore core.TemplateStore, stepLimit uint64) core.ConvertService {
 	return &templatePlugin{
 		templateStore: templateStore,
-		stepLimit: stepLimit,
+		stepLimit:     stepLimit,
 	}
 }
 
 type templatePlugin struct {
 	templateStore core.TemplateStore
-	stepLimit uint64
+	stepLimit     uint64
 }
 
 func (p *templatePlugin) Convert(ctx context.Context, req *core.ConvertArgs) (*core.Config, error) {


### PR DESCRIPTION
# Why?

I feel that this extVar was missed or determined to not be as useful as the others. I use `build.number` in the form of `${DRONE_BUILD_NUMBER}`, but would prefer to use `extVar("build.number")` instead.

# What?

Supply `build.number` as an external variable available to the jsonnet and starlark conversion plugins.

# Docs

See: drone/docs#481