### PR TITLE
Add drone debug env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased](https://github.com/drone/drone/tree/HEAD)
+
+[Full Changelog](https://github.com/drone/drone/compare/v2.4.0...HEAD)
+
+**Implemented enhancements:**
+
+- \(DRON-124\) adding new status endpoint [\#3143](https://github.com/drone/drone/pull/3143) ([tphoney](https://github.com/tphoney))
+
+**Fixed bugs:**
+
+- fix a typo in readme [\#3150](https://github.com/drone/drone/pull/3150) ([nothatDinger](https://github.com/nothatDinger))
+
 ## [v2.4.0](https://github.com/drone/drone/tree/v2.4.0) (2021-09-23)
 
 [Full Changelog](https://github.com/drone/drone/compare/v2.3.1...v2.4.0)
@@ -17,6 +29,7 @@
 
 **Merged pull requests:**
 
+- \(maint\)-release 2.4.0 [\#3148](https://github.com/drone/drone/pull/3148) ([d1wilko](https://github.com/d1wilko))
 - Allow jsonnet imports in pipeline configuration [\#3105](https://github.com/drone/drone/pull/3105) ([hhamalai](https://github.com/hhamalai))
 
 ## [v2.3.1](https://github.com/drone/drone/tree/v2.3.1) (2021-09-09)

--- a/operator/runner/env.go
+++ b/operator/runner/env.go
@@ -17,6 +17,7 @@ package runner
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/drone/drone/core"
@@ -106,29 +107,30 @@ func buildEnviron(build *core.Build) map[string]string {
 		"DRONE_BUILD_CREATED":        fmt.Sprint(build.Created),
 		"DRONE_BUILD_STARTED":        fmt.Sprint(build.Started),
 		"DRONE_BUILD_FINISHED":       fmt.Sprint(build.Finished),
+		"DRONE_BUILD_DEBUG":          strconv.FormatBool(build.Debug),
 		"DRONE_DEPLOY_TO":            build.Deploy,
 
 		//
 		// these are legacy configuration parameters for backward
 		// compatibility with drone 0.8.
 		//
-		"CI_BUILD_NUMBER":              fmt.Sprint(build.Number),
-		"CI_PARENT_BUILD_NUMBER":       fmt.Sprint(build.Parent),
-		"CI_BUILD_CREATED":             fmt.Sprint(build.Created),
-		"CI_BUILD_STARTED":             fmt.Sprint(build.Started),
-		"CI_BUILD_FINISHED":            fmt.Sprint(build.Finished),
-		"CI_BUILD_STATUS":              build.Status,
-		"CI_BUILD_EVENT":               build.Event,
-		"CI_BUILD_LINK":                build.Link,
-		"CI_BUILD_TARGET":              build.Deploy,
-		"CI_COMMIT_SHA":                build.After,
-		"CI_COMMIT_REF":                build.Ref,
-		"CI_COMMIT_BRANCH":             build.Target,
-		"CI_COMMIT_MESSAGE":            build.Message,
-		"CI_COMMIT_AUTHOR":             build.Author,
-		"CI_COMMIT_AUTHOR_NAME":        build.AuthorName,
-		"CI_COMMIT_AUTHOR_EMAIL":       build.AuthorEmail,
-		"CI_COMMIT_AUTHOR_AVATAR":      build.AuthorAvatar,
+		"CI_BUILD_NUMBER":         fmt.Sprint(build.Number),
+		"CI_PARENT_BUILD_NUMBER":  fmt.Sprint(build.Parent),
+		"CI_BUILD_CREATED":        fmt.Sprint(build.Created),
+		"CI_BUILD_STARTED":        fmt.Sprint(build.Started),
+		"CI_BUILD_FINISHED":       fmt.Sprint(build.Finished),
+		"CI_BUILD_STATUS":         build.Status,
+		"CI_BUILD_EVENT":          build.Event,
+		"CI_BUILD_LINK":           build.Link,
+		"CI_BUILD_TARGET":         build.Deploy,
+		"CI_COMMIT_SHA":           build.After,
+		"CI_COMMIT_REF":           build.Ref,
+		"CI_COMMIT_BRANCH":        build.Target,
+		"CI_COMMIT_MESSAGE":       build.Message,
+		"CI_COMMIT_AUTHOR":        build.Author,
+		"CI_COMMIT_AUTHOR_NAME":   build.AuthorName,
+		"CI_COMMIT_AUTHOR_EMAIL":  build.AuthorEmail,
+		"CI_COMMIT_AUTHOR_AVATAR": build.AuthorAvatar,
 	}
 	if strings.HasPrefix(build.Ref, "refs/tags/") {
 		env["DRONE_TAG"] = strings.TrimPrefix(build.Ref, "refs/tags/")


### PR DESCRIPTION
this pull request adds DRONE_BUILD_DEBUG=true|false to allow conditionally run debug step when using drone-runner-ssh.
for example:

```yml
kind: pipeline
type: ssh
name: default

steps:
- name: debug
  commands:
  - [ "$${DRONE_BUILD_DEBUG}" == "true" ] && exit 0
  - sleep infinity # or run tmate
```